### PR TITLE
chore: wire disable telemetry into everest helm values for install and upgrades.

### DIFF
--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -50,7 +50,9 @@ func init() {
 	upgradeCmd.Flags().BoolVar(&upgradeCfg.DryRun, cli.FlagUpgradeDryRun, false, "If set, only executes the pre-upgrade checks")
 	upgradeCmd.Flags().BoolVar(&upgradeCfg.InCluster, cli.FlagUpgradeInCluster, false, "If set, uses the in-cluster Kubernetes client configuration")
 	upgradeCmd.Flags().StringVar(&upgradeCfg.VersionToUpgrade, cli.FlagUpgradeVersionToUpgrade, "", "(Optional) Version to upgrade to. This version may be ahead by at most one minor version from the current version")
+	upgradeCmd.Flags().BoolVar(&upgradeCfg.DisableTelemetry, cli.FlagDisableTelemetry, false, "Disable telemetry")
 	_ = upgradeCmd.Flags().MarkHidden(cli.FlagUpgradeInCluster)
+	_ = upgradeCmd.Flags().MarkHidden(cli.FlagDisableTelemetry)
 
 	// --helm.* flags
 	upgradeCmd.Flags().StringVar(&upgradeCfg.ChartDir, helm.FlagChartDir, "", "Path to the chart directory. If not set, the chart will be downloaded from the repository")

--- a/pkg/cli/helm/values.go
+++ b/pkg/cli/helm/values.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package helm
 
 import "github.com/percona/everest/pkg/kubernetes"

--- a/pkg/cli/helm/values.go
+++ b/pkg/cli/helm/values.go
@@ -6,6 +6,7 @@ import "github.com/percona/everest/pkg/kubernetes"
 type Values struct {
 	ClusterType        kubernetes.ClusterType
 	VersionMetadataURL string
+	DisableTelemetry   bool
 }
 
 // NewValues creates a map of values that can be used to render the Helm chart.
@@ -28,6 +29,9 @@ func NewValues(v Values) map[string]string {
 	}
 	if v.VersionMetadataURL != "" {
 		values["versionMetadataURL"] = v.VersionMetadataURL
+	}
+	if v.DisableTelemetry {
+		values["telemetry"] = "false"
 	}
 	return values
 }

