### PR TITLE
Fix homebrew tap dispatch

### DIFF
--- a/.github/workflows/homebrew-tap-dispatch.yml
+++ b/.github/workflows/homebrew-tap-dispatch.yml
@@ -1,0 +1,42 @@
+name: Trigger Homebrew tap update
+
+# Fires when a draft release is published. RCs/pre-releases are filtered out
+# so only GA releases reach the Homebrew tap.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.release.prerelease == false &&
+      github.event.release.draft == false
+    steps:
+      - name: Validate release tag is GA semver
+        id: version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # Strip leading "v"; require strict X.Y.Z (no -rc, -beta, etc.)
+          VERSION="${TAG#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Skipping non-GA release: $TAG"
+            exit 0
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch to homebrew-tap
+        if: steps.version.outputs.version != ''
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TOKEN: ${{ secrets.TAP_REPO_TOKEN }}
+        run: |
+          curl -fsSL -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            https://api.github.com/repos/openeverest/homebrew-tap/dispatches \
+            -d "{\"event_type\":\"new-release\",\"client_payload\":{\"version\":\"${VERSION}\"}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,6 +420,7 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           draft: true
+          prerelease: ${{ env.IS_RC == '1' }}
           files: |
             dist/*
 
@@ -445,14 +446,6 @@ jobs:
           platforms: ${{ matrix.platform }}
           tags: ${{ steps.everestctl_meta.outputs.tags }}
 
-      - name: Trigger Homebrew tap update
-        if: env.IS_RC == 0
-        run: |
-          curl -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.TAP_REPO_TOKEN }}" \
-            https://api.github.com/repos/openeverest/homebrew-tap/dispatches \
-            -d "{\"event_type\":\"new-release\",\"client_payload\":{\"version\":\"$VERSION\"}}"
   create-manifests:
     name: Create multi-arch manifests
     needs: build


### PR DESCRIPTION
Previously, we were triggering homebrew as soon as the release was created but since it's created in draft mode the artificats aren't public and as a consequence the formula update workflow fails to calculate the SHA256 hashes. By triggering the formula only when the release is actually published we ensure that the homebrew tap is updated correctly.