### PR TITLE
API-tests CI fix

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -181,6 +181,9 @@ jobs:
         run: |
           make build-cli-debug
 
+      - name: Clean Go cache
+        run: make clean-go-cache
+
       - name: Deploy Everest to K3D test cluster
         timeout-minutes: 10
         run: |

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,9 @@ cert:                   ## Create dev TLS certificates.
 	mkcert -install
 	mkcert -cert-file=dev-cert.pem -key-file=dev-key.pem everest everest.localhost 127.0.0.1
 
+clean-go-cache:
+	go clean -modcache
+
 ##@ GitHub PR
 
 CHART_BRANCH ?= main


### PR DESCRIPTION
When deploying a minio storage in CI for api-tests, it often fails with 
```
0/4 nodes are available: 4 node(s) had untolerated taint {node.kubernetes.io/disk-pressure: }. preemption: 0/4 nodes are available: 4 Preemption is not helpful for scheduling.
```

This PR reduces the disk pressure by removing go modules before running the tests environment