### PR TITLE
Increase timeout for Merge Gatekeeper Github action

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -255,7 +255,7 @@ jobs:
       make_target: ${{ matrix.make_target }}
 
   merge-gatekeeper:
-    needs: [ test, check, integration_tests_api, integration_tests_flows, integration_tests_cli]
+    needs: [test, check, integration_tests_api, integration_tests_flows, integration_tests_cli]
     name: Merge Gatekeeper
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -266,6 +266,7 @@ jobs:
           self: Merge Gatekeeper
           token: ${{ secrets.GITHUB_TOKEN }}
           interval: 45
-          timeout: 600
+          # Some tests take a long time
+          timeout: 1800
           ignored: "license/snyk (Percona Everest), security/snyk (Percona Everest)"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/dev-fe-gatekeeper.yaml
+++ b/.github/workflows/dev-fe-gatekeeper.yaml
@@ -144,6 +144,7 @@ jobs:
           self: Merge Gatekeeper
           token: ${{ secrets.GITHUB_TOKEN }}
           interval: 45
-          timeout: 600
+          # Some tests take a long time
+          timeout: 1800
           ignored: "license/snyk (Percona Github Org), security/snyk (Percona Github Org)"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/oapi-codegen/echo-middleware v1.0.2
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/operator-framework/api v0.33.0
-	github.com/percona/everest-operator v0.6.0-dev1.0.20250908085733-47ec7799e09d
-	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250908105349-cff8ea938bd9
+	github.com/percona/everest-operator v0.6.0-dev1.0.20250908184224-8da8ec898e42
+	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250909092137-1e1ffdef1c5d
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -924,12 +924,12 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
-github.com/percona/everest-operator v0.6.0-dev1.0.20250908085733-47ec7799e09d h1:E5cKb8vwcwfARKpyvhHY6k1v3L0LCLhHNPrnLSt4htk=
-github.com/percona/everest-operator v0.6.0-dev1.0.20250908085733-47ec7799e09d/go.mod h1:PTV1SAdP9gSrHLcPiJgdAEUcxA+aLbqWiolnjSoGKYQ=
+github.com/percona/everest-operator v0.6.0-dev1.0.20250908184224-8da8ec898e42 h1:DRW5auVfh2LyBoSHNlOWIFVPw9A2BBNL2s46qB2xeIM=
+github.com/percona/everest-operator v0.6.0-dev1.0.20250908184224-8da8ec898e42/go.mod h1:a8vugONXV/r5ht/sI3oqEZqu3BpKGFWZS97pncIQfV8=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20250327100109-3ca299246bfe h1:CPO2T7ADauXJEXjwflAVYGRSZ/fKVVP12jE/Iy/1b7k=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20250327100109-3ca299246bfe/go.mod h1:HRKf8nO4SqtNJ1oNzfY3THcwIsjGTWGBF3rNz1TwA9c=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250908105349-cff8ea938bd9 h1:c117XoDdD4PLExCJmT5BKjiRynZqUP9P1w5Zz4VyEY8=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250908105349-cff8ea938bd9/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250909092137-1e1ffdef1c5d h1:4bp/Etnw+wD47VI7/ZB05y4drfXOnKJhVxjAtqpNR/I=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250909092137-1e1ffdef1c5d/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
 github.com/percona/percona-postgresql-operator v0.0.0-20250313094841-676233c83e26 h1:hng2p9QPk/OxHVZEdsv+k0ByyHzTNSB0SWlVuuTxMjs=
 github.com/percona/percona-postgresql-operator v0.0.0-20250313094841-676233c83e26/go.mod h1:3D56UIi6Z0Z2gduNUuBcgjd1RNht3N8RKKmR9Wbfu4o=
 github.com/percona/percona-server-mongodb-operator v1.19.1 h1:lqIC7V80bZPJwjeYLYl/WA+QVQMHo193uEAx5zyIg84=


### PR DESCRIPTION
Some of our tests take too much time already, so the default timeout (600 sec) is not enough anymore