### PR TITLE
UI (1941) feat(ui-generator): implement API providers for dynamic select fields

### DIFF
--- a/docs/ui/ui-generator/Readme.md
+++ b/docs/ui/ui-generator/Readme.md
@@ -34,6 +34,7 @@
   - [Path vs ID](#path-vs-id)
   - [Components Order](#components-order)
   - [CEL Condition Rendering](#cel-condition-rendering)
+  - [API Providers](api-providers.md)
 - [Complete Example](#complete-example)
 
 ## What is UI Generator?

--- a/docs/ui/ui-generator/api-providers.md
+++ b/docs/ui/ui-generator/api-providers.md
@@ -1,153 +1,104 @@
 # API Providers
 
-## Table of Contents
+Select fields whose options come from an Everest API at runtime.
 
-- [What Is It](#what-is-it)
-- [How It Works](#how-it-works)
-- [How To Use It](#how-to-use-it)
-  - [Properties](#properties)
-  - [fieldParams](#fieldparams)
-  - [Validation](#validation)
-  - [Modes](#modes)
-  - [Field Behavior](#field-behavior)
-- [Available Providers](#available-providers)
-- [Examples](#examples)
-  - [Required select with monitoring configs](#required-select-with-monitoring-configs)
-  - [Optional select with empty placeholder](#optional-select-with-empty-placeholder)
+## Quick Start
 
-## What Is It
+```yaml
+storageClass:
+  uiType: select
+  dataSource:
+    provider: storageClasses
+  path: spec.engine.storage.class
+  fieldParams:
+    label: Storage class
+```
 
-`dataSource` is a property you can add to any `select` field so that its options are loaded from an Everest API at runtime instead of being declared statically in the schema.
+That's it. Options load automatically, first option is selected by default, and loading/error states are handled.
 
-The options are scoped to the current cluster and namespace context of the form — each user sees only the resources that exist in their environment.
-
-## How It Works
-
-When the form opens, the field fetches its options from the API. While loading, the field is disabled and shows `Loading...`. If the fetch fails, the field stays disabled and shows `Failed to load options`. If the fetch succeeds but returns no items, the field shows `No options available` (or the `helperText` you defined) and remains interactive.
-
-Because the field is still a standard select, all regular select validation rules — `required`, `regex`, CEL expressions — work exactly as documented in [SelectField](components/select-field.md).
-
-If you specify a `dataSource.provider` that does not exist in the registry, a warning is logged in the browser console during schema preprocessing with a list of available provider keys.
-
-## How To Use It
-
-### Properties
+## Schema Reference
 
 ```yaml
 fieldKey:
-  uiType: select # Required — dataSource works with select fields
-  dataSource:
-    provider: <providerKey> # Required — see Available Providers
-    config: { ... } # Optional
-  path: <dot.separated.api.path> # Required if the value should be submitted
-  id: <uniqueId> # Alternative to path for UI-only fields
-  fieldParams: { ... } # Optional — see fieldParams
-  validation: { ... } # Optional — same as SelectField validation
-  modes: { ... } # Optional — same as any other field
-```
-
-**`uiType`** _(required)_
-
-Must be `select` when using `dataSource`.
-
-**`dataSource.provider`** _(required)_
-
-The key of the provider to use. Must match one of the [available providers](#available-providers). If the key is unknown, a warning is printed and the field renders with no options.
-
-**`path` / `id`**
-
-`dataSource` fields use the same `path`, multi-path, and `id` rules as every other UI Generator component. See [Path vs ID](../Readme.md#path-vs-id).
-
-**`dataSource.config`**
-
-> **TODO:** Document supported `dataSource.config` overrides after the API is finalized.
-
-### fieldParams
-
-`fieldParams` for an API provider field follows the same structure as [SelectField fieldParams](components/select-field.md#properties), except `options` are always provided by the API and must not be specified manually.
-
-Supported keys:
-
-| Key            | Type      | Default | Description                                                                                                                 |
-| -------------- | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `label`        | `string`  | —       | Display label shown above the field                                                                                         |
-| `helperText`   | `string`  | —       | Text shown below the field. When options are empty and no helperText is set, `No options available` is shown automatically. |
-| `disabled`     | `boolean` | `false` | Disable the field regardless of loading state                                                                               |
-| `defaultValue` | `string`  | `""`    | Pre-selected value. Must match one of the option values that the provider will return.                                      |
-| `displayEmpty` | `boolean` | `false` | When `true` and the field is optional, an empty "None" option is automatically added so the user can clear their selection. |
-| `readOnly`     | `boolean` | `false` | Show the value but prevent changes                                                                                          |
-| `autoFocus`    | `boolean` | `false` | Focus this field when the form opens                                                                                        |
-
-### Validation
-
-Validation is declared under `validation` and works identically to [SelectField validation](components/select-field.md#native-validation):
-
-```yaml
-validation:
-  required: true # field must have a value before submit
-  regex:
-    pattern: "^prod-.*"
-    message: Must start with prod-
-  celExpressions:
-    - celExpr: "self != 'disabled-config'"
-      message: This config is not allowed
-```
-
-The selected value is automatically validated against the set of options returned by the API (enum validation).
-
-### Modes
-
-`modes` works the same as for any other field. You can override any `fieldParams` property or `uiType` per form mode:
-
-```yaml
-monitoringEndpoint:
   uiType: select
   dataSource:
-    provider: monitoringConfigs
-  path: spec.components.monitoring.customSpec.monitoringConfigName
+    provider: <providerKey>   # required — see Available Providers
+    config:                   # optional
+      refetchInterval: 5000
+  path: <dot.separated.path>  # required if the value should be submitted
   fieldParams:
-    label: Monitoring endpoint
-    modes:
-      edit:
-        helperText: Changing this will restart the monitoring agent
+    label: string
+    helperText: string        # shown below; defaults to "No options available" when empty
+    disabled: boolean         # always disabled, regardless of loading state
+    defaultValue: string      # overrides auto-selection of first option
+    displayEmpty: boolean     # adds empty "None" option for optional fields
+  validation:                 # same as regular select — required, regex, celExpressions
+    required: true
+  modes:                      # per-mode overrides — same as any field
+    edit:
+      helperText: Changing this will restart the agent
 ```
-
-See [Mode-Aware Overrides](../Readme.md#mode-aware-overrides) for the full list of supported per-mode overrides.
-
-### Field Behavior
-
-| State               | Field    | Displayed text                                |
-| ------------------- | -------- | --------------------------------------------- |
-| Loading             | disabled | `Loading...`                                  |
-| Fetch failed        | disabled | `Failed to load options`                      |
-| Loaded, no options  | enabled  | `No options available` (or your `helperText`) |
-| Loaded, has options | enabled  | your `helperText` (if set)                    |
 
 ## Available Providers
 
-### `monitoringConfigs`
+| Key                 | Returns                                          | Scoped to         |
+| ------------------- | ------------------------------------------------ | ----------------- |
+| `monitoringConfigs` | MonitoringConfig resource names                  | cluster/namespace |
+| `storageClasses`    | StorageClass names available on the cluster       | cluster           |
 
-Returns the names of all `MonitoringConfig` resources in the current namespace as select options.
+## Field Behavior
 
-Each option has the form `{ label: <name>, value: <name> }`.
+| State              | Field    | Text                       |
+| ------------------ | -------- | -------------------------- |
+| Loading            | disabled | Loading...                 |
+| Fetch failed       | disabled | Failed to load options     |
+| No options         | enabled  | No options available       |
+| Options loaded     | enabled  | first option auto-selected |
 
-```yaml
-dataSource:
-  provider: monitoringConfigs
+## Adding a New Provider
+
+1. Create a `useXxxOptions` hook in `hooks/api/<resource>/` that accepts `ProviderParams` and returns `ProviderOptions`.
+2. Register it in `api-providers/providers.ts`:
+   ```ts
+   import { useXxxOptions } from 'hooks/api/<resource>/useXxxOptions';
+
+   providerRegistry.register('xxx', {
+     description: 'Short description.',
+     useOptions: useXxxOptions,
+   });
+   ```
+3. Use `provider: xxx` in your schema.
+
+### ProviderParams / ProviderOptions types
+
+```ts
+interface ProviderParams {
+  namespace: string;
+  cluster: string;
+  config?: { refetchInterval?: number };
+}
+
+interface ProviderOptions {
+  options: Array<{ label: string; value: string }>;
+  isLoading: boolean;
+  error: unknown;
+  isEmpty: boolean;
+  rawData?: unknown;
+}
 ```
 
-## Examples
+## Architecture
 
-### Required select with monitoring configs
-
-```yaml
-monitoringEndpoint:
-  uiType: select
-  dataSource:
-    provider: monitoringConfigs
-  path: spec.components.monitoring.customSpec.monitoringConfigName
-  fieldParams:
-    label: Monitoring endpoint
-  validation:
-    required: true
 ```
+Schema (provider CRD)
+  → preprocessing warns on unknown providers
+  → DataSourceField wraps the select at render time
+  → useProviderOptions calls the registered hook
+  → options + default value flow into the form
+```
+
+Key files:
+- `api-providers/providers.ts` — provider registrations
+- `api-providers/registry.ts` — singleton registry + `useProviderOptions`
+- `api-providers/data-source-field/` — runtime wrapper that patches options and sets default value
+- `hooks/api/<resource>/use*Options.ts` — data-fetching hooks

--- a/docs/ui/ui-generator/api-providers.md
+++ b/docs/ui/ui-generator/api-providers.md
@@ -1,0 +1,153 @@
+# API Providers
+
+## Table of Contents
+
+- [What Is It](#what-is-it)
+- [How It Works](#how-it-works)
+- [How To Use It](#how-to-use-it)
+  - [Properties](#properties)
+  - [fieldParams](#fieldparams)
+  - [Validation](#validation)
+  - [Modes](#modes)
+  - [Field Behavior](#field-behavior)
+- [Available Providers](#available-providers)
+- [Examples](#examples)
+  - [Required select with monitoring configs](#required-select-with-monitoring-configs)
+  - [Optional select with empty placeholder](#optional-select-with-empty-placeholder)
+
+## What Is It
+
+`dataSource` is a property you can add to any `select` field so that its options are loaded from an Everest API at runtime instead of being declared statically in the schema.
+
+The options are scoped to the current cluster and namespace context of the form — each user sees only the resources that exist in their environment.
+
+## How It Works
+
+When the form opens, the field fetches its options from the API. While loading, the field is disabled and shows `Loading...`. If the fetch fails, the field stays disabled and shows `Failed to load options`. If the fetch succeeds but returns no items, the field shows `No options available` (or the `helperText` you defined) and remains interactive.
+
+Because the field is still a standard select, all regular select validation rules — `required`, `regex`, CEL expressions — work exactly as documented in [SelectField](components/select-field.md).
+
+If you specify a `dataSource.provider` that does not exist in the registry, a warning is logged in the browser console during schema preprocessing with a list of available provider keys.
+
+## How To Use It
+
+### Properties
+
+```yaml
+fieldKey:
+  uiType: select # Required — dataSource works with select fields
+  dataSource:
+    provider: <providerKey> # Required — see Available Providers
+    config: { ... } # Optional
+  path: <dot.separated.api.path> # Required if the value should be submitted
+  id: <uniqueId> # Alternative to path for UI-only fields
+  fieldParams: { ... } # Optional — see fieldParams
+  validation: { ... } # Optional — same as SelectField validation
+  modes: { ... } # Optional — same as any other field
+```
+
+**`uiType`** _(required)_
+
+Must be `select` when using `dataSource`.
+
+**`dataSource.provider`** _(required)_
+
+The key of the provider to use. Must match one of the [available providers](#available-providers). If the key is unknown, a warning is printed and the field renders with no options.
+
+**`path` / `id`**
+
+`dataSource` fields use the same `path`, multi-path, and `id` rules as every other UI Generator component. See [Path vs ID](../Readme.md#path-vs-id).
+
+**`dataSource.config`**
+
+> **TODO:** Document supported `dataSource.config` overrides after the API is finalized.
+
+### fieldParams
+
+`fieldParams` for an API provider field follows the same structure as [SelectField fieldParams](components/select-field.md#properties), except `options` are always provided by the API and must not be specified manually.
+
+Supported keys:
+
+| Key            | Type      | Default | Description                                                                                                                 |
+| -------------- | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `label`        | `string`  | —       | Display label shown above the field                                                                                         |
+| `helperText`   | `string`  | —       | Text shown below the field. When options are empty and no helperText is set, `No options available` is shown automatically. |
+| `disabled`     | `boolean` | `false` | Disable the field regardless of loading state                                                                               |
+| `defaultValue` | `string`  | `""`    | Pre-selected value. Must match one of the option values that the provider will return.                                      |
+| `displayEmpty` | `boolean` | `false` | When `true` and the field is optional, an empty "None" option is automatically added so the user can clear their selection. |
+| `readOnly`     | `boolean` | `false` | Show the value but prevent changes                                                                                          |
+| `autoFocus`    | `boolean` | `false` | Focus this field when the form opens                                                                                        |
+
+### Validation
+
+Validation is declared under `validation` and works identically to [SelectField validation](components/select-field.md#native-validation):
+
+```yaml
+validation:
+  required: true # field must have a value before submit
+  regex:
+    pattern: "^prod-.*"
+    message: Must start with prod-
+  celExpressions:
+    - celExpr: "self != 'disabled-config'"
+      message: This config is not allowed
+```
+
+The selected value is automatically validated against the set of options returned by the API (enum validation).
+
+### Modes
+
+`modes` works the same as for any other field. You can override any `fieldParams` property or `uiType` per form mode:
+
+```yaml
+monitoringEndpoint:
+  uiType: select
+  dataSource:
+    provider: monitoringConfigs
+  path: spec.components.monitoring.customSpec.monitoringConfigName
+  fieldParams:
+    label: Monitoring endpoint
+    modes:
+      edit:
+        helperText: Changing this will restart the monitoring agent
+```
+
+See [Mode-Aware Overrides](../Readme.md#mode-aware-overrides) for the full list of supported per-mode overrides.
+
+### Field Behavior
+
+| State               | Field    | Displayed text                                |
+| ------------------- | -------- | --------------------------------------------- |
+| Loading             | disabled | `Loading...`                                  |
+| Fetch failed        | disabled | `Failed to load options`                      |
+| Loaded, no options  | enabled  | `No options available` (or your `helperText`) |
+| Loaded, has options | enabled  | your `helperText` (if set)                    |
+
+## Available Providers
+
+### `monitoringConfigs`
+
+Returns the names of all `MonitoringConfig` resources in the current namespace as select options.
+
+Each option has the form `{ label: <name>, value: <name> }`.
+
+```yaml
+dataSource:
+  provider: monitoringConfigs
+```
+
+## Examples
+
+### Required select with monitoring configs
+
+```yaml
+monitoringEndpoint:
+  uiType: select
+  dataSource:
+    provider: monitoringConfigs
+  path: spec.components.monitoring.customSpec.monitoringConfigName
+  fieldParams:
+    label: Monitoring endpoint
+  validation:
+    required: true
+```

--- a/docs/ui/ui-generator/api-providers.md
+++ b/docs/ui/ui-generator/api-providers.md
@@ -2,6 +2,15 @@
 
 Select fields whose options come from an Everest API at runtime.
 
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Schema Reference](#schema-reference)
+- [Validation, Modes & fieldParams](#validation-modes--fieldparams)
+- [Available Providers](#available-providers)
+- [Field Behavior](#field-behavior)
+- [Adding a New Provider](#adding-a-new-provider-in-httpsgithubcomopeneverestopeneverest)
+
 ## Quick Start
 
 ```yaml
@@ -22,52 +31,62 @@ That's it. Options load automatically, first option is selected by default, and 
 fieldKey:
   uiType: select
   dataSource:
-    provider: <providerKey>   # required — see Available Providers
-    config:                   # optional
+    provider: <providerKey> # required — see Available Providers
+    config: # optional
       refetchInterval: 5000
-  path: <dot.separated.path>  # required if the value should be submitted
+  path: <dot.separated.path> # required if the value should be submitted
   fieldParams:
     label: string
-    helperText: string        # shown below; defaults to "No options available" when empty
-    disabled: boolean         # always disabled, regardless of loading state
-    defaultValue: string      # overrides auto-selection of first option
-    displayEmpty: boolean     # adds empty "None" option for optional fields
-  validation:                 # same as regular select — required, regex, celExpressions
+    helperText: string # shown below; defaults to "No options available" when empty
+    disabled: boolean # always disabled, regardless of loading state
+    defaultValue: string # overrides auto-selection of first option
+    displayEmpty: boolean # adds empty "None" option for optional fields
+  validation: # same as regular select — required, regex, celExpressions
     required: true
-  modes:                      # per-mode overrides — same as any field
+  modes: # per-mode overrides — same as any field
     edit:
       helperText: Changing this will restart the agent
 ```
 
+## Validation, Modes & fieldParams
+
+A `dataSource` field is still a regular `select` — the only difference is that options come from an API instead of being declared inline. Everything else works the same:
+
+- **Validation** — `required`, `regex`, and `celExpressions` all apply as documented in [Validation](validation.md). CEL cross-field rules (e.g. "storageClass is required when replicas > 1") work without changes — see [CEL Expressions](validation.md#cel-expressions).
+- **Modes** — per-mode overrides for `fieldParams`, `validation`, and `uiType` follow the standard rules described in [Mode-Aware Overrides](Readme.md#mode-aware-overrides).
+- **fieldParams** — supports the same keys as [Select Field](components/select-field.md): `label`, `helperText`, `disabled`, `defaultValue`, `displayEmpty`, etc. The only key you should **not** set manually is `options` — it is always provided by the API.
+
 ## Available Providers
 
-| Key                 | Returns                                          | Scoped to         |
-| ------------------- | ------------------------------------------------ | ----------------- |
-| `monitoringConfigs` | MonitoringConfig resource names                  | cluster/namespace |
-| `storageClasses`    | StorageClass names available on the cluster       | cluster           |
+| Key                 | Returns                                     | Scoped to         |
+| ------------------- | ------------------------------------------- | ----------------- |
+| `monitoringConfigs` | MonitoringConfig resource names             | cluster/namespace |
+| `storageClasses`    | StorageClass names available on the cluster | cluster           |
 
 ## Field Behavior
 
-| State              | Field    | Text                       |
-| ------------------ | -------- | -------------------------- |
-| Loading            | disabled | Loading...                 |
-| Fetch failed       | disabled | Failed to load options     |
-| No options         | enabled  | No options available       |
-| Options loaded     | enabled  | first option auto-selected |
+| State          | Field    | Text                       |
+| -------------- | -------- | -------------------------- |
+| Loading        | disabled | Loading...                 |
+| Fetch failed   | disabled | Failed to load options     |
+| No options     | enabled  | No options available       |
+| Options loaded | enabled  | first option auto-selected |
 
-## Adding a New Provider
+## Adding a New Provider in https://github.com/openeverest/openeverest
 
 1. Create a `useXxxOptions` hook in `hooks/api/<resource>/` that accepts `ProviderParams` and returns `ProviderOptions`.
 2. Register it in `api-providers/providers.ts`:
-   ```ts
-   import { useXxxOptions } from 'hooks/api/<resource>/useXxxOptions';
 
-   providerRegistry.register('xxx', {
-     description: 'Short description.',
+   ```ts
+   import { useXxxOptions } from "hooks/api/<resource>/useXxxOptions";
+
+   providerRegistry.register("xxx", {
+     description: "Short description.",
      useOptions: useXxxOptions,
    });
    ```
-3. Use `provider: xxx` in your schema.
+
+3. Use `provider: xxx` in the schema schema.
 
 ### ProviderParams / ProviderOptions types
 
@@ -86,19 +105,3 @@ interface ProviderOptions {
   rawData?: unknown;
 }
 ```
-
-## Architecture
-
-```
-Schema (provider CRD)
-  → preprocessing warns on unknown providers
-  → DataSourceField wraps the select at render time
-  → useProviderOptions calls the registered hook
-  → options + default value flow into the form
-```
-
-Key files:
-- `api-providers/providers.ts` — provider registrations
-- `api-providers/registry.ts` — singleton registry + `useProviderOptions`
-- `api-providers/data-source-field/` — runtime wrapper that patches options and sets default value
-- `hooks/api/<resource>/use*Options.ts` — data-fetching hooks

--- a/ui/.github/copilot-instructions.md
+++ b/ui/.github/copilot-instructions.md
@@ -73,6 +73,13 @@ component-name/
 
 ## Code Style Rules
 
+### Self-Documenting Code
+
+- Prefer renaming variables, functions, and types to make their purpose obvious over adding comments.
+- Inline comments should explain **why**, not **what**. If a comment restates the code, rename the code instead.
+- Avoid "comment-first" code — if you need a comment to clarify a line, first consider whether a better name would eliminate the need.
+- Reserve block comments (`/** ... */`) for public API documentation, non-obvious design decisions, and TODOs.
+
 ### Exports
 
 - Use **named exports** — not default exports (`export const Component`, not `export default`).

--- a/ui/apps/everest/src/api/monitoringConfigs.ts
+++ b/ui/apps/everest/src/api/monitoringConfigs.ts
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { api } from 'api/api';
+import { MonitoringConfig, MonitoringConfigList } from 'shared-types/api.types';
+
+// TODO: When all monitoring APIs migrate to v2, consolidate this file
+//       into api/monitoring.ts and unify the monitoring hooks layer.
+
+export const getMonitoringConfigsFn = async (
+  cluster: string,
+  namespace: string
+): Promise<MonitoringConfig[]> => {
+  const response = await api.get<MonitoringConfigList>(
+    `clusters/${cluster}/namespaces/${namespace}/monitoring-configs`
+  );
+  return response.data?.items ?? [];
+};

--- a/ui/apps/everest/src/components/ui-generator/ARCHITECTURE.md
+++ b/ui/apps/everest/src/components/ui-generator/ARCHITECTURE.md
@@ -122,7 +122,18 @@ Preprocessed sections
                │
                └── leaf component:
                      generateFieldId(item, name)  →  form field name
-                     <CustomField /> → registered in react-hook-form
+                     │
+                     ├── hasDataSource?
+                     │     → <ComponentErrorBoundary>
+                     │         <DataSourceField name={fieldName}>
+                     │           (patchedItem) → <UIComponent />
+                     │         </DataSourceField>
+                     │       </ComponentErrorBoundary>
+                     │
+                     └── otherwise:
+                           <ComponentErrorBoundary>
+                             <UIComponent />
+                           </ComponentErrorBoundary>
 ```
 
 ## 6. Postprocessing Pipeline
@@ -233,3 +244,74 @@ for full documentation):
 | Schema walker      | `utils/schema-walker/schema-walker.ts`             |
 | Object path        | `utils/object-path/object-path.ts`                 |
 | Edit modal         | `cluster-overview/sections/section-edit-modal/`    |
+| API providers      | `api-providers/` (see §10)                         |
+| Error boundary     | `component-error-boundary/`                        |
+
+## 10. API-Backed Select Fields (dataSource)
+
+Select fields can declare a `dataSource.provider` in the schema so their
+options are loaded from an API at runtime. The system has three layers:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  1. Registry  (singleton, populated at import time)     │
+│     api-providers/registry.ts                           │
+│       ├── register(key, entry)                          │
+│       └── useProviderOptions(key, params) → options     │
+│                                                         │
+│  2. Providers  (side-effect import, called once)        │
+│     api-providers/providers.ts                          │
+│       └── imports + registers each provider hook:       │
+│             hooks/api/monitoring/useMonitoringConfigsOptions.ts
+│             hooks/api/kubernetesClusters/useStorageClassesOptions.ts
+│                                                         │
+│  3. Runtime (two paths)                                 │
+│     a) DataSourcePrefetcher                             │
+│        — renders inside <FormProvider>                   │
+│        — fires useProviderOptions per unique provider    │
+│        — sets form defaults (setValue) for all fields    │
+│          that use each provider, so the summary panel    │
+│          shows values before the user visits the step    │
+│                                                         │
+│     b) DataSourceField                                  │
+│        — wraps individual select at render time          │
+│        — patches fieldParams.options with fetched data   │
+│        — also sets default (idempotent safety net)       │
+│        — handles loading/error/empty states              │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Default value flow
+
+`getDefaultValues()` runs synchronously during form init, before any API
+response arrives. For dataSource fields the initial value is `""`. The
+default is set asynchronously in two places (whichever fires first wins):
+
+1. **DataSourcePrefetcher** — runs on form mount, sets `setValue(path,
+options[0].value)` as soon as the query resolves. This makes the
+   preview/summary panel show the value immediately.
+2. **DataSourceField** — runs when the user navigates to the step. Acts
+   as a safety net in case the prefetcher hasn't fired yet.
+
+Both check `getValues(path)` before writing, so they never overwrite a
+user-selected or pre-existing value.
+
+### Error isolation
+
+Each rendered component (including DataSourceField and PrefetchItem) is
+wrapped in `<ComponentErrorBoundary>` — a lightweight MUI Alert that
+catches React errors so a single failing field doesn't break the form.
+
+### Key files
+
+| Area                   | File                                                       |
+| ---------------------- | ---------------------------------------------------------- |
+| Registry               | `api-providers/registry.ts`                                |
+| Provider registrations | `api-providers/providers.ts`                               |
+| DataSourceField        | `api-providers/data-source-field/data-source-field.tsx`    |
+| Prefetcher             | `api-providers/data-source-prefetcher.tsx`                 |
+| Error boundary         | `component-error-boundary/component-error-boundary.tsx`    |
+| Monitoring hook        | `hooks/api/monitoring/useMonitoringConfigsOptions.ts`      |
+| Storage classes hook   | `hooks/api/kubernetesClusters/useStorageClassesOptions.ts` |
+
+See also: [docs/ui/ui-generator/api-providers.md](../../../docs/ui/ui-generator/api-providers.md)

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.test.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.test.tsx
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, waitFor } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { DataSourceField } from './data-source-field';
+import type { ComponentWithDataSource } from './data-source-field.types';
+import { FieldType } from '../../ui-generator.types';
+
+const mockUseProviderOptions = vi.fn();
+
+vi.mock('../registry', () => ({
+  useProviderOptions: (...args: unknown[]) => mockUseProviderOptions(...args),
+}));
+
+vi.mock('../../ui-generator-context', () => ({
+  useUiGeneratorContext: () => ({ namespace: 'ns', cluster: 'cl' }),
+}));
+
+const makeItem = (): ComponentWithDataSource => ({
+  uiType: FieldType.Select,
+  path: 'spec.storageClass',
+  fieldParams: { label: 'Storage class' },
+  dataSource: { provider: 'storageClasses' },
+});
+
+describe('DataSourceField', () => {
+  it('sets form value to first option when options arrive and field is empty', async () => {
+    mockUseProviderOptions.mockReturnValue({
+      options: [
+        { label: 'standard', value: 'standard' },
+        { label: 'premium', value: 'premium' },
+      ],
+      isLoading: false,
+      error: null,
+      isEmpty: false,
+    });
+
+    let getValues: (name: string) => unknown = () => undefined;
+
+    const Harness = () => {
+      const methods = useForm({
+        defaultValues: { spec: { storageClass: '' } },
+      });
+      getValues = methods.getValues;
+      return (
+        <FormProvider {...methods}>
+          <DataSourceField item={makeItem()} name="spec.storageClass">
+            {() => <div />}
+          </DataSourceField>
+        </FormProvider>
+      );
+    };
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(getValues('spec.storageClass')).toBe('standard');
+    });
+  });
+
+  it('does not overwrite an existing form value', async () => {
+    mockUseProviderOptions.mockReturnValue({
+      options: [
+        { label: 'standard', value: 'standard' },
+        { label: 'premium', value: 'premium' },
+      ],
+      isLoading: false,
+      error: null,
+      isEmpty: false,
+    });
+
+    let getValues: (name: string) => unknown = () => undefined;
+
+    const Harness = () => {
+      const methods = useForm({
+        defaultValues: { spec: { storageClass: 'premium' } },
+      });
+      getValues = methods.getValues;
+      return (
+        <FormProvider {...methods}>
+          <DataSourceField item={makeItem()} name="spec.storageClass">
+            {() => <div />}
+          </DataSourceField>
+        </FormProvider>
+      );
+    };
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(getValues('spec.storageClass')).toBe('premium');
+    });
+  });
+});

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
@@ -37,8 +37,6 @@ export const DataSourceField: React.FC<DataSourceFieldProps> = ({
     }
   );
 
-  // Set form value to first option when options arrive and the field is empty.
-  // Mirrors the optionsPath behavior in preprocess-schema.ts.
   useEffect(() => {
     if (isLoading || options.length === 0 || !name) return;
 

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
 import type { Component } from '../../ui-generator.types';
 import { useProviderOptions } from '../registry';
 import { useUiGeneratorContext } from '../../ui-generator-context';
@@ -20,9 +21,11 @@ import type { DataSourceFieldProps } from './data-source-field.types';
 
 export const DataSourceField: React.FC<DataSourceFieldProps> = ({
   item,
+  name,
   children,
 }) => {
   const { namespace, cluster } = useUiGeneratorContext();
+  const { getValues, setValue } = useFormContext();
   const { dataSource, ...baseComponent } = item;
 
   const { options, isLoading, error, isEmpty } = useProviderOptions(
@@ -33,6 +36,17 @@ export const DataSourceField: React.FC<DataSourceFieldProps> = ({
       config: dataSource.config,
     }
   );
+
+  // Set form value to first option when options arrive and the field is empty.
+  // Mirrors the optionsPath behavior in preprocess-schema.ts.
+  useEffect(() => {
+    if (isLoading || options.length === 0 || !name) return;
+
+    const current = getValues(name);
+    if (current === '' || current === undefined || current === null) {
+      setValue(name, options[0].value, { shouldValidate: true });
+    }
+  }, [isLoading, options, name, getValues, setValue]);
 
   const patchedItem = useMemo(() => {
     const originalHelperText = (

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { useMemo } from 'react';
+import type { Component } from '../../ui-generator.types';
+import { useProviderOptions } from '../registry';
+import { useUiGeneratorContext } from '../../ui-generator-context';
+import type { DataSourceFieldProps } from './data-source-field.types';
+
+export const DataSourceField: React.FC<DataSourceFieldProps> = ({
+  item,
+  children,
+}) => {
+  const { namespace, cluster } = useUiGeneratorContext();
+  const { dataSource, ...baseComponent } = item;
+
+  const { options, isLoading, error, isEmpty } = useProviderOptions(
+    dataSource.provider,
+    {
+      namespace: namespace ?? '',
+      cluster: cluster ?? '',
+      config: dataSource.config,
+    }
+  );
+
+  const patchedItem = useMemo(() => {
+    const originalHelperText = (
+      baseComponent.fieldParams as Record<string, unknown>
+    )?.helperText;
+
+    const helperText = isLoading
+      ? 'Loading...'
+      : error
+        ? 'Failed to load options'
+        : isEmpty
+          ? (originalHelperText ?? 'No options available')
+          : originalHelperText;
+
+    return {
+      ...baseComponent,
+      fieldParams: {
+        ...baseComponent.fieldParams,
+        options,
+        disabled:
+          isLoading ||
+          !!error ||
+          (baseComponent.fieldParams as Record<string, unknown>)?.disabled,
+        ...(helperText !== undefined ? { helperText } : {}),
+      },
+    } as Component;
+  }, [baseComponent, options, isLoading, error, isEmpty]);
+
+  // TODO: Render fallback component when isEmpty/error and fallback is defined
+  // (requires Alert component — see separate issue)
+
+  return <>{children(patchedItem)}</>;
+};

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.types.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.types.ts
@@ -19,5 +19,6 @@ export type ComponentWithDataSource = Component & { dataSource: DataSource };
 
 export interface DataSourceFieldProps {
   item: ComponentWithDataSource;
+  name: string;
   children: (patchedItem: Component) => React.ReactNode;
 }

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.types.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.types.ts
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type React from 'react';
+import type { Component, DataSource } from '../../ui-generator.types';
+
+export type ComponentWithDataSource = Component & { dataSource: DataSource };
+
+export interface DataSourceFieldProps {
+  item: ComponentWithDataSource;
+  children: (patchedItem: Component) => React.ReactNode;
+}

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.utils.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.utils.ts
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Component } from '../../ui-generator.types';
+import type { ComponentWithDataSource } from './data-source-field.types';
+
+export const hasDataSource = (
+  item: Component
+): item is ComponentWithDataSource => {
+  return (
+    'dataSource' in item &&
+    typeof (item as Record<string, unknown>).dataSource === 'object' &&
+    !!(item as Record<string, unknown>).dataSource
+  );
+};

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/index.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/index.ts
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export { DataSourceField } from './data-source-field';
+export { hasDataSource } from './data-source-field.utils';
+export type {
+  DataSourceFieldProps,
+  ComponentWithDataSource,
+} from './data-source-field.types';

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-prefetcher.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-prefetcher.tsx
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
 import type {
   Component,
   ComponentGroup,
@@ -21,17 +22,20 @@ import type {
 } from '../ui-generator.types';
 import { hasDataSource } from './data-source-field';
 import { useProviderOptions } from './registry';
+import { ComponentErrorBoundary } from '../component-error-boundary';
+import { getComponentSourcePath } from '../utils/preprocess/normalized-component';
 
 type DataSourceDeclaration = {
   provider: string;
   config?: DataSourceConfig;
+  fieldPaths: string[];
 };
 
 const collectDataSources = (
   sections: Record<string, Section>
 ): DataSourceDeclaration[] => {
   const results: DataSourceDeclaration[] = [];
-  const seen = new Set<string>();
+  const byProvider = new Map<string, DataSourceDeclaration>();
 
   const walk = (components: Record<string, Component | ComponentGroup>) => {
     for (const comp of Object.values(components)) {
@@ -40,12 +44,18 @@ const collectDataSources = (
       }
       const asComponent = comp as Component;
       if (hasDataSource(asComponent)) {
-        if (!seen.has(asComponent.dataSource.provider)) {
-          seen.add(asComponent.dataSource.provider);
-          results.push({
+        const fieldPath = getComponentSourcePath(asComponent);
+        const existing = byProvider.get(asComponent.dataSource.provider);
+        if (existing) {
+          if (fieldPath) existing.fieldPaths.push(fieldPath);
+        } else {
+          const decl: DataSourceDeclaration = {
             provider: asComponent.dataSource.provider,
             config: asComponent.dataSource.config,
-          });
+            fieldPaths: fieldPath ? [fieldPath] : [],
+          };
+          byProvider.set(asComponent.dataSource.provider, decl);
+          results.push(decl);
         }
       }
     }
@@ -60,19 +70,40 @@ const collectDataSources = (
   return results;
 };
 
-// Each data source gets its own component so hook rules are satisfied
+// Each data source gets its own component so hook rules are satisfied.
+// Also sets the default form value when options arrive so the preview
+// panel shows the value before the user navigates to the field's step.
 const PrefetchItem = ({
   provider,
   namespace,
   cluster,
   config,
+  fieldPaths,
 }: {
   provider: string;
   namespace: string;
   cluster: string;
   config?: DataSourceConfig;
+  fieldPaths: string[];
 }) => {
-  useProviderOptions(provider, { namespace, cluster, config });
+  const { options, isLoading } = useProviderOptions(provider, {
+    namespace,
+    cluster,
+    config,
+  });
+  const { getValues, setValue } = useFormContext();
+
+  useEffect(() => {
+    if (isLoading || options.length === 0) return;
+
+    for (const path of fieldPaths) {
+      const current = getValues(path);
+      if (current === '' || current === undefined || current === null) {
+        setValue(path, options[0].value, { shouldValidate: true });
+      }
+    }
+  }, [isLoading, options, fieldPaths, getValues, setValue]);
+
   return null;
 };
 
@@ -100,13 +131,18 @@ export const DataSourcePrefetcher = ({
   return (
     <>
       {dataSources.map((ds) => (
-        <PrefetchItem
+        <ComponentErrorBoundary
           key={ds.provider}
-          provider={ds.provider}
-          namespace={namespace}
-          cluster={cluster}
-          config={ds.config}
-        />
+          componentName={`prefetch:${ds.provider}`}
+        >
+          <PrefetchItem
+            provider={ds.provider}
+            namespace={namespace}
+            cluster={cluster}
+            config={ds.config}
+            fieldPaths={ds.fieldPaths}
+          />
+        </ComponentErrorBoundary>
       ))}
     </>
   );

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-prefetcher.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-prefetcher.tsx
@@ -70,9 +70,6 @@ const collectDataSources = (
   return results;
 };
 
-// Each data source gets its own component so hook rules are satisfied.
-// Also sets the default form value when options arrive so the preview
-// panel shows the value before the user navigates to the field's step.
 const PrefetchItem = ({
   provider,
   namespace,

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-prefetcher.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-prefetcher.tsx
@@ -1,0 +1,113 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useMemo } from 'react';
+import type {
+  Component,
+  ComponentGroup,
+  DataSourceConfig,
+  Section,
+} from '../ui-generator.types';
+import { hasDataSource } from './data-source-field';
+import { useProviderOptions } from './registry';
+
+type DataSourceDeclaration = {
+  provider: string;
+  config?: DataSourceConfig;
+};
+
+const collectDataSources = (
+  sections: Record<string, Section>
+): DataSourceDeclaration[] => {
+  const results: DataSourceDeclaration[] = [];
+  const seen = new Set<string>();
+
+  const walk = (components: Record<string, Component | ComponentGroup>) => {
+    for (const comp of Object.values(components)) {
+      if ('components' in comp) {
+        walk((comp as ComponentGroup).components);
+      }
+      const asComponent = comp as Component;
+      if (hasDataSource(asComponent)) {
+        if (!seen.has(asComponent.dataSource.provider)) {
+          seen.add(asComponent.dataSource.provider);
+          results.push({
+            provider: asComponent.dataSource.provider,
+            config: asComponent.dataSource.config,
+          });
+        }
+      }
+    }
+  };
+
+  for (const section of Object.values(sections)) {
+    if (section.components) {
+      walk(section.components);
+    }
+  }
+
+  return results;
+};
+
+// Each data source gets its own component so hook rules are satisfied
+const PrefetchItem = ({
+  provider,
+  namespace,
+  cluster,
+  config,
+}: {
+  provider: string;
+  namespace: string;
+  cluster: string;
+  config?: DataSourceConfig;
+}) => {
+  useProviderOptions(provider, { namespace, cluster, config });
+  return null;
+};
+
+type DataSourcePrefetcherProps = {
+  sections: Record<string, Section>;
+  namespace?: string;
+  cluster?: string;
+};
+
+export const DataSourcePrefetcher = ({
+  sections,
+  namespace,
+  cluster,
+}: DataSourcePrefetcherProps) => {
+  const dataSources = useMemo(() => collectDataSources(sections), [sections]);
+
+  if (!namespace || !cluster) return null;
+
+  // TODO: Support enable/disable toggle wrappers — when a component has
+  // an on/off toggle (e.g. monitoring enabled/disabled), the prefetch
+  // should only fire when the toggle is enabled. This will require
+  // reading the toggle state from the form and conditionally including
+  // the PrefetchItem.
+
+  return (
+    <>
+      {dataSources.map((ds) => (
+        <PrefetchItem
+          key={ds.provider}
+          provider={ds.provider}
+          namespace={namespace}
+          cluster={cluster}
+          config={ds.config}
+        />
+      ))}
+    </>
+  );
+};

--- a/ui/apps/everest/src/components/ui-generator/api-providers/index.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/index.ts
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Side-effect import: registers all built-in providers (monitoringConfigs, etc.)
+import './providers';
+
+export { providerRegistry, useProviderOptions } from './registry';
+export { DataSourceField, hasDataSource } from './data-source-field';
+export { DataSourcePrefetcher } from './data-source-prefetcher';
+export type {
+  DataSourceFieldProps,
+  ComponentWithDataSource,
+} from './data-source-field';
+export type {
+  ProviderParams,
+  ProviderOptions,
+  ProviderRegistryEntry,
+} from './types';

--- a/ui/apps/everest/src/components/ui-generator/api-providers/providers.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/providers.ts
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { providerRegistry } from './registry';
+import type { ProviderParams, ProviderOptions } from './types';
+import { useMonitoringConfigsList } from 'hooks/api/monitoring/useMonitoringConfigsList';
+
+const useMonitoringConfigsOptions = (
+  params: ProviderParams
+): ProviderOptions => {
+  const { data, isLoading, error } = useMonitoringConfigsList(
+    params.cluster,
+    params.namespace,
+    { refetchInterval: params.config?.refetchInterval }
+  );
+
+  const options = (data ?? []).map((mc) => ({
+    label: mc.metadata.name,
+    value: mc.metadata.name,
+  }));
+
+  return {
+    options,
+    isLoading,
+    error,
+    isEmpty: !isLoading && options.length === 0,
+    rawData: data,
+  };
+};
+
+providerRegistry.register('monitoringConfigs', {
+  description:
+    'List of MonitoringConfig resources in the given namespace. ' +
+    'Returns config names as select options.',
+  useOptions: useMonitoringConfigsOptions,
+});
+
+// TODO: Register 'storageClasses' provider (migrate from optionsPath-based resolution)
+// TODO: When all monitoring APIs migrate to v2, consolidate api/monitoringConfigs.ts
+//       into api/monitoring.ts and unify hooks under hooks/api/monitoring/

--- a/ui/apps/everest/src/components/ui-generator/api-providers/registry.test.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/registry.test.ts
@@ -12,102 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, expect, it, beforeEach } from 'vitest';
-import type { ProviderRegistryEntry } from './types';
-
-// Create a fresh registry for each test to avoid cross-test pollution.
-// We inline the class here because importing from registry.ts would also
-// trigger the singleton + side-effect provider registrations.
-class TestApiProviderRegistry {
-  private entries = new Map<string, ProviderRegistryEntry>();
-
-  register(key: string, entry: ProviderRegistryEntry): void {
-    if (this.entries.has(key)) {
-      throw new Error(`provider "${key}" is already registered.`);
-    }
-    this.entries.set(key, entry);
-  }
-
-  get(key: string): ProviderRegistryEntry | undefined {
-    return this.entries.get(key);
-  }
-
-  has(key: string): boolean {
-    return this.entries.has(key);
-  }
-
-  getAll(): Map<string, ProviderRegistryEntry> {
-    return new Map(this.entries);
-  }
-
-  getAvailableKeys(): string[] {
-    return Array.from(this.entries.keys());
-  }
-}
-
-const mockEntry: ProviderRegistryEntry = {
-  useOptions: () => ({
-    options: [{ label: 'test', value: 'test' }],
-    isLoading: false,
-    error: null,
-    isEmpty: false,
-  }),
-  description: 'Test provider',
-};
+import { describe, expect, it } from 'vitest';
+import { providerRegistry, useProviderOptions } from './index';
 
 describe('ApiProviderRegistry', () => {
-  let registry: TestApiProviderRegistry;
-
-  beforeEach(() => {
-    registry = new TestApiProviderRegistry();
+  it('built-in providers are registered via side-effect import', () => {
+    expect(providerRegistry.has('monitoringConfigs')).toBe(true);
+    expect(providerRegistry.has('storageClasses')).toBe(true);
   });
 
-  it('registers and retrieves a provider', () => {
-    registry.register('test', mockEntry);
-    expect(registry.get('test')).toBe(mockEntry);
-  });
-
-  it('returns undefined for unregistered key', () => {
-    expect(registry.get('nonExistent')).toBeUndefined();
-  });
-
-  it('has() returns true for registered key', () => {
-    registry.register('test', mockEntry);
-    expect(registry.has('test')).toBe(true);
-    expect(registry.has('other')).toBe(false);
-  });
-
-  it('throws on duplicate registration', () => {
-    registry.register('test', mockEntry);
-    expect(() => registry.register('test', mockEntry)).toThrow(
-      'already registered'
-    );
-  });
-
-  it('getAll returns all registered entries', () => {
-    registry.register('a', mockEntry);
-    registry.register('b', { ...mockEntry, description: 'B' });
-
-    const all = registry.getAll();
-    expect(all.size).toBe(2);
-    expect(all.has('a')).toBe(true);
-    expect(all.has('b')).toBe(true);
-  });
-
-  it('getAvailableKeys returns sorted key list', () => {
-    registry.register('beta', mockEntry);
-    registry.register('alpha', { ...mockEntry, description: 'Alpha' });
-
-    const keys = registry.getAvailableKeys();
-    expect(keys).toContain('alpha');
-    expect(keys).toContain('beta');
-  });
-
-  it('getAll returns a copy — mutations do not affect registry', () => {
-    registry.register('test', mockEntry);
-    const copy = registry.getAll();
-    copy.delete('test');
-
-    expect(registry.has('test')).toBe(true);
+  it('useProviderOptions throws for unknown provider key', () => {
+    expect(() =>
+      useProviderOptions('nonExistent', { namespace: 'ns', cluster: 'cl' })
+    ).toThrow('Unknown API provider');
   });
 });

--- a/ui/apps/everest/src/components/ui-generator/api-providers/registry.test.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/registry.test.ts
@@ -1,0 +1,113 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import type { ProviderRegistryEntry } from './types';
+
+// Create a fresh registry for each test to avoid cross-test pollution.
+// We inline the class here because importing from registry.ts would also
+// trigger the singleton + side-effect provider registrations.
+class TestApiProviderRegistry {
+  private entries = new Map<string, ProviderRegistryEntry>();
+
+  register(key: string, entry: ProviderRegistryEntry): void {
+    if (this.entries.has(key)) {
+      throw new Error(`provider "${key}" is already registered.`);
+    }
+    this.entries.set(key, entry);
+  }
+
+  get(key: string): ProviderRegistryEntry | undefined {
+    return this.entries.get(key);
+  }
+
+  has(key: string): boolean {
+    return this.entries.has(key);
+  }
+
+  getAll(): Map<string, ProviderRegistryEntry> {
+    return new Map(this.entries);
+  }
+
+  getAvailableKeys(): string[] {
+    return Array.from(this.entries.keys());
+  }
+}
+
+const mockEntry: ProviderRegistryEntry = {
+  useOptions: () => ({
+    options: [{ label: 'test', value: 'test' }],
+    isLoading: false,
+    error: null,
+    isEmpty: false,
+  }),
+  description: 'Test provider',
+};
+
+describe('ApiProviderRegistry', () => {
+  let registry: TestApiProviderRegistry;
+
+  beforeEach(() => {
+    registry = new TestApiProviderRegistry();
+  });
+
+  it('registers and retrieves a provider', () => {
+    registry.register('test', mockEntry);
+    expect(registry.get('test')).toBe(mockEntry);
+  });
+
+  it('returns undefined for unregistered key', () => {
+    expect(registry.get('nonExistent')).toBeUndefined();
+  });
+
+  it('has() returns true for registered key', () => {
+    registry.register('test', mockEntry);
+    expect(registry.has('test')).toBe(true);
+    expect(registry.has('other')).toBe(false);
+  });
+
+  it('throws on duplicate registration', () => {
+    registry.register('test', mockEntry);
+    expect(() => registry.register('test', mockEntry)).toThrow(
+      'already registered'
+    );
+  });
+
+  it('getAll returns all registered entries', () => {
+    registry.register('a', mockEntry);
+    registry.register('b', { ...mockEntry, description: 'B' });
+
+    const all = registry.getAll();
+    expect(all.size).toBe(2);
+    expect(all.has('a')).toBe(true);
+    expect(all.has('b')).toBe(true);
+  });
+
+  it('getAvailableKeys returns sorted key list', () => {
+    registry.register('beta', mockEntry);
+    registry.register('alpha', { ...mockEntry, description: 'Alpha' });
+
+    const keys = registry.getAvailableKeys();
+    expect(keys).toContain('alpha');
+    expect(keys).toContain('beta');
+  });
+
+  it('getAll returns a copy — mutations do not affect registry', () => {
+    registry.register('test', mockEntry);
+    const copy = registry.getAll();
+    copy.delete('test');
+
+    expect(registry.has('test')).toBe(true);
+  });
+});

--- a/ui/apps/everest/src/components/ui-generator/api-providers/registry.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/registry.ts
@@ -22,11 +22,12 @@ class ApiProviderRegistry {
   private entries = new Map<string, ProviderRegistryEntry>();
 
   register(key: string, entry: ProviderRegistryEntry): void {
-    if (this.entries.has(key)) {
+    if (this.entries.has(key) && !import.meta.hot) {
       throw new Error(
         `ApiProviderRegistry: provider "${key}" is already registered.`
       );
     }
+    // Vite HMR re-runs providers.ts while this singleton survives — allow overwrite.
     this.entries.set(key, entry);
   }
 
@@ -45,8 +46,6 @@ class ApiProviderRegistry {
   getAvailableKeys(): string[] {
     return Array.from(this.entries.keys());
   }
-
-  // TODO: unregister(key) — if hot-reloading of providers is needed
 }
 
 // Singleton registry instance

--- a/ui/apps/everest/src/components/ui-generator/api-providers/registry.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/registry.ts
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {
+  ProviderRegistryEntry,
+  ProviderOptions,
+  ProviderParams,
+} from './types';
+
+class ApiProviderRegistry {
+  private entries = new Map<string, ProviderRegistryEntry>();
+
+  register(key: string, entry: ProviderRegistryEntry): void {
+    if (this.entries.has(key)) {
+      throw new Error(
+        `ApiProviderRegistry: provider "${key}" is already registered.`
+      );
+    }
+    this.entries.set(key, entry);
+  }
+
+  get(key: string): ProviderRegistryEntry | undefined {
+    return this.entries.get(key);
+  }
+
+  has(key: string): boolean {
+    return this.entries.has(key);
+  }
+
+  getAll(): Map<string, ProviderRegistryEntry> {
+    return new Map(this.entries);
+  }
+
+  getAvailableKeys(): string[] {
+    return Array.from(this.entries.keys());
+  }
+
+  // TODO: unregister(key) — if hot-reloading of providers is needed
+}
+
+// Singleton registry instance
+export const providerRegistry = new ApiProviderRegistry();
+
+export const useProviderOptions = (
+  providerKey: string,
+  params: ProviderParams
+): ProviderOptions => {
+  const entry = providerRegistry.get(providerKey);
+
+  if (!entry) {
+    const available = providerRegistry.getAvailableKeys().join(', ');
+    throw new Error(
+      `Unknown API provider "${providerKey}". Available providers: ${available}`
+    );
+  }
+
+  return entry.useOptions(params);
+};

--- a/ui/apps/everest/src/components/ui-generator/api-providers/types.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/types.ts
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DataSourceConfig } from '../ui-generator.types';
+
+export interface ProviderParams {
+  namespace: string;
+  cluster: string;
+  config?: DataSourceConfig;
+  // TODO: Add currentValue?: string for filtering out unavailable options at edit time
+}
+
+export interface ProviderOptions {
+  options: Array<{ label: string; value: string }>;
+  isLoading: boolean;
+  error: unknown;
+  isEmpty: boolean;
+  rawData?: unknown;
+}
+
+export interface ProviderRegistryEntry {
+  useOptions: (params: ProviderParams) => ProviderOptions;
+  description: string;
+  // TODO: Add lifecycle hooks — beforeFetch, afterFetch, onError
+  // TODO: Add optional `validate` callback for dev-time schema validation
+}

--- a/ui/apps/everest/src/components/ui-generator/component-error-boundary/component-error-boundary.tsx
+++ b/ui/apps/everest/src/components/ui-generator/component-error-boundary/component-error-boundary.tsx
@@ -1,0 +1,67 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component, type ReactNode } from 'react';
+import { Alert, AlertTitle } from '@mui/material';
+
+interface ComponentErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  componentName?: string;
+}
+
+interface ComponentErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+const initialState: ComponentErrorBoundaryState = {
+  hasError: false,
+  error: null,
+};
+
+export class ComponentErrorBoundary extends Component<
+  ComponentErrorBoundaryProps,
+  ComponentErrorBoundaryState
+> {
+  constructor(props: ComponentErrorBoundaryProps) {
+    super(props);
+    this.state = initialState;
+  }
+
+  static getDerivedStateFromError(error: Error): ComponentErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <Alert severity="error" sx={{ my: 1 }}>
+          <AlertTitle>
+            {this.props.componentName
+              ? `Failed to render "${this.props.componentName}"`
+              : 'Failed to render component'}
+          </AlertTitle>
+          {this.state.error?.message}
+        </Alert>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/ui/apps/everest/src/components/ui-generator/component-error-boundary/index.ts
+++ b/ui/apps/everest/src/components/ui-generator/component-error-boundary/index.ts
@@ -12,16 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { providerRegistry } from './registry';
-import { useMonitoringConfigsOptions } from 'hooks/api/monitoring/useMonitoringConfigsOptions';
-import { useStorageClassesOptions } from 'hooks/api/kubernetesClusters/useStorageClassesOptions';
-
-providerRegistry.register('monitoringConfigs', {
-  description: 'MonitoringConfig names in the current namespace.',
-  useOptions: useMonitoringConfigsOptions,
-});
-
-providerRegistry.register('storageClasses', {
-  description: 'StorageClass names available on the cluster.',
-  useOptions: useStorageClassesOptions,
-});
+export { ComponentErrorBoundary } from './component-error-boundary';

--- a/ui/apps/everest/src/components/ui-generator/form-engine/types.ts
+++ b/ui/apps/everest/src/components/ui-generator/form-engine/types.ts
@@ -41,14 +41,13 @@ export type StepDefinition = {
 };
 
 export type FormEngineConfig = {
-  /** Pre-processed topology UI schema. */
+  // Pre-processed topology UI schema
   uiSchema: TopologyUISchemas;
-  /** Currently selected topology key. */
   selectedTopology: string;
-  /** Hand-coded steps injected before the schema-generated steps. */
   staticSteps?: StepDefinition[];
-  /** Provider object passed down to UIGenerator for option resolution. */
   providerObject?: Provider;
+  namespace?: string;
+  cluster?: string;
 };
 
 export type FormEngineResult = {

--- a/ui/apps/everest/src/components/ui-generator/form-engine/use-form-engine.ts
+++ b/ui/apps/everest/src/components/ui-generator/form-engine/use-form-engine.ts
@@ -37,6 +37,8 @@ export const useFormEngine = (config: FormEngineConfig): FormEngineResult => {
     selectedTopology,
     staticSteps = [],
     providerObject,
+    namespace,
+    cluster,
   } = config;
 
   // 1. Schema processing (sections, zod, field map)
@@ -76,6 +78,8 @@ export const useFormEngine = (config: FormEngineConfig): FormEngineResult => {
             sections,
             providerObject,
             loadingDefaultsForEdition,
+            namespace,
+            cluster,
           });
 
         return {
@@ -87,7 +91,7 @@ export const useFormEngine = (config: FormEngineConfig): FormEngineResult => {
           fields,
         };
       }),
-    [sectionKeys, sections, sectionFieldMap, providerObject]
+    [sectionKeys, sections, sectionFieldMap, providerObject, namespace, cluster]
   );
 
   // 3. Merge static + generated steps

--- a/ui/apps/everest/src/components/ui-generator/ui-generator-context.tsx
+++ b/ui/apps/everest/src/components/ui-generator/ui-generator-context.tsx
@@ -20,6 +20,8 @@ type UiGeneratorContextValue = {
   providerObject?: Provider;
   loadingDefaultsForEdition?: boolean;
   formMode?: FormMode;
+  namespace?: string;
+  cluster?: string;
 };
 
 const UiGeneratorContext = createContext<UiGeneratorContextValue | null>(null);
@@ -28,6 +30,8 @@ type UiGeneratorProviderProps = {
   providerObject?: Provider;
   loadingDefaultsForEdition?: boolean;
   formMode?: FormMode;
+  namespace?: string;
+  cluster?: string;
   children: ReactNode;
 };
 
@@ -35,6 +39,8 @@ export const UiGeneratorProvider = ({
   providerObject,
   loadingDefaultsForEdition,
   formMode,
+  namespace,
+  cluster,
   children,
 }: UiGeneratorProviderProps) => {
   return (
@@ -43,6 +49,8 @@ export const UiGeneratorProvider = ({
         providerObject,
         loadingDefaultsForEdition,
         formMode,
+        namespace,
+        cluster,
       }}
     >
       {children}
@@ -58,6 +66,8 @@ export const useUiGeneratorContext = () => {
       providerObject: undefined,
       loadingDefaultsForEdition: false,
       formMode: undefined,
+      namespace: undefined,
+      cluster: undefined,
     }
   );
 };

--- a/ui/apps/everest/src/components/ui-generator/ui-generator.tsx
+++ b/ui/apps/everest/src/components/ui-generator/ui-generator.tsx
@@ -14,19 +14,9 @@
 
 import React from 'react';
 import { FormGroup, Stack, Typography } from '@mui/material';
-import { Section, FormMode } from './ui-generator.types';
+import { UIGeneratorProps } from './ui-generator.types';
 import { orderComponents, renderComponent } from './utils/component-renderer';
 import { UiGeneratorProvider } from './ui-generator-context';
-import { Provider } from 'shared-types/api.types';
-
-type UIGeneratorProps = {
-  /** Section key identifying which section to render. */
-  sectionKey: string;
-  sections: { [key: string]: Section };
-  providerObject?: Provider;
-  loadingDefaultsForEdition?: boolean;
-  formMode?: FormMode;
-};
 
 export const UIGenerator = ({
   sectionKey,
@@ -34,6 +24,8 @@ export const UIGenerator = ({
   providerObject,
   loadingDefaultsForEdition,
   formMode,
+  namespace,
+  cluster,
 }: UIGeneratorProps) => {
   const section = sections[sectionKey];
   const components = section?.components;
@@ -55,6 +47,8 @@ export const UIGenerator = ({
       providerObject={providerObject}
       loadingDefaultsForEdition={loadingDefaultsForEdition}
       formMode={formMode}
+      namespace={namespace}
+      cluster={cluster}
     >
       <FormGroup sx={{ mt: 3 }}>
         <Stack spacing={2}>

--- a/ui/apps/everest/src/components/ui-generator/ui-generator.types.ts
+++ b/ui/apps/everest/src/components/ui-generator/ui-generator.types.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Provider } from "shared-types/api.types";
+
 export enum FormMode {
   New = 'new',
   Edit = 'edit',
@@ -45,6 +47,15 @@ export type NormalizedPathMeta = {
   sourcePath?: string;
   targetPaths: string[];
 };
+
+export interface DataSourceConfig {
+  refetchInterval?: number;
+}
+
+export interface DataSource {
+  provider: string;
+  config?: DataSourceConfig;
+}
 
 export enum FieldType {
   Number = 'number',
@@ -87,7 +98,7 @@ type SelectFieldParamsBase = CommonFieldParams & {
 
 export type SelectFieldParams =
   | (SelectFieldParamsBase & {
-      options: SelectOptionsItem[];
+      options?: SelectOptionsItem[];
       optionsPath?: never;
       optionsPathConfig?: never;
     })
@@ -181,6 +192,7 @@ export type Component = {
     fieldParams: FieldParamsMap[K];
     modes?: ComponentModeOverrides;
     _normalized?: NormalizedPathMeta;
+    dataSource?: DataSource;
   } & PathOrId;
 }[keyof FieldParamsMap];
 
@@ -215,3 +227,13 @@ export type TopologyUISchemas = {
   // if we will want more properties for topology
   [K in string]: Topology;
 } & Record<string, unknown>;
+
+export type UIGeneratorProps = {
+  sectionKey: string;
+  sections: { [key: string]: Section };
+  providerObject?: Provider;
+  loadingDefaultsForEdition?: boolean;
+  formMode?: FormMode;
+  namespace?: string;
+  cluster?: string;
+};

--- a/ui/apps/everest/src/components/ui-generator/ui-generator.types.ts
+++ b/ui/apps/everest/src/components/ui-generator/ui-generator.types.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Provider } from "shared-types/api.types";
+import { Provider } from 'shared-types/api.types';
 
 export enum FormMode {
   New = 'new',

--- a/ui/apps/everest/src/components/ui-generator/utils/component-renderer/render-component.tsx
+++ b/ui/apps/everest/src/components/ui-generator/utils/component-renderer/render-component.tsx
@@ -27,6 +27,7 @@ import {
   hasDataSource,
   type ComponentWithDataSource,
 } from 'components/ui-generator/api-providers';
+import { ComponentErrorBoundary } from 'components/ui-generator/component-error-boundary';
 
 export type RenderComponentProps = {
   item: Component | ComponentGroup;
@@ -57,27 +58,35 @@ export const renderComponent = ({
       );
     })
   ) : hasDataSource(item as Component) ? (
-    <DataSourceField key={fieldName} item={item as ComponentWithDataSource}>
-      {(patchedItem: Component) => (
-        <UIComponent key={fieldName} item={patchedItem} name={fieldName} />
-      )}
-    </DataSourceField>
+    <ComponentErrorBoundary key={fieldName} componentName={name}>
+      <DataSourceField item={item as ComponentWithDataSource} name={fieldName}>
+        {(patchedItem: Component) => (
+          <UIComponent key={fieldName} item={patchedItem} name={fieldName} />
+        )}
+      </DataSourceField>
+    </ComponentErrorBoundary>
   ) : (
     <UIComponent key={fieldName} item={item as Component} name={fieldName} />
   );
 
   if (isGroup) {
     return (
-      <UIGroup
-        key={fieldName}
-        item={item}
-        groupType={(item as ComponentGroup).groupType}
-        groupParams={(item as ComponentGroup).groupParams}
-      >
-        {children}
-      </UIGroup>
+      <ComponentErrorBoundary key={fieldName} componentName={name}>
+        <UIGroup
+          key={fieldName}
+          item={item}
+          groupType={(item as ComponentGroup).groupType}
+          groupParams={(item as ComponentGroup).groupParams}
+        >
+          {children}
+        </UIGroup>
+      </ComponentErrorBoundary>
     );
   }
 
-  return <React.Fragment key={fieldName}>{children}</React.Fragment>;
+  return (
+    <ComponentErrorBoundary key={fieldName} componentName={name}>
+      {children}
+    </ComponentErrorBoundary>
+  );
 };

--- a/ui/apps/everest/src/components/ui-generator/utils/component-renderer/render-component.tsx
+++ b/ui/apps/everest/src/components/ui-generator/utils/component-renderer/render-component.tsx
@@ -22,6 +22,11 @@ import UIComponent from 'components/ui-generator/ui-component/ui-component';
 import UIGroup from 'components/ui-generator/ui-group/ui-group';
 import { generateFieldId } from './generate-field-id';
 import { orderComponents } from './order-components';
+import {
+  DataSourceField,
+  hasDataSource,
+  type ComponentWithDataSource,
+} from 'components/ui-generator/api-providers';
 
 export type RenderComponentProps = {
   item: Component | ComponentGroup;
@@ -51,6 +56,12 @@ export const renderComponent = ({
         </React.Fragment>
       );
     })
+  ) : hasDataSource(item as Component) ? (
+    <DataSourceField key={fieldName} item={item as ComponentWithDataSource}>
+      {(patchedItem: Component) => (
+        <UIComponent key={fieldName} item={patchedItem} name={fieldName} />
+      )}
+    </DataSourceField>
   ) : (
     <UIComponent key={fieldName} item={item as Component} name={fieldName} />
   );

--- a/ui/apps/everest/src/components/ui-generator/utils/preprocess/preprocess-schema.test.ts
+++ b/ui/apps/everest/src/components/ui-generator/utils/preprocess/preprocess-schema.test.ts
@@ -31,7 +31,7 @@ vi.mock('../../api-providers/registry', async () => {
     providerRegistry: {
       ...actual.providerRegistry,
       has: () => true,
-      getAvailableKeys: () => ['monitoringConfigs'],
+      getAvailableKeys: () => ['monitoringConfigs', 'storageClasses'],
     },
   };
 });

--- a/ui/apps/everest/src/components/ui-generator/utils/preprocess/preprocess-schema.test.ts
+++ b/ui/apps/everest/src/components/ui-generator/utils/preprocess/preprocess-schema.test.ts
@@ -12,13 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   Component,
+  DataSource,
   FieldType,
   TopologyUISchemas,
 } from '../../ui-generator.types';
 import { preprocessSchema } from './preprocess-schema';
+
+// Suppress console.error from dev-time validation when using test providers
+vi.mock('../../api-providers/registry', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../api-providers/registry')
+  >('../../api-providers/registry');
+  return {
+    ...actual,
+    providerRegistry: {
+      ...actual.providerRegistry,
+      has: () => true,
+      getAvailableKeys: () => ['monitoringConfigs'],
+    },
+  };
+});
 
 describe('preprocessSchema', () => {
   it('normalizes path metadata even without provider object', () => {
@@ -49,5 +65,35 @@ describe('preprocessSchema', () => {
         'spec.proxy.version',
       ]);
     }
+  });
+
+  it('preserves dataSource through preprocessing', () => {
+    const dataSource: DataSource = {
+      provider: 'monitoringConfigs',
+      config: { refetchInterval: 15000 },
+    };
+    const schema: TopologyUISchemas = {
+      single: {
+        sections: {
+          monitoring: {
+            components: {
+              monitoringEndpoint: {
+                uiType: FieldType.Select,
+                dataSource,
+                path: 'spec.components.monitoring.customSpec.monitoringConfigName',
+                fieldParams: { label: 'Monitoring endpoint' },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = preprocessSchema(schema);
+    const comp = result.single.sections.monitoring.components
+      .monitoringEndpoint as Component;
+
+    expect(comp.uiType).toBe(FieldType.Select);
+    expect(comp.dataSource).toEqual(dataSource);
   });
 });

--- a/ui/apps/everest/src/components/ui-generator/utils/preprocess/preprocess-schema.ts
+++ b/ui/apps/everest/src/components/ui-generator/utils/preprocess/preprocess-schema.ts
@@ -22,6 +22,7 @@ import {
 import { Provider } from 'shared-types/api.types';
 import { resolveSelectOptions } from '../../ui-component/utils/select-component-handler';
 import { withNormalizedPathMeta } from './normalized-component';
+import { providerRegistry } from '../../api-providers/registry';
 
 const preprocessComponent = (
   item: Component | ComponentGroup,
@@ -41,6 +42,20 @@ const preprocessComponent = (
   }
 
   const component = item as Component;
+
+  // Dev-time validation: warn if a dataSource references an unregistered provider.
+  // TODO: Extract into a dedicated dev-time validation pass
+  if (
+    component.dataSource?.provider &&
+    !providerRegistry.has(component.dataSource.provider)
+  ) {
+    const available = providerRegistry.getAvailableKeys().join(', ');
+    // eslint-disable-next-line no-console
+    console.error(
+      `[UISchema] Unknown API provider "${component.dataSource.provider}". ` +
+        `Available providers: ${available}`
+    );
+  }
   const normalizedComponent = withNormalizedPathMeta(component);
 
   if (

--- a/ui/apps/everest/src/hooks/api/kubernetesClusters/useStorageClassesOptions.ts
+++ b/ui/apps/everest/src/hooks/api/kubernetesClusters/useStorageClassesOptions.ts
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {
+  ProviderParams,
+  ProviderOptions,
+} from 'components/ui-generator/api-providers/types';
+import { useKubernetesClusterInfo } from './useKubernetesClusterInfo';
+
+// TODO: useKubernetesClusterInfo currently requires queryKey as a parameter
+// (legacy API from react-query v3 migration). Every caller invents its own key,
+// which prevents proper React Query cache sharing. When refactoring this hook
+// check section-edit-modal still work correctly with a shared canonical key.
+
+const STORAGE_CLASSES_QUERY_KEY = ['kubernetesClusterInfo'];
+
+export const useStorageClassesOptions = (): ProviderOptions => {
+  const { data, isLoading, error } = useKubernetesClusterInfo(
+    STORAGE_CLASSES_QUERY_KEY
+  );
+
+  const names = data?.storageClassNames ?? [];
+  const options = names.map((name) => ({ label: name, value: name }));
+
+  return {
+    options,
+    isLoading,
+    error,
+    isEmpty: !isLoading && options.length === 0,
+    rawData: data?.storageClassNames,
+  };
+};

--- a/ui/apps/everest/src/hooks/api/kubernetesClusters/useStorageClassesOptions.ts
+++ b/ui/apps/everest/src/hooks/api/kubernetesClusters/useStorageClassesOptions.ts
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type {
-  ProviderParams,
-  ProviderOptions,
-} from 'components/ui-generator/api-providers/types';
+import type { ProviderOptions } from 'components/ui-generator/api-providers/types';
 import { useKubernetesClusterInfo } from './useKubernetesClusterInfo';
 
 // TODO: useKubernetesClusterInfo currently requires queryKey as a parameter

--- a/ui/apps/everest/src/hooks/api/monitoring/useMonitoringConfigsList.ts
+++ b/ui/apps/everest/src/hooks/api/monitoring/useMonitoringConfigsList.ts
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useQuery } from '@tanstack/react-query';
+import { getMonitoringConfigsFn } from 'api/monitoringConfigs';
+
+export const MONITORING_CONFIGS_QUERY_KEY = 'monitoringConfigs';
+
+export const useMonitoringConfigsList = (
+  cluster: string,
+  namespace: string,
+  options?: { refetchInterval?: number; enabled?: boolean }
+) => {
+  return useQuery({
+    queryKey: [MONITORING_CONFIGS_QUERY_KEY, cluster, namespace],
+    queryFn: () => getMonitoringConfigsFn(cluster, namespace),
+    refetchInterval: options?.refetchInterval ?? 5_000,
+    enabled: options?.enabled ?? (!!namespace && !!cluster),
+  });
+};

--- a/ui/apps/everest/src/hooks/api/monitoring/useMonitoringConfigsOptions.ts
+++ b/ui/apps/everest/src/hooks/api/monitoring/useMonitoringConfigsOptions.ts
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {
+  ProviderParams,
+  ProviderOptions,
+} from 'components/ui-generator/api-providers/types';
+import { useMonitoringConfigsList } from './useMonitoringConfigsList';
+
+export const useMonitoringConfigsOptions = (
+  params: ProviderParams
+): ProviderOptions => {
+  const { data, isLoading, error } = useMonitoringConfigsList(
+    params.cluster,
+    params.namespace,
+    { refetchInterval: params.config?.refetchInterval }
+  );
+
+  const options = (data ?? [])
+    .filter((mc) => mc.metadata?.name)
+    .map((mc) => ({
+      label: mc.metadata!.name!,
+      value: mc.metadata!.name!,
+    }));
+
+  return {
+    options,
+    isLoading,
+    error,
+    isEmpty: !isLoading && options.length === 0,
+    rawData: data,
+  };
+};

--- a/ui/apps/everest/src/pages/database-form/database-form.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form.tsx
@@ -310,13 +310,13 @@ export const DatabasePage = () => {
         providerObject,
       }}
     >
-      <DataSourcePrefetcher
-        sections={engine.sections}
-        namespace={selectedNamespace || namespaces[0]}
-        cluster="main"
-      />
       <Stack direction={isDesktop ? 'row' : 'column'}>
         <FormProvider {...methods}>
+          <DataSourcePrefetcher
+            sections={engine.sections}
+            namespace={selectedNamespace || namespaces[0]}
+            cluster="main"
+          />
           <DatabaseFormBody
             steps={engine.steps}
             activeStep={nav.activeStepIndex}

--- a/ui/apps/everest/src/pages/database-form/database-form.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form.tsx
@@ -51,6 +51,7 @@ import {
   useErrorRouting,
   StepDefinition,
 } from 'components/ui-generator/form-engine';
+import { DataSourcePrefetcher } from 'components/ui-generator/api-providers';
 import { BaseInfoStep } from './database-form-body/steps/base-step/base-step';
 import { ImportStep } from './database-form-body/steps-old/import/import-step';
 import { mergeTopologyDefaults } from 'components/ui-generator/utils/default-values/merge-topology-defaults';
@@ -138,6 +139,11 @@ export const DatabasePage = () => {
     name: DbWizardFormFields.topology,
   });
 
+  const selectedNamespace = useWatch({
+    control,
+    name: DbWizardFormFields.k8sNamespace,
+  });
+
   // Static step definitions
   const staticSteps = useMemo((): StepDefinition[] => {
     const steps: StepDefinition[] = [
@@ -169,6 +175,9 @@ export const DatabasePage = () => {
     selectedTopology,
     staticSteps,
     providerObject,
+    namespace: selectedNamespace || namespaces[0],
+    // TODO: Replace hardcoded cluster name when multi-cluster support is implemented
+    cluster: 'main',
   });
 
   // Navigation
@@ -301,6 +310,11 @@ export const DatabasePage = () => {
         providerObject,
       }}
     >
+      <DataSourcePrefetcher
+        sections={engine.sections}
+        namespace={selectedNamespace || namespaces[0]}
+        cluster="main"
+      />
       <Stack direction={isDesktop ? 'row' : 'column'}>
         <FormProvider {...methods}>
           <DatabaseFormBody

--- a/ui/apps/everest/src/shared-types/api.types.ts
+++ b/ui/apps/everest/src/shared-types/api.types.ts
@@ -16,7 +16,8 @@ import { CrdsGen, HttpApi } from '@generated/api-types';
 
 export type GetProviders = CrdsGen.components['schemas']['ProviderList'];
 export type Provider = CrdsGen.components['schemas']['Provider'];
-export type MonitoringConfig = CrdsGen.components['schemas']['MonitoringConfig'];
+export type MonitoringConfig =
+  CrdsGen.components['schemas']['MonitoringConfig'];
 export type MonitoringConfigList =
   CrdsGen.components['schemas']['MonitoringConfigList'];
 export type GetInstances = CrdsGen.components['schemas']['InstanceList'];

--- a/ui/apps/everest/src/shared-types/api.types.ts
+++ b/ui/apps/everest/src/shared-types/api.types.ts
@@ -16,6 +16,9 @@ import { CrdsGen, HttpApi } from '@generated/api-types';
 
 export type GetProviders = CrdsGen.components['schemas']['ProviderList'];
 export type Provider = CrdsGen.components['schemas']['Provider'];
+export type MonitoringConfig = CrdsGen.components['schemas']['MonitoringConfig'];
+export type MonitoringConfigList =
+  CrdsGen.components['schemas']['MonitoringConfigList'];
 export type GetInstances = CrdsGen.components['schemas']['InstanceList'];
 export type Instance = CrdsGen.components['schemas']['Instance'];
 export type InstanceConnectionDetails =

--- a/ui/apps/everest/src/utils/ErrorBoundary.tsx
+++ b/ui/apps/everest/src/utils/ErrorBoundary.tsx
@@ -32,13 +32,17 @@ export class ErrorBoundary extends Component<
     this.state = initialState;
   }
 
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
   componentDidCatch(error: Error) {
     this.context.updateError(true);
     this.context.updateErrorObject(error);
   }
 
   render() {
-    if (this.context.hasError) {
+    if (this.state.hasError || this.context.hasError) {
       return this.props.fallback;
     }
 

--- a/ui/apps/everest/src/utils/ErrorBoundary.tsx
+++ b/ui/apps/everest/src/utils/ErrorBoundary.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Component } from 'react';
 import { ErrorContext } from './ErrorBoundaryProvider';
 


### PR DESCRIPTION
This pull request introduces a new "API-backed select fields" (dataSource) system to the UI Generator, enabling form select fields to fetch their options dynamically from APIs at runtime. 
([relevant PR on the provider's side](https://github.com/openeverest/provider-percona-server-mongodb/pull/27), [relevant issue](https://github.com/openeverest/openeverest/issues/1941))

```yaml
  dataSource:
    provider: storageClasses
```

It includes comprehensive documentation, architectural updates, implementation of the core `DataSourceField` component, utility functions, type definitions, and associated tests. The documentation and architecture files have been updated to describe how to use and extend this system, and new code style guidance on self-documenting code has been added.

A complete fragment of the schema using the example of the storage-class field:
```yaml
storageClass:
  uiType: select
  path: spec.componentsThis PR support 
```yaml
  dataSource:
    provider: storageClasses
```

**API-backed select fields (dataSource):**

* Added a new `DataSourceField` React component and supporting utilities/types, allowing select fields in the UI Generator to declare a `dataSource.provider` and fetch options from APIs at runtime. This includes logic for setting default values, handling loading/error/empty states, and patching field parameters for rendering.
* Implemented unit tests for `DataSourceField` to ensure correct value-setting behavior and non-overwriting of user-selected values.
* Updated the UI Generator architecture documentation to describe the new dataSource system, including registry, provider, and runtime layers, and how error isolation and default value flows are handled.

**Documentation:**

* Added a new `api-providers.md` documentation file detailing how to use API-backed select fields, schema reference, validation, provider extension, and field behavior. Linked this documentation from the main UI Generator README.

**Code style:**

* Introduced new code style rules emphasizing self-documenting code: prefer clear naming over comments, use comments to explain "why" not "what", and reserve block comments for APIs or design decisions.

**Supporting API:**

* Added a new API function `getMonitoringConfigsFn` to fetch monitoring configs, supporting the new dataSource provider system.

