### PR TITLE
test: add unit tests for pkg/cli/namespaces/utils.go

### DIFF
--- a/pkg/cli/namespaces/utils_test.go
+++ b/pkg/cli/namespaces/utils_test.go
@@ -1,0 +1,261 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespaces
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/percona/everest/pkg/common"
+)
+
+func TestIsManagedByEverest(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		name     string
+		input    *v1.Namespace
+		expected bool
+	}
+
+	tcases := []tcase{
+		{
+			name: "managed by everest",
+			input: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ns",
+					Labels: map[string]string{
+						common.KubernetesManagedByLabel: common.Everest,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "managed by other",
+			input: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ns",
+					Labels: map[string]string{
+						common.KubernetesManagedByLabel: "helm",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "label not present",
+			input: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-ns",
+					Labels: make(map[string]string),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "nil labels",
+			input: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ns",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "empty label value",
+			input: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ns",
+					Labels: map[string]string{
+						common.KubernetesManagedByLabel: "",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "extra labels present",
+			input: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ns",
+					Labels: map[string]string{
+						common.KubernetesManagedByLabel: common.Everest,
+						"other-label":                   "other-value",
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := isManagedByEverest(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEnsureNoOperatorsRemoved(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		name          string
+		subscriptions []olmv1alpha1.Subscription
+		installPG     bool
+		installPXC    bool
+		installPSMDB  bool
+		expected      bool
+	}
+
+	tcases := []tcase{
+		{
+			name:          "no subscriptions, all flags false - allowed",
+			subscriptions: []olmv1alpha1.Subscription{},
+			installPG:     false,
+			installPXC:    false,
+			installPSMDB:  false,
+			expected:      true,
+		},
+		{
+			name:          "no subscriptions, all flags true - allowed",
+			subscriptions: []olmv1alpha1.Subscription{},
+			installPG:     true,
+			installPXC:    true,
+			installPSMDB:  true,
+			expected:      true,
+		},
+		{
+			name: "pg installed, pg flag true - allowed",
+			subscriptions: []olmv1alpha1.Subscription{
+				{ObjectMeta: metav1.ObjectMeta{Name: common.PostgreSQLOperatorName}},
+			},
+			installPG: true,
+			expected:  true,
+		},
+		{
+			name: "pg installed, pg flag false - blocked",
+			subscriptions: []olmv1alpha1.Subscription{
+				{ObjectMeta: metav1.ObjectMeta{Name: common.PostgreSQLOperatorName}},
+			},
+			installPG: false,
+			expected:  false,
+		},
+		{
+			name: "pxc installed, pxc flag true - allowed",
+			subscriptions: []olmv1alpha1.Subscription{
+				{ObjectMeta: metav1.ObjectMeta{Name: common.MySQLOperatorName}},
+			},
+			installPXC: true,
+			expected:   true,
+		},
+		{
+			name: "pxc installed, pxc flag false - blocked",
+			subscriptions: []olmv1alpha1.Subscription{
+				{ObjectMeta: metav1.ObjectMeta{Name: common.MySQLOperatorName}},
+			},
+			installPXC: false,
+			expected:   false,
+		},
+		{
+			name: "psmdb installed, psmdb flag true - allowed",
+			subscriptions: []olmv1alpha1.Subscription{
+				{ObjectMeta: metav1.ObjectMeta{Name: common.MongoDBOperatorName}},
+			},
+			installPSMDB: true,
+			expected:     true,
+		},
+		{
+			name: "psmdb installed, psmdb flag false - blocked",
+			subscriptions: []olmv1alpha1.Subscription{
+				{ObjectMeta: metav1.ObjectMeta{Name: common.MongoDBOperatorName}},
+			},
+			installPSMDB: false,
+			expected:     false,
+		},
+		{
+			name: "all operators installed, all flags true - allowed",
+			subscriptions: []olmv1alpha1.Subscription{
+				{ObjectMeta: metav1.ObjectMeta{Name: common.PostgreSQLOperatorName}},
+				{ObjectMeta: metav1.ObjectMeta{Name: common.MySQLOperatorName}},
+				{ObjectMeta: metav1.ObjectMeta{Name: common.MongoDBOperatorName}},
+			},
+			installPG:    true,
+			installPXC:   true,
+			installPSMDB: true,
+			expected:     true,
+		},
+		{
+			name: "all operators installed, one flag false - blocked",
+			subscriptions: []olmv1alpha1.Subscription{
+				{ObjectMeta: metav1.ObjectMeta{Name: common.PostgreSQLOperatorName}},
+				{ObjectMeta: metav1.ObjectMeta{Name: common.MySQLOperatorName}},
+				{ObjectMeta: metav1.ObjectMeta{Name: common.MongoDBOperatorName}},
+			},
+			installPG:    true,
+			installPXC:   false,
+			installPSMDB: true,
+			expected:     false,
+		},
+		{
+			name: "unknown operator subscription is ignored",
+			subscriptions: []olmv1alpha1.Subscription{
+				{ObjectMeta: metav1.ObjectMeta{Name: "unknown-operator"}},
+			},
+			installPG:    false,
+			installPXC:   false,
+			installPSMDB: false,
+			expected:     true,
+		},
+		{
+			name: "mixed known and unknown subscriptions",
+			subscriptions: []olmv1alpha1.Subscription{
+				{ObjectMeta: metav1.ObjectMeta{Name: "custom-operator"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: common.PostgreSQLOperatorName}},
+			},
+			installPG: true,
+			expected:  true,
+		},
+		{
+			name: "mixed known and unknown, known removed - blocked",
+			subscriptions: []olmv1alpha1.Subscription{
+				{ObjectMeta: metav1.ObjectMeta{Name: "custom-operator"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: common.PostgreSQLOperatorName}},
+			},
+			installPG: false,
+			expected:  false,
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := ensureNoOperatorsRemoved(
+				tc.subscriptions,
+				tc.installPG,
+				tc.installPXC,
+				tc.installPSMDB,
+			)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
### Problem

The file pkg/cli/namespaces/utils.go has partial unit test coverage:

- ParseNamespaceNames and validateNamespaceNames are already well-tested in add_test.go
- However, the following functions remain untested:
   - isManagedByEverest
   - ensureNoOperatorsRemoved

These functions contain important logic used in namespace lifecycle and operator management.
Lack of tests here can lead to silent regressions in behavior, especially around operator validation and namespace ownership checks.

### Solution

Added a new test file: pkg/cli/namespaces/utils_test.go
Includes 19 sub-tests across 2 test functions for isManagedByEverest and ensureNoOperatorsRemoved

### Testing 

script :  go test ./pkg/cli/namespaces/ -run "TestIsManagedByEverest|TestEnsureNoOperatorsRemoved" -v -count=1

<img width="508" height="116" alt="image" src="https://github.com/user-attachments/assets/41eebfec-b14b-4b8c-869a-0f2795f5b262" />
<img width="726" height="258" alt="image" src="https://github.com/user-attachments/assets/f54c8d5a-0b75-48be-bdba-5abe3709925b" />
