### PR TITLE
Do not use deprecated exposure method in api-tests

### DIFF
--- a/api-tests/Makefile
+++ b/api-tests/Makefile
@@ -55,7 +55,7 @@ MINIO_RESOURCE=$(TEST_ROOT)/manifests/minio.yaml
 deploy-minio:
 	$(info Deploying MinIO to K3D cluster)
 	kubectl apply -f $(MINIO_RESOURCE)
-	if ! kubectl wait deploy/minio --for=condition=Available -n minio --timeout=300s; then \
+	if ! kubectl wait deploy/minio --for=condition=Available -n minio --timeout=600s; then \
 		echo "❌ MinIO deployment did not become ready in time"; \
 		echo "🔎 Deployment YAML:"; \
 		kubectl get deploy minio -n minio -o yaml || true; \

--- a/api-tests/tests/pg/cluster.spec.ts
+++ b/api-tests/tests/pg/cluster.spec.ts
@@ -66,10 +66,10 @@ test.describe.serial('PG cluster tests', () => {
       await test.step('expose DB cluster', async () => {
         await expect(async () => {
           dbCluster = await th.getDBCluster(request, dbClusterSinName)
-          dbCluster.spec.proxy.expose.type = 'external'
+          dbCluster.spec.proxy.expose.type = 'Load'
 
           dbCluster = await th.updateDBCluster(request, dbClusterSinName, dbCluster)
-          expect(dbCluster.spec.proxy.expose.type).toMatch('external')
+          expect(dbCluster.spec.proxy.expose.type).toMatch('ClusterIP')
         }).toPass({
           intervals: [1000],
           timeout: 30 * 1000,
@@ -125,10 +125,10 @@ test.describe.serial('PG cluster tests', () => {
       await test.step('expose DB cluster', async () => {
         await expect(async () => {
           dbCluster = await th.getDBCluster(request, dbClusterMulName)
-          dbCluster.spec.proxy.expose.type = 'external'
+          dbCluster.spec.proxy.expose.type = 'LoadBalancer'
 
           dbCluster = await th.updateDBCluster(request, dbClusterMulName, dbCluster)
-          expect(dbCluster.spec.proxy.expose.type).toMatch('external')
+          expect(dbCluster.spec.proxy.expose.type).toMatch('LoadBalancer')
         }).toPass({
           intervals: [1000],
           timeout: 30 * 1000,

--- a/api-tests/tests/pg/cluster.spec.ts
+++ b/api-tests/tests/pg/cluster.spec.ts
@@ -66,10 +66,10 @@ test.describe.serial('PG cluster tests', () => {
       await test.step('expose DB cluster', async () => {
         await expect(async () => {
           dbCluster = await th.getDBCluster(request, dbClusterSinName)
-          dbCluster.spec.proxy.expose.type = 'Load'
+          dbCluster.spec.proxy.expose.type = 'LoadBalancer'
 
           dbCluster = await th.updateDBCluster(request, dbClusterSinName, dbCluster)
-          expect(dbCluster.spec.proxy.expose.type).toMatch('ClusterIP')
+          expect(dbCluster.spec.proxy.expose.type).toMatch('LoadBalancer')
         }).toPass({
           intervals: [1000],
           timeout: 30 * 1000,

--- a/api-tests/tests/pxc/cluster.spec.ts
+++ b/api-tests/tests/pxc/cluster.spec.ts
@@ -67,10 +67,10 @@ test.describe.serial('PXC cluster tests', () => {
       await test.step('expose DB cluster', async () => {
         await expect(async () => {
           dbCluster = await th.getDBCluster(request, dbClusterSinName)
-          dbCluster.spec.proxy.expose.type = 'external'
+          dbCluster.spec.proxy.expose.type = 'LoadBalancer'
 
           dbCluster = await th.updateDBCluster(request, dbClusterSinName, dbCluster)
-          expect(dbCluster.spec.proxy.expose.type).toMatch('external')
+          expect(dbCluster.spec.proxy.expose.type).toMatch('LoadBalancer')
         }).toPass({
           intervals: [1000],
           timeout: 30 * 1000,
@@ -125,10 +125,10 @@ test.describe.serial('PXC cluster tests', () => {
       await test.step('expose DB cluster', async () => {
         await expect(async () => {
           dbCluster = await th.getDBCluster(request, dbClusterMulName)
-          dbCluster.spec.proxy.expose.type = 'external'
+          dbCluster.spec.proxy.expose.type = 'LoadBalancer'
 
           dbCluster = await th.updateDBCluster(request, dbClusterMulName, dbCluster)
-          expect(dbCluster.spec.proxy.expose.type).toMatch('external')
+          expect(dbCluster.spec.proxy.expose.type).toMatch('LoadBalancer')
         }).toPass({
           intervals: [1000],
           timeout: 30 * 1000,

--- a/api-tests/tests/utils/api.ts
+++ b/api-tests/tests/utils/api.ts
@@ -80,7 +80,7 @@ export const getPGClusterDataSimple = (name: string) => {
         type: 'pgbouncer',
         replicas: 1,
         expose: {
-          type: 'internal',
+          type: 'ClusterIP',
         },
       },
     },
@@ -117,7 +117,7 @@ export const getPSMDBClusterDataSimple = (name: string) => {
         type: 'mongos',
         replicas: 1,
         expose: {
-          type: 'internal',
+          type: 'ClusterIP',
         },
       },
       sharding: {
@@ -157,7 +157,7 @@ export const getPXCClusterDataSimple = (name: string) => {
         type: 'haproxy',
         replicas: 1,
         expose: {
-          type: 'internal',
+          type: 'ClusterIP',
         },
       },
     },


### PR DESCRIPTION
Do not use deprecated exposure method in api-tests