--- a/pkg/cli/install/install.go
+++ b/pkg/cli/install/install.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cli/install/install.go
+++ b/pkg/cli/install/install.go
@@ -305,6 +305,7 @@ func (o *Installer) setupHelmInstaller(ctx context.Context) error {
 	overrides := helm.NewValues(helm.Values{
 		ClusterType:        o.cfg.ClusterType,
 		VersionMetadataURL: o.cfg.VersionMetadataURL,
+		DisableTelemetry:   o.cfg.DisableTelemetry,
 	})
 	values := Must(helmutils.MergeVals(o.cfg.HelmConfig.Values, overrides))
 	installer := &helm.Installer{

--- a/pkg/cli/upgrade/steps.go
+++ b/pkg/cli/upgrade/steps.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package upgrade
 
 import (

--- a/pkg/cli/upgrade/steps.go
+++ b/pkg/cli/upgrade/steps.go
@@ -214,7 +214,7 @@ func (u *Upgrade) helmAdoptDBNamespaces(ctx context.Context, namespace, version 
 		ClusterType:        u.clusterType,
 		VersionMetadataURL: u.config.VersionMetadataURL,
 	})
-	values := Must(helmutils.MergeVals(helmValuesForDBEngines(dbEngines), overrides))
+	values := Must(helmutils.MergeVals(helmValuesForDBEngines(dbEngines, u.config.DisableTelemetry), overrides))
 	installer := helm.Installer{
 		ReleaseName:      namespace,
 		ReleaseNamespace: namespace,
@@ -242,14 +242,14 @@ func (u *Upgrade) helmAdoptDBNamespaces(ctx context.Context, namespace, version 
 	})
 }
 
-func helmValuesForDBEngines(list *everestv1alpha1.DatabaseEngineList) values.Options {
+func helmValuesForDBEngines(list *everestv1alpha1.DatabaseEngineList, disableTelemetry bool) values.Options {
 	var vals []string
 	for _, dbEngine := range list.Items {
 		t := dbEngine.Spec.Type
 		vals = append(vals, fmt.Sprintf("%s=%t", t, dbEngine.Status.State == everestv1alpha1.DBEngineStateInstalled))
 	}
 	vals = append(vals, "cleanupOnUninstall=false") // uninstall command will do the clean-up on its own.
-	// TODO: figure out how to set telemetry.
+	vals = append(vals, fmt.Sprintf("telemetry=%t", !disableTelemetry))
 	return values.Options{Values: vals}
 }
 

--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -62,6 +62,8 @@ type (
 		Pretty bool
 		// SkipEnvDetection skips detecting the Kubernetes environment.
 		SkipEnvDetection bool
+		// DisableTelemetry disables telemetry.
+		DisableTelemetry bool
 
 		// VersionToUpgrade specifies the version to upgrade to.
 		// This version may be ahead by at most one minor version from the current version.
@@ -208,6 +210,7 @@ func (u *Upgrade) setupHelmInstaller(ctx context.Context) error {
 	overrides := helm.NewValues(helm.Values{
 		ClusterType:        u.clusterType,
 		VersionMetadataURL: u.config.VersionMetadataURL,
+		DisableTelemetry:   u.config.DisableTelemetry,
 	})
 
 	values := Must(helmutils.MergeVals(u.config.Values, overrides))


### PR DESCRIPTION
## Summary

  This PR fixes telemetry flag propagation for the main Everest Helm release so --disable-telemetry behaves as users expect during
  install and upgrade workflows.

  Before this change, --disable-telemetry only affected the everest-db-namespace chart (operator subscriptions), but did not set
  telemetry=false on the main everest chart, so everest-server still ran telemetry.


  ## Changes Included

  ### 1) Main Helm values wiring

  - File: `pkg/cli/helm/values.go`
  - Added DisableTelemetry bool to helm.Values.
  - NewValues(...) now sets:
      - telemetry=false when DisableTelemetry is true.

  ### 2) Install flow propagation

  - File: `pkg/cli/install/install.go`
  - In setupHelmInstaller, pass:
      - DisableTelemetry: o.cfg.DisableTelemetry
        to helm.NewValues(...).

  ### 3) Upgrade flow propagation

  - File: `pkg/cli/upgrade/upgrade.go`
  - Added DisableTelemetry bool to upgrade.Config.
  - In setupHelmInstaller, pass:
      - DisableTelemetry: u.config.DisableTelemetry.
  - File: commands/upgrade.go
  - Added hidden --disable-telemetry flag wiring for upgrade:
      - binds to upgradeCfg.DisableTelemetry
      - hidden, consistent with install behavior.

  ### 4) Upgrade DB namespace adoption telemetry TODO

  - File: `pkg/cli/upgrade/steps.go`
  - Updated helmValuesForDBEngines(...) signature to accept disableTelemetry.
  - Appends:
      - telemetry=<true|false> (inverted from disable flag) for DB namespace chart values.
  - Removes previous TODO gap and aligns behavior with install path.

  ## Behavior After Change

  When --disable-telemetry is used:

  - Main chart gets telemetry=false.
  - everest-server deployment receives DISABLE_TELEMETRY=true.
  - Server does not start telemetry job (Telemetry is running should not appear in fresh logs).

  ## Validation Performed

  ### Unit/package tests

  go test ./pkg/cli/helm ./pkg/cli/install ./pkg/cli/upgrade ./commands

  All passed (commands has no test files).

  ### Manual validation plan

  1. Fresh install:

  everestctl install --disable-telemetry --skip-wizard

  2. Check Helm values:

  helm -n everest-system get values everest-system -a | grep '^telemetry:'

  Expected: telemetry: false
  3. Check server env:

 ```
 kubectl -n everest-system get deploy everest-server -o jsonpath='{.spec.template.spec.containers[0].env}' | jq '.[] |
  select(.name=="DISABLE_TELEMETRY")'
```

  Expected: DISABLE_TELEMETRY=true
  4. Check recent logs:

`kubectl -n everest-system logs deploy/everest-server --since=10m | grep -i telemetry`

  Expected: no new Telemetry is running.

  ## Checklist

  - [x] Root cause confirmed in CLI values propagation
  - [x] Main chart telemetry wiring added
  - [x] Install path updated
  - [x] Upgrade path updated
  - [x] Upgrade DB adoption telemetry TODO addressed
  - [x] Package tests passing
  
  ## Screenshots
  
  
<img width="1624" height="1061" alt="Screenshot 2026-04-29 at 10 58 53 PM" src="https://github.com/user-attachments/assets/65f12393-b4d7-42f8-8b1c-e42ddf2d9479" />

## Related Issues

### Closes: #2081 


