### PR TITLE
Test SSO with keycloak

### DIFF
--- a/api-tests/Makefile
+++ b/api-tests/Makefile
@@ -66,6 +66,22 @@ deploy-minio:
 		exit 1; \
     fi
 
+KEYCLOAK_RESOURCE=$(TEST_ROOT)/manifests/keycloak.yaml
+.PHONY: deploy-keycloak
+deploy-keycloak: ## Deploy Keycloak to K3D test cluster for SSO tests.
+	$(info Deploying Keycloak to K3D cluster)
+	kubectl apply -f $(KEYCLOAK_RESOURCE)
+	if ! kubectl wait deploy/keycloak --for=condition=Available -n everest-system --timeout=120s; then \
+		echo "❌ Keycloak deployment did not become ready in time"; \
+		echo "🔎 Pods:"; \
+		kubectl get pods -n everest-system -l app=keycloak -o wide || true; \
+		echo "🔎 Events:"; \
+		kubectl get events -n everest-system --sort-by=.lastTimestamp || true; \
+		exit 1; \
+	fi
+	$(info Port-forwarding Keycloak to localhost:8180)
+	kubectl port-forward -n everest-system svc/keycloak 8180:8080 &
+
 .PHONY: k3d-upload-pg-images
 k3d-upload-pg-images: ## Pre-upload Postgresql images to K3D test  cluster to speedup tests execution.
 	$(info Uploading PG images to K3D test cluster)
@@ -151,4 +167,15 @@ test:               ## Run all tests.
 	  cmd_proj="$${cmd_proj} --project=$${project}" ;\
 	done ;\
 	npx playwright test --config=./playwright.config.ts $${cmd_proj} $${FLAGS};\
+	}
+
+.PHONY: test-sso
+test-sso:           ## Run SSO tests with Keycloak (requires deploy-keycloak first).
+	@{ \
+	set -xe ;\
+	export KEYCLOAK_ENABLED="true" ;\
+	export KEYCLOAK_URL="http://localhost:8180" ;\
+	export CI_USER="everest_ci" ;\
+	export CI_PASSWORD="password" ;\
+	npx playwright test --config=./playwright.config.ts --project=sso $${FLAGS};\
 	}

--- a/api-tests/Makefile
+++ b/api-tests/Makefile
@@ -178,4 +178,5 @@ test-sso:           ## Run SSO tests with Keycloak (requires deploy-keycloak fir
 	export CI_USER="everest_ci" ;\
 	export CI_PASSWORD="password" ;\
 	npx playwright test --config=./playwright.config.ts --project=sso $${FLAGS};\
+	$(EVERESTCTL) settings oidc configure --issuer-url="" --client-id="" ;\
 	}

--- a/api-tests/constants.ts
+++ b/api-tests/constants.ts
@@ -15,8 +15,11 @@ export const EVEREST_CI_NAMESPACE = 'everest',
   ),
   API_CI_TOKEN = 'API_CI_TOKEN',
   API_TEST_TOKEN = 'API_TEST_TOKEN',
+  API_SSO_TOKEN = 'API_SSO_TOKEN',
   MONITORING_CONFIG_1 = 'pmm-conf-1',
   MONITORING_CONFIG_2 = 'pmm-conf-2';
+
+export const KEYCLOAK_URL = process.env.KEYCLOAK_URL || 'http://localhost:8180';
 
 const second = 1_000,
   minute = 60 * second;

--- a/api-tests/manifests/keycloak.yaml
+++ b/api-tests/manifests/keycloak.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: keycloak
+  name: keycloak
+  namespace: everest-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:26.6.1
+          args:
+            - start-dev
+          env:
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
+              value: admin
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+              value: admin
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+            - name: KC_HTTP_ENABLED # Explicitly enable HTTP
+              value: "true"
+            - name: KC_HTTP_PORT
+              value: "8080"
+            - name: KC_HOSTNAME
+              value: "http://keycloak.everest-system.svc.cluster.local:8080"
+            - name: KC_HOSTNAME_STRICT # Disable strict hostname for internal K8s probes
+              value: "false"
+            - name: KC_HOSTNAME_STRICT_HTTPS # Disable strict HTTPS for dev
+              value: "false"
+            - name: KC_HTTP_MANAGEMENT_PORT
+              value: "8080"
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: 1Gi
+              cpu: "1"
+            requests:
+              memory: 512Mi
+              cpu: 250m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: everest-system
+spec:
+  type: ClusterIP
+  selector:
+    app: keycloak
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/api-tests/playwright.config.ts
+++ b/api-tests/playwright.config.ts
@@ -2,7 +2,7 @@ import {defineConfig} from '@playwright/test';
 import path from 'path';
 import {dirname} from 'path';
 import {fileURLToPath} from 'url';
