### PR TITLE
fix(api-tests): pre-upload PMM images to k3d to fix installation timeout

### DIFF
--- a/api-tests/Makefile
+++ b/api-tests/Makefile
@@ -25,8 +25,20 @@ ci-init: $(CI_INIT_DEPS) 	## Prepare environment for running tests.
 
 PMM_HELM_CHART_VER=1.4.13
 HELM=go tool -modfile=$(TEST_ROOT)/../go.mod helm
+.PHONY: k3d-upload-pmm-images
+k3d-upload-pmm-images: ## Pre-upload PMM server images to K3D test cluster to speedup PMM installation.
+	$(info Uploading PMM images to K3D test cluster)
+	$(HELM) repo add percona https://percona.github.io/percona-helm-charts/ 2>/dev/null || true
+	@{ \
+	for node in $$(k3d node list | grep everest-server-test | grep -v registry | awk '{print $$1}'); do \
+		for image in $$($(HELM) template pmm percona/pmm --version $(PMM_HELM_CHART_VER) | grep -E '^\s+image:' | awk '{print $$2}' | tr -d '"' | sort -u); do \
+			docker exec $$node ctr image pull $${image} ;\
+		done ;\
+	done ;\
+	}
+
 .PHONY: deploy-monitoring
-deploy-monitoring:   ## Deploy monitoring instances to K3D test cluster.
+deploy-monitoring: k3d-upload-pmm-images  ## Deploy monitoring instances to K3D test cluster.
 	$(info Deploying PMM instances to K3D test cluster)
 	$(HELM) repo add percona https://percona.github.io/percona-helm-charts/
 	# PMM 3 starts really slowly, so we increase timeout to 15 minutes
@@ -115,7 +127,7 @@ k3d-upload-pxc-images: ## Pre-upload PXC images to K3D test cluster to speedup t
 	}
 
 .PHONY: k3d-upload-images
-k3d-upload-images: k3d-upload-pg-images k3d-upload-psmdb-images k3d-upload-pxc-images 	## Pre-upload PG,PSMDB,PXC images to K3D test cluster to speedup tests execution.
+k3d-upload-images: k3d-upload-pg-images k3d-upload-psmdb-images k3d-upload-pxc-images k3d-upload-pmm-images 	## Pre-upload PG,PSMDB,PXC,PMM images to K3D test cluster to speedup tests execution.
 
 ##@ Development
 

--- a/api-tests/Makefile
+++ b/api-tests/Makefile
@@ -32,7 +32,7 @@ k3d-upload-pmm-images: ## Pre-upload PMM server images to K3D test cluster to sp
 	@{ \
 	for node in $$(k3d node list | grep everest-server-test | grep -v registry | awk '{print $$1}'); do \
 		for image in $$($(HELM) template pmm percona/pmm --version $(PMM_HELM_CHART_VER) | grep -E '^\s+image:' | awk '{print $$2}' | tr -d '"' | sort -u); do \
-			docker exec $$node ctr image pull $${image} ;\
+			docker exec $$node ctr image pull docker.io/$${image} ;\
 		done ;\
 	done ;\
 	}


### PR DESCRIPTION
## What's the problem?

While looking into issue #2070, I noticed that the CI was timing out when
trying to install PMM during the API test setup. The error showed that PMM
was given 15 minutes to install but still didn't finish in time:

`Error: INSTALLATION FAILED: context deadline exceeded`

After digging into the Makefile, I found out why. When `deploy-monitoring`
runs, it does a `helm install pmm` which has to pull all the PMM Docker
images from the internet on the spot. That's slow, especially on CI.

What was interesting is that other images like PostgreSQL, PSMDB, and PXC
already had a solution for this — they get pre-loaded into the k3d cluster
nodes before their installs run, using the `k3d-upload-*` targets. PMM
didn't have anything like that.

## What I did

I added a new `k3d-upload-pmm-images` target in `api-tests/Makefile` that
pre-pulls all the PMM images into the k3d nodes before the helm install
starts. I used `helm template` to figure out which images the chart needs,
so it automatically stays correct if the chart version ever changes.

I also made `deploy-monitoring` depend on `k3d-upload-pmm-images` so the
images are always loaded first, and added it to `k3d-upload-images` to keep
things consistent with the other upload targets.

## Changes

- `api-tests/Makefile` — new `k3d-upload-pmm-images` target, wired into
  `deploy-monitoring` and `k3d-upload-images`

Fixes #2070
