### PR TITLE
Update `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,10 +152,10 @@ make test
 
 # API integration tests (requires local Kubernetes cluster)
 make k3d-cluster-up
-make test-api
+make -C api-tests test
 
 # CLI integration tests (requires local Kubernetes cluster)
-make test-cli
+make -C cli-tests test-cli
 ```
 
 ### CI Requirements

--- a/Makefile
+++ b/Makefile
@@ -197,14 +197,6 @@ test:                   ## Run unit tests.
 	mkdir -p ./public/dist && [ -f ./public/dist/index.html ] || touch ./public/dist/index.html
 	CGO_ENABLED=1 go test -race -timeout=20m ./...
 
-.PHONY: test-api
-test-api:               ## Run API integration tests.
-	$(MAKE) -C api-tests test
-
-.PHONY: test-cli
-test-cli:               ## Run CLI integration tests.
-	$(MAKE) -C cli-tests test-cli
-
 .PHONY: test-cover
 test-cover:             ## Run unit tests and collect per-package coverage information.
 # We need to ensure that /public/dist/index.html exists before running tests

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,14 @@ test:                   ## Run unit tests.
 	mkdir -p ./public/dist && [ -f ./public/dist/index.html ] || touch ./public/dist/index.html
 	CGO_ENABLED=1 go test -race -timeout=20m ./...
 
+.PHONY: test-api
+test-api:               ## Run API integration tests.
+	$(MAKE) -C api-tests test
+
+.PHONY: test-cli
+test-cli:               ## Run CLI integration tests.
+	$(MAKE) -C cli-tests test-cli
+
 .PHONY: test-cover
 test-cover:             ## Run unit tests and collect per-package coverage information.
 # We need to ensure that /public/dist/index.html exists before running tests


### PR DESCRIPTION
fixes #2073 
This PR updates `CONTRIBUTING.md` integration test commands to run from the correct subdirectories:
`make -C api-tests test` and `make -C cli-tests test-cli`