-import {API_CI_TOKEN, API_TEST_TOKEN} from '@root/constants';
+import {API_CI_TOKEN, API_TEST_TOKEN, API_SSO_TOKEN} from '@root/constants';
 import {TIMEOUTS} from "./constants";
 
 // Convert 'import.meta.url' to the equivalent __dirname
@@ -114,6 +114,22 @@ export default defineConfig({
         },
       },
     },
+    // global:keycloak (optional — only when KEYCLOAK_ENABLED=true)
+    ...(process.env.KEYCLOAK_ENABLED === 'true'
+      ? [
+          {
+            name: 'global:keycloak:setup',
+            testDir: 'tests/setup/keycloak',
+            testMatch: /keycloak\.setup\.ts/,
+            teardown: 'global:keycloak:teardown',
+          },
+          {
+            name: 'global:keycloak:teardown',
+            testDir: 'tests/teardown/keycloak',
+            testMatch: /keycloak\.teardown\.ts/,
+          },
+        ]
+      : []),
     // ---------------------- TESTS ----------------------
     // api-tests project
     {
@@ -232,6 +248,22 @@ export default defineConfig({
         }
       },
     },
+    // -------------------- SSO tests (optional) --------------------
+    ...(process.env.KEYCLOAK_ENABLED === 'true'
+      ? [
+          {
+            name: 'sso',
+            testDir: 'tests/sso',
+            testMatch: /keycloak\.spec\.ts/,
+            dependencies: ['global:keycloak:setup'],
+            use: {
+              extraHTTPHeaders: {
+                'Authorization': `Bearer ${process.env[API_SSO_TOKEN]}`,
+              },
+            },
+          },
+        ]
+      : []),
     // ------------------------ PG tests ----------------------------
     // pg:backup-storage:setup
     {

--- a/api-tests/tests/setup/keycloak/keycloak.setup.ts
+++ b/api-tests/tests/setup/keycloak/keycloak.setup.ts
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {test as setup, expect} from '@playwright/test';
+import {
+  waitForKeycloak,
+  configureKeycloak,
+  keycloakLogin,
+  grantSSOUserAdmin,
+  KEYCLOAK_IN_CLUSTER_URL,
+} from '@tests/utils/keycloak';
+import {
+  KEYCLOAK_URL,
+  API_SSO_TOKEN,
+} from '@root/constants';
+import {CliHelper} from '@helpers/cliHelper';
+
+// OIDC config YAML written directly to everest-settings ConfigMap.
+// Using the in-cluster Keycloak service URL so the Everest backend pod can reach it.
+const buildOIDCConfigYAML = (clientId: string) =>
+  `issuerUrl: ${KEYCLOAK_IN_CLUSTER_URL}/realms/everest\nclientId: ${clientId}\nscopes:\n    - openid\n    - profile\n    - email`;
+
+setup.describe.serial('Keycloak SSO setup', () => {
+  const cli = new CliHelper();
+
+  setup('Wait for Keycloak readiness', async ({request}) => {
+    await waitForKeycloak(request, KEYCLOAK_URL);
+  });
+
+  setup('Configure Keycloak realm, client, and user', async ({request}) => {
+    const everestURL = process.env.EVEREST_URL || 'http://localhost:8080';
+    const config = await configureKeycloak(request, KEYCLOAK_URL, everestURL);
+
+    // Store config in env for subsequent steps
+    process.env.KEYCLOAK_CLIENT_ID = config.clientId;
+    process.env.KEYCLOAK_SSO_USER = config.username;
+    process.env.KEYCLOAK_SSO_PASSWORD = config.password;
+  });
+
+  setup('Configure Everest OIDC settings via ConfigMap', async () => {
+    const clientId = process.env.KEYCLOAK_CLIENT_ID;
+    expect(clientId, 'KEYCLOAK_CLIENT_ID must be set').toBeTruthy();
+
+    // Patch the ConfigMap directly — no network validation, works without port-forward.
+    const oidcYAML = buildOIDCConfigYAML(clientId!);
+    const patch = JSON.stringify({data: {'oidc.config': oidcYAML}});
+    const patchResult = await cli.execute(
+      `kubectl patch configmap everest-settings -n everest-system --type merge -p '${patch}'`,
+    );
+    expect(patchResult.code, `ConfigMap patch failed: ${patchResult.stderr}`).toEqual(0);
+
+    // Restart Everest so it picks up the new OIDC config.
+    const restartResult = await cli.execute(
+      'kubectl rollout restart deployment/everest-server -n everest-system',
+    );
+    expect(restartResult.code, `Restart failed: ${restartResult.stderr}`).toEqual(0);
+
+    // Wait for Everest to be ready again.
+    const waitResult = await cli.execute(
+      'kubectl rollout status deployment/everest-server -n everest-system --timeout=120s',
+    );
+    expect(waitResult.code, `Everest did not become ready: ${waitResult.stderr}`).toEqual(0);
+  });
+
+  setup('Login via Keycloak and obtain SSO token', async ({request}) => {
+    const tokens = await keycloakLogin(request, KEYCLOAK_URL);
+
+    // Store the access token for SSO test project
+    process.env[API_SSO_TOKEN] = tokens.access_token;
+  });
+
+  setup('Grant SSO user admin RBAC role', async () => {
+    // The Keycloak user's subject in the JWT is the username
+    await grantSSOUserAdmin('sso-test-user');
+  });
+});

--- a/api-tests/tests/sso/keycloak.spec.ts
+++ b/api-tests/tests/sso/keycloak.spec.ts
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {expect, test} from '@playwright/test';
+import {keycloakLogin} from '@tests/utils/keycloak';
+import {KEYCLOAK_URL, API_SSO_TOKEN} from '@root/constants';
+
+test.describe('SSO with Keycloak', () => {
+  test('OIDC settings are configured', async ({request}) => {
+    const resp = await request.get('/v1/settings');
+    expect(resp.ok()).toBeTruthy();
+
+    const settings = await resp.json();
+    expect(settings.oidcConfig).toBeDefined();
+    expect(settings.oidcConfig.issuerURL).toContain('/realms/everest');
+    expect(settings.oidcConfig.clientId).toBeTruthy();
+  });
+
+  test('SSO access token is accepted as Bearer token', async ({request}) => {
+    // Get a fresh token from Keycloak
+    const tokens = await keycloakLogin(request, KEYCLOAK_URL);
+
+    const resp = await request.get('/v1/version', {
+      headers: {
+        Authorization: `Bearer ${tokens.access_token}`,
+      },
+    });
+    expect(resp.status(), `Expected 200 but got ${resp.status()}`).toEqual(200);
+  });
+
+  test('SSO token can access authenticated endpoints', async ({request}) => {
+    const tokens = await keycloakLogin(request, KEYCLOAK_URL);
+
+    // Access database-engines endpoint (requires auth)
+    const resp = await request.get('/v1/namespaces', {
+      headers: {
+        Authorization: `Bearer ${tokens.access_token}`,
+      },
+    });
+    expect(resp.ok(), `Namespaces request failed: ${resp.status()}`).toBeTruthy();
+  });
+
+  test('logout invalidates SSO session', async ({request}) => {
+    const tokens = await keycloakLogin(request, KEYCLOAK_URL);
+    const authHeader = {Authorization: `Bearer ${tokens.access_token}`};
+
+    // Verify the token works
+    const beforeLogout = await request.get('/v1/version', {headers: authHeader});
+    expect(beforeLogout.status()).toEqual(200);
+
+    // Logout (add token to blocklist)
+    const logoutResp = await request.delete('/v1/session', {headers: authHeader});
+    expect(logoutResp.status()).toEqual(204);
+
+    // Token should now be rejected
+    const afterLogout = await request.get('/v1/version', {headers: authHeader});
+    expect(afterLogout.status()).toEqual(401);
+  });
+
+  test('invalid SSO token is rejected', async ({request}) => {
+    const resp = await request.get('/v1/version', {
+      headers: {
+        Authorization: 'Bearer invalid-sso-token-12345',
+      },
+    });
+    expect(resp.status()).toEqual(401);
+  });
+
+  test('expired or tampered JWT is rejected', async ({request}) => {
+    // Use the token already obtained during setup — no need for a fresh Keycloak login.
+    const token = process.env['API_SSO_TOKEN'];
+    expect(token, 'API_SSO_TOKEN must be set by setup').toBeTruthy();
+
+    const parts = token!.split('.');
+    expect(parts.length, 'Expected a JWT with 3 parts').toEqual(3);
+
+    const tampered = parts[0] + '.' + parts[1] + 'tampered.' + parts[2];
+    const resp = await request.get('/v1/version', {
+      headers: {Authorization: `Bearer ${tampered}`},
+    });
+    expect(resp.status()).toEqual(401);
+  });
+});

--- a/api-tests/tests/sso/keycloak.spec.ts
+++ b/api-tests/tests/sso/keycloak.spec.ts
@@ -40,14 +40,10 @@ test.describe('SSO with Keycloak', () => {
   });
 
   test('SSO token can access authenticated endpoints', async ({request}) => {
-    const tokens = await keycloakLogin(request, KEYCLOAK_URL);
-
-    // Access database-engines endpoint (requires auth)
-    const resp = await request.get('/v1/namespaces', {
-      headers: {
-        Authorization: `Bearer ${tokens.access_token}`,
-      },
-    });
+    // Use the project-level Authorization header (set from API_SSO_TOKEN in
+    // playwright.config.ts).  No need for a fresh keycloakLogin — this test
+    // verifies a protected endpoint works, not that keycloakLogin works.
+    const resp = await request.get('/v1/namespaces');
     expect(resp.ok(), `Namespaces request failed: ${resp.status()}`).toBeTruthy();
   });
 

--- a/api-tests/tests/teardown/keycloak/keycloak.teardown.ts
+++ b/api-tests/tests/teardown/keycloak/keycloak.teardown.ts
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {test as teardown} from '@playwright/test';
+import {CliHelper} from '@helpers/cliHelper';
+
+teardown.describe.serial('Keycloak SSO teardown', () => {
+  const cli = new CliHelper();
+
+  teardown('Reset Everest OIDC settings', async () => {
+    // Reset OIDC configuration by setting empty values
+    await cli.execute(
+      'everestctl settings oidc configure --issuer-url="" --client-id=""',
+    );
+  });
+
+  teardown('Delete Keycloak deployment', async () => {
+    await cli.execute(
+      'kubectl delete -f manifests/keycloak.yaml --ignore-not-found',
+    );
+  });
+});

--- a/api-tests/tests/teardown/keycloak/keycloak.teardown.ts
+++ b/api-tests/tests/teardown/keycloak/keycloak.teardown.ts
@@ -18,13 +18,6 @@ import {CliHelper} from '@helpers/cliHelper';
 teardown.describe.serial('Keycloak SSO teardown', () => {
   const cli = new CliHelper();
 
-  teardown('Reset Everest OIDC settings', async () => {
-    // Reset OIDC configuration by setting empty values
-    await cli.execute(
-      'everestctl settings oidc configure --issuer-url="" --client-id=""',
-    );
-  });
-
   teardown('Delete Keycloak deployment', async () => {
     await cli.execute(
       'kubectl delete -f manifests/keycloak.yaml --ignore-not-found',

--- a/api-tests/tests/utils/keycloak.ts
+++ b/api-tests/tests/utils/keycloak.ts
@@ -1,0 +1,303 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {APIRequestContext, expect} from '@playwright/test';
+
+const KEYCLOAK_ADMIN_USER = 'admin';
+const KEYCLOAK_ADMIN_PASSWORD = 'admin';
+const KEYCLOAK_REALM = 'everest';
+const KEYCLOAK_CLIENT_ID = 'everest-app';
+const KEYCLOAK_TEST_USER = 'sso-test-user';
+const KEYCLOAK_TEST_PASSWORD = 'sso-test-password';
+const KEYCLOAK_SCOPES = ['openid', 'profile', 'email'];
+
+// In-cluster Keycloak service URL — used as the OIDC issuer configured in Everest,
+// so the Everest backend pod can reach Keycloak for JWKS validation.
+export const KEYCLOAK_IN_CLUSTER_URL =
+  'http://keycloak.everest-system.svc.cluster.local:8080';
+
+export interface KeycloakConfig {
+  issuerURL: string;
+  clientId: string;
+  username: string;
+  password: string;
+  userId: string;
+  baseURL: string;
+  realm: string;
+}
+
+/**
+ * Get an admin access token from Keycloak master realm.
+ */
+const getAdminToken = async (
+  request: APIRequestContext,
+  keycloakBaseURL: string,
+): Promise<string> => {
+  const resp = await request.post(
+    `${keycloakBaseURL}/realms/master/protocol/openid-connect/token`,
+    {
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      form: {
+        grant_type: 'password',
+        client_id: 'admin-cli',
+        username: KEYCLOAK_ADMIN_USER,
+        password: KEYCLOAK_ADMIN_PASSWORD,
+      },
+    },
+  );
+  expect(resp.ok(), `Failed to get Keycloak admin token: ${resp.status()}`).toBeTruthy();
+  const body = await resp.json();
+  return body.access_token as string;
+};
+
+/**
+ * Create the 'everest' realm in Keycloak.
+ */
+const createRealm = async (
+  request: APIRequestContext,
+  keycloakBaseURL: string,
+  adminToken: string,
+): Promise<void> => {
+  const resp = await request.post(
+    `${keycloakBaseURL}/admin/realms`,
+    {
+      headers: {Authorization: `Bearer ${adminToken}`},
+      data: {
+        realm: KEYCLOAK_REALM,
+        enabled: true,
+      },
+    },
+  );
+  // 409 = realm already exists, which is fine
+  expect(
+    resp.ok() || resp.status() === 409,
+    `Failed to create Keycloak realm: ${resp.status()}`,
+  ).toBeTruthy();
+
+  // Disable the VERIFY_PROFILE required action at realm level.
+  // Keycloak 26 enables this by default, which blocks ROPC (password grant) logins
+  // with "Account is not fully set up".
+  const vpResp = await request.put(
+    `${keycloakBaseURL}/admin/realms/${KEYCLOAK_REALM}/authentication/required-actions/VERIFY_PROFILE`,
+    {
+      headers: {Authorization: `Bearer ${adminToken}`},
+      data: {
+        alias: 'VERIFY_PROFILE',
+        name: 'Verify Profile',
+        providerId: 'VERIFY_PROFILE',
+        enabled: false,
+        defaultAction: false,
+        priority: 90,
+      },
+    },
+  );
+  expect(
+    vpResp.ok(),
+    `Failed to disable VERIFY_PROFILE: ${vpResp.status()}`,
+  ).toBeTruthy();
+};
+
+/**
+ * Create a public OIDC client in the realm.
+ */
+const createClient = async (
+  request: APIRequestContext,
+  keycloakBaseURL: string,
+  adminToken: string,
+  everestURL: string,
+): Promise<void> => {
+  const resp = await request.post(
+    `${keycloakBaseURL}/admin/realms/${KEYCLOAK_REALM}/clients`,
+    {
+      headers: {Authorization: `Bearer ${adminToken}`},
+      data: {
+        clientId: KEYCLOAK_CLIENT_ID,
+        enabled: true,
+        publicClient: true,
+        directAccessGrantsEnabled: true,
+        standardFlowEnabled: true,
+        redirectUris: [`${everestURL}/*`],
+        webOrigins: [everestURL],
+        protocol: 'openid-connect',
+      },
+    },
+  );
+  expect(
+    resp.ok() || resp.status() === 409,
+    `Failed to create Keycloak client: ${resp.status()}`,
+  ).toBeTruthy();
+};
+
+/**
+ * Create a test user in the realm and return their ID.
+ */
+const createUser = async (
+  request: APIRequestContext,
+  keycloakBaseURL: string,
+  adminToken: string,
+): Promise<string> => {
+  const createResp = await request.post(
+    `${keycloakBaseURL}/admin/realms/${KEYCLOAK_REALM}/users`,
+    {
+      headers: {Authorization: `Bearer ${adminToken}`},
+      data: {
+        username: KEYCLOAK_TEST_USER,
+        enabled: true,
+        emailVerified: true,
+        email: `${KEYCLOAK_TEST_USER}@example.com`,
+        requiredActions: [],
+      },
+    },
+  );
+  expect(
+    createResp.ok() || createResp.status() === 409,
+    `Failed to create Keycloak user: ${createResp.status()}`,
+  ).toBeTruthy();
+
+  // Fetch the user to get their ID
+  const searchResp = await request.get(
+    `${keycloakBaseURL}/admin/realms/${KEYCLOAK_REALM}/users?username=${KEYCLOAK_TEST_USER}&exact=true`,
+    {headers: {Authorization: `Bearer ${adminToken}`}},
+  );
+  expect(searchResp.ok(), `Failed to search Keycloak user: ${searchResp.status()}`).toBeTruthy();
+  const users = await searchResp.json();
+  expect(users.length, 'Expected to find the created user').toBeGreaterThan(0);
+  const userId = users[0].id as string;
+
+  // Set password via dedicated endpoint (more reliable than credentials in create payload)
+  const pwResp = await request.put(
+    `${keycloakBaseURL}/admin/realms/${KEYCLOAK_REALM}/users/${userId}/reset-password`,
+    {
+      headers: {Authorization: `Bearer ${adminToken}`},
+      data: {
+        type: 'password',
+        value: KEYCLOAK_TEST_PASSWORD,
+        temporary: false,
+      },
+    },
+  );
+  expect(pwResp.ok(), `Failed to set Keycloak user password: ${pwResp.status()}`).toBeTruthy();
+
+  // Explicitly clear required actions (Keycloak 26 adds VERIFY_PROFILE by default)
+  const updateResp = await request.put(
+    `${keycloakBaseURL}/admin/realms/${KEYCLOAK_REALM}/users/${userId}`,
+    {
+      headers: {Authorization: `Bearer ${adminToken}`},
+      data: {requiredActions: []},
+    },
+  );
+  expect(
+    updateResp.ok(),
+    `Failed to clear required actions: ${updateResp.status()}`,
+  ).toBeTruthy();
+
+  return userId;
+};
+
+/**
+ * Wait for Keycloak to be ready by polling the master realm OIDC discovery endpoint.
+ */
+export const waitForKeycloak = async (
+  request: APIRequestContext,
+  keycloakBaseURL: string,
+  timeoutMs = 120_000,
+): Promise<void> => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const resp = await request.get(
+        `${keycloakBaseURL}/realms/master/.well-known/openid-configuration`,
+      );
+      if (resp.ok()) return;
+    } catch {
+      // Keycloak not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error(`Keycloak did not become ready within ${timeoutMs}ms`);
+};
+
+/**
+ * Configure Keycloak with a realm, client, and test user.
+ * Returns the configuration needed for Everest OIDC setup and SSO tests.
+ */
+export const configureKeycloak = async (
+  request: APIRequestContext,
+  keycloakBaseURL: string,
+  everestURL: string,
+): Promise<KeycloakConfig> => {
+  const adminToken = await getAdminToken(request, keycloakBaseURL);
+  await createRealm(request, keycloakBaseURL, adminToken);
+  await createClient(request, keycloakBaseURL, adminToken, everestURL);
+  const userId = await createUser(request, keycloakBaseURL, adminToken);
+
+  return {
+    issuerURL: `${keycloakBaseURL}/realms/${KEYCLOAK_REALM}`,
+    clientId: KEYCLOAK_CLIENT_ID,
+    username: KEYCLOAK_TEST_USER,
+    password: KEYCLOAK_TEST_PASSWORD,
+    userId,
+    baseURL: keycloakBaseURL,
+    realm: KEYCLOAK_REALM,
+  };
+};
+
+/**
+ * Perform OIDC Resource Owner Password Credentials (direct access grant) login
+ * against Keycloak and return the access token.
+ *
+ * This uses Keycloak's "direct access grants" (ROPC) which is enabled on the client
+ * to allow programmatic login without browser interaction.
+ */
+export const keycloakLogin = async (
+  request: APIRequestContext,
+  keycloakBaseURL: string,
+  username?: string,
+  password?: string,
+): Promise<{access_token: string; id_token: string; refresh_token: string}> => {
+  const resp = await request.post(
+    `${keycloakBaseURL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`,
+    {
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      form: {
+        grant_type: 'password',
+        client_id: KEYCLOAK_CLIENT_ID,
+        username: username ?? KEYCLOAK_TEST_USER,
+        password: password ?? KEYCLOAK_TEST_PASSWORD,
+        scope: KEYCLOAK_SCOPES.join(' '),
+      },
+    },
+  );
+  const body = await resp.text();
+  expect(resp.ok(), `Keycloak login failed: HTTP ${resp.status()} — ${body}`).toBeTruthy();
+  return JSON.parse(body);
+};
+
+/**
+ * Add the SSO test user to the Everest admin RBAC role.
+ * This patches the everest-rbac ConfigMap to grant the SSO user admin permissions,
+ * similar to how the CI user is granted admin in the standard test setup.
+ */
+export const grantSSOUserAdmin = async (
+  ssoSubject: string,
+): Promise<void> => {
+  const {execSync} = await import('child_process');
+  // Patch the configmap to add the SSO user to the admin role
+  const patchCmd = `kubectl get configmap everest-rbac -n everest-system -o json | jq '.data["policy.csv"] += "\\ng, ${ssoSubject}, role:admin"' | jq '{data: { "policy.csv": .data["policy.csv"] } }' | xargs -0 kubectl patch configmap everest-rbac -n everest-system --type merge -p`;
+  // Simpler approach: just append to the policy
+  execSync(
+    `kubectl patch configmap everest-rbac -n everest-system --type merge -p "$(kubectl get configmap everest-rbac -n everest-system -o json | jq '{data: { "policy.csv": (.data["policy.csv"] + "\\ng, ${ssoSubject}, role:admin") } }')"`,
+    {stdio: 'pipe'},
+  );
+};


### PR DESCRIPTION
This PR adds the test for SSO with keycloak.
This test is optional and it only runs when `KEYCLOAK_ENABLED=true` is set. In `playwright.config.ts` the keycloak setup/teardown and sso projects are inside a conditional spread.

How to use:
```
make deploy-keycloak
make test-sso
```

Test results:
```
Running 13 tests using 5 workers

  ✓   1 …ycloak:setup] › tests/setup/keycloak/keycloak.setup.ts:38:3 › Keycloak SSO setup › Wait for Keycloak readiness (482ms)
  ✓   2 …› tests/setup/keycloak/keycloak.setup.ts:42:3 › Keycloak SSO setup › Configure Keycloak realm, client, and user (3.0s)
  ✓   3 …sts/setup/keycloak/keycloak.setup.ts:52:3 › Keycloak SSO setup › Configure Everest OIDC settings via ConfigMap (12.4s)
  ✓   4 …] › tests/setup/keycloak/keycloak.setup.ts:77:3 › Keycloak SSO setup › Login via Keycloak and obtain SSO token (665ms)
  ✓   5 …oak:setup] › tests/setup/keycloak/keycloak.setup.ts:84:3 › Keycloak SSO setup › Grant SSO user admin RBAC role (201ms)
  ✓   6 [sso] › tests/sso/keycloak.spec.ts:21:3 › SSO with Keycloak › OIDC settings are configured (364ms)
  ✓   7 [sso] › tests/sso/keycloak.spec.ts:43:3 › SSO with Keycloak › SSO token can access authenticated endpoints (753ms)
  ✓   8 [sso] › tests/sso/keycloak.spec.ts:55:3 › SSO with Keycloak › logout invalidates SSO session (959ms)
  ✓   9 [sso] › tests/sso/keycloak.spec.ts:72:3 › SSO with Keycloak › invalid SSO token is rejected (329ms)
  ✓  10 [sso] › tests/sso/keycloak.spec.ts:31:3 › SSO with Keycloak › SSO access token is accepted as Bearer token (710ms)
  ✓  11 [sso] › tests/sso/keycloak.spec.ts:81:3 › SSO with Keycloak › expired or tampered JWT is rejected (77ms)
  ✓  12 …own] › tests/teardown/keycloak/keycloak.teardown.ts:22:3 › Keycloak SSO teardown › Reset Everest OIDC settings (10.1s)
  ✓  13 …down] › tests/teardown/keycloak/keycloak.teardown.ts:29:3 › Keycloak SSO teardown › Delete Keycloak deployment (227ms)
::notice title=🎭 Playwright Run Summary::  13 passed (30.4s)
```


Signed-off-by: Sergey Pronin <sp@solanica.io>