### PR TITLE
fix: correct singular field name in Storage CRD

### DIFF
--- a/data/testchart/crds/crd.yaml
+++ b/data/testchart/crds/crd.yaml
@@ -50,7 +50,7 @@ spec:
     kind: Storage
     listKind: StorageList
     plural: storages
-    singular: storages
+    singular: storage
   scope: Namespaced
   versions:
     - name: v1


### PR DESCRIPTION
Fixes #2055

What changed
The Storage CRD in `data/testchart/crds/crd.yaml` had the `singular` 
field incorrectly set to `storages` (the plural form) instead of 
`storage`.

Fix
Changed `singular: storages` to `singular: storage` to follow 
Kubernetes naming conventions where singular should be the non-plural 
form of the resource name.