### PR TITLE
Pass manager as parameter in `provider-runtime`

### DIFF
--- a/provider-runtime/controller/README.md
+++ b/provider-runtime/controller/README.md
@@ -42,7 +42,6 @@ Implement the `ProviderInterface` to create a provider:
 ```go
 type ProviderInterface interface {
     Name() string
-	Types() func(*runtime.Scheme) error
 	Validate(c *Context) error
 	Sync(c *Context) error
 	Status(c *Context) (Status, error)
@@ -55,14 +54,15 @@ Use `BaseProvider` to inherit default implementations:
 ```go
 type MyProvider struct {
     controller.BaseProvider
+    client client.Client
 }
 
-func NewMyProvider() *MyProvider {
+func NewMyProvider(mgr ctrl.Manager) *MyProvider {
     return &MyProvider{
         BaseProvider: controller.BaseProvider{
             ProviderName: "mydb",
-            SchemeFuncs:  []func(*runtime.Scheme) error{mydbv1.AddToScheme},
         },
+        client: mgr.GetClient(),
     }
 }
 
@@ -71,4 +71,13 @@ func (p *MyProvider) Validate(c *controller.Context) error { ... }
 func (p *MyProvider) Sync(c *controller.Context) error { ... }
 func (p *MyProvider) Status(c *controller.Context) (controller.Status, error) { ... }
 func (p *MyProvider) Cleanup(c *controller.Context) error { ... }
+```
+
+Scheme registration (e.g. `mydbv1.AddToScheme`) is passed directly to
+`reconciler.SetupManager`, not through the provider:
+
+```go
+mgr, err := reconciler.SetupManager(mydbv1.AddToScheme)
+provider := NewMyProvider(mgr)
+r, err := reconciler.New(ctx, mgr, provider)
 ```

--- a/provider-runtime/controller/interface.go
+++ b/provider-runtime/controller/interface.go
@@ -18,7 +18,6 @@ package controller
 // Embed BaseProvider for default implementations.
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -29,9 +28,6 @@ import (
 type ProviderInterface interface {
 	// Name returns the unique identifier for this provider (e.g., "psmdb", "postgresql").
 	Name() string
-
-	// Types returns the scheme builder for registering provider-specific CRDs.
-	Types() func(*runtime.Scheme) error
 
 	// Validate checks if the Instance spec is valid.
 	Validate(c *Context) error
@@ -239,26 +235,11 @@ type FieldIndexProvider interface {
 // Embed this in your provider struct to inherit defaults.
 type BaseProvider struct {
 	ProviderName string
-	SchemeFuncs  []func(*runtime.Scheme) error
 	WatchConfigs []WatchConfig
 }
 
 func (b *BaseProvider) Name() string {
 	return b.ProviderName
-}
-
-func (b *BaseProvider) Types() func(*runtime.Scheme) error {
-	if len(b.SchemeFuncs) == 0 {
-		return nil
-	}
-	return func(s *runtime.Scheme) error {
-		for _, fn := range b.SchemeFuncs {
-			if err := fn(s); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
 }
 
 // Watches returns the configured watch configurations.

--- a/provider-runtime/reconciler/provider.go
+++ b/provider-runtime/reconciler/provider.go
@@ -55,7 +55,6 @@ type ProviderReconciler struct {
 // providerAdapter is the internal interface that both provider types satisfy.
 type providerAdapter interface {
 	Name() string
-	Types() func(*runtime.Scheme) error
 	Validate(c *controller.Context) error
 	Sync(c *controller.Context) error
 	Status(c *controller.Context) (controller.Status, error)
@@ -67,8 +66,19 @@ type providerAdapter interface {
 type ServerConfig = server.ServerConfig
 
 // New creates a reconciler from a provider.
-func New(ctx context.Context, p controller.ProviderInterface, opts ...ReconcilerOption) (*ProviderReconciler, error) {
-	return newReconciler(ctx, p, opts...)
+//
+// The manager must be created first via SetupManager and passed here.
+// This allows providers to receive the manager at construction time.
+//
+// Example:
+//
+//	mgr, err := reconciler.SetupManager(psmdbv1.AddToScheme)
+//	provider := psmdb.NewProvider(mgr)
+//	r, err := reconciler.New(ctx, mgr, provider,
+//	    reconciler.WithServer(reconciler.ServerConfig{Port: 8082, ValidationPath: "/validate"}),
+//	)
+func New(ctx context.Context, mgr ctrl.Manager, p controller.ProviderInterface, opts ...ReconcilerOption) (*ProviderReconciler, error) {
+	return newReconciler(ctx, mgr, p, opts...)
 }
 
 // ReconcilerOption configures the reconciler.
@@ -111,12 +121,12 @@ func WithServer(config server.ServerConfig) ReconcilerOption {
 // Example:
 //
 //	// Custom port
-//	r, err := reconciler.New(provider,
+//	mgr, err := reconciler.SetupManager(psmdbv1.AddToScheme,
 //	    reconciler.WithMetrics(":9090"),
 //	)
 //
 //	// Disable metrics
-//	r, err := reconciler.New(provider,
+//	mgr, err := reconciler.SetupManager(psmdbv1.AddToScheme,
 //	    reconciler.WithMetrics("0"),
 //	)
 func WithMetrics(bindAddress string) ReconcilerOption {
@@ -125,9 +135,19 @@ func WithMetrics(bindAddress string) ReconcilerOption {
 	}
 }
 
-// newReconciler creates a reconciler from any provider that satisfies providerAdapter.
-func newReconciler(ctx context.Context, p providerAdapter, opts ...ReconcilerOption) (*ProviderReconciler, error) {
-	// Apply options
+// SetupManager creates a controller-runtime Manager with the scheme
+// registration.
+//
+// Example:
+//
+//	mgr, err := reconciler.SetupManager(psmdbv1.AddToScheme,
+//	    reconciler.WithMetrics(":9090"),
+//	)
+//	provider := psmdb.NewProvider(mgr)
+//	r, err := reconciler.New(ctx, mgr, provider,
+//	    reconciler.WithServer(reconciler.ServerConfig{Port: 8082, ValidationPath: "/validate"}),
+//	)
+func SetupManager(schemeFuncs []func(*runtime.Scheme) error, opts ...ReconcilerOption) (ctrl.Manager, error) {
 	options := &reconcilerOptions{}
 	for _, opt := range opts {
 		opt(options)
@@ -145,8 +165,8 @@ func newReconciler(ctx context.Context, p providerAdapter, opts ...ReconcilerOpt
 	}
 
 	// Register provider-specific types
-	if typesFunc := p.Types(); typesFunc != nil {
-		if err := typesFunc(scheme); err != nil {
+	for _, fn := range schemeFuncs {
+		if err := fn(scheme); err != nil {
 			return nil, fmt.Errorf("failed to add provider scheme: %w", err)
 		}
 	}
@@ -164,6 +184,17 @@ func newReconciler(ctx context.Context, p providerAdapter, opts ...ReconcilerOpt
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create manager: %w", err)
+	}
+
+	return mgr, nil
+}
+
+// newReconciler creates a reconciler from any provider that satisfies providerAdapter.
+func newReconciler(ctx context.Context, mgr ctrl.Manager, p providerAdapter, opts ...ReconcilerOption) (*ProviderReconciler, error) {
+	// Apply options
+	options := &reconcilerOptions{}
+	for _, opt := range opts {
+		opt(options)
 	}
 
 	// Setup field indexes if provider implements FieldIndexProvider


### PR DESCRIPTION
When a provider sets watches, often you need to access `Client` from controller `Manager` to list kubernetes resources. This becomes awkward because `Client` is instantiated upon creating provider, while it's needed before creating a provider for watches. An awkward example is found in this [PR](https://github.com/openeverest/provider-percona-server-mongodb/pull/12/changes#diff-36b6d20eb5aea66cf39f8d94111bd96513626ef7f61459f0d9e8e9507ded1d17).

This PR creates manager first, then passes that manager to provider. 

Refs openeverest/provider-percona-server-mongodb#18.

Before merging this PR, merge openeverest/provider-percona-server-mongodb#18 first.