### PR TITLE
docs(dev): Port 5000 conflict for k3d registry on macOS

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -30,6 +30,8 @@ make dev-up
 ```
 This creates a k3d cluster and starts Tilt. The Everest UI will be available at http://localhost:8080.
 
+> **NOTE**: The default k3d registry uses port `5000`, which may already be occupied on some systems (e.g., macOS Control Center). Update the `hostPort` in `k3d_config.dev.yaml`.
+
 #### Option B: Local (CI-style testing)
 ```sh
 make k3d-cluster-up


### PR DESCRIPTION
Add a note that the default k3d registry port (5000) may already be in use (e.g., by macOS Control Center), and suggest updating hostPort in k3d_config.dev.yaml if needed.

### How to reproduce
run `make dev-up` on macOS.

### Logs
```bash
ERRO[0019] Failed Cluster Start: Failed to add one or more helper nodes: runtime failed to start node 'k3d-registry': docker failed to start container for node 'k3d-registry': Error response from daemon: Ports are not available: exposing port TCP 0.0.0.0:5000 -> 127.0.0.1:0: listen tcp 0.0.0.0:5000: bind: address already in use 
ERRO[0019] Failed to create cluster >>> Rolling Back    
INFO[0019] Deleting cluster 'everest-dev'               
INFO[0020] Deleting cluster network 'k3d-everest-dev'   
INFO[0020] Deleting 1 attached volumes...               
FATA[0020] Cluster creation FAILED, all changes have been rolled back! 
make: *** [k3d-cluster-up-dev] Error 1

```