### PR TITLE
feat(ui): expose spec.proxy.config in Advanced Configuration UIFeat/proxy config UI

### DIFF
--- a/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration-schema.ts
+++ b/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration-schema.ts
@@ -47,6 +47,8 @@ export const advancedConfigurationsSchema = () =>
         z.nativeEnum(ProxyExposeType),
       [AdvancedConfigurationFields.splitHorizonDNSEnabled]: z.boolean(),
       [AdvancedConfigurationFields.splitHorizonDNS]: z.string().optional(),
+      [AdvancedConfigurationFields.proxyConfigEnabled]: z.boolean(),
+      [AdvancedConfigurationFields.proxyConfig]: z.string().optional(),
     })
     .passthrough()
     .superRefine(({ sourceRanges, exposureMethod }, ctx) => {

--- a/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.tsx
+++ b/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.tsx
@@ -29,7 +29,11 @@ import {
 import { ProxyExposeType } from 'shared-types/dbCluster.types';
 import { useFormContext } from 'react-hook-form';
 import { DbEngineType, DbType } from '@percona/types';
-import { getParamsPlaceholderFromDbType } from './advanced-configuration.utils';
+import {
+  getParamsPlaceholderFromDbType,
+  getProxyConfigLabelFromDbType,
+  getProxyConfigPlaceholderFromDbType,
+} from './advanced-configuration.utils';
 import {
   Box,
   FormGroup,
@@ -64,6 +68,7 @@ import ToggableFormCard from 'components/toggable-form-card';
 interface AdvancedConfigurationFormProps {
   dbType: DbType;
   showSplitHorizonDNS: boolean;
+  showProxyConfig?: boolean;
   loadingDefaultsForEdition?: boolean;
   automaticallyTogglePodSchedulingPolicySwitch?: boolean;
   allowedFieldsToInitiallyLoadDefaults?: AllowedFieldsToInitiallyLoadDefaults[];
@@ -81,6 +86,7 @@ export const AdvancedConfigurationForm = ({
   activePolicy,
   namespace,
   showSplitHorizonDNS,
+  showProxyConfig = true,
 }: AdvancedConfigurationFormProps) => {
   const { watch, setValue, getFieldState, getValues, trigger } =
     useFormContext();
@@ -96,11 +102,13 @@ export const AdvancedConfigurationForm = ({
   >(null);
   const [
     engineParametersEnabled,
+    proxyConfigEnabled,
     policiesEnabled,
     exposureMethod,
     splitHorizonDNSEnabled,
   ] = watch([
     AdvancedConfigurationFields.engineParametersEnabled,
+    AdvancedConfigurationFields.proxyConfigEnabled,
     AdvancedConfigurationFields.podSchedulingPolicyEnabled,
     AdvancedConfigurationFields.exposureMethod,
     AdvancedConfigurationFields.splitHorizonDNSEnabled,
@@ -591,6 +599,32 @@ export const AdvancedConfigurationForm = ({
           />
         }
       />
+      {showProxyConfig && (
+        <FormCard
+          title={getProxyConfigLabelFromDbType(dbType)}
+          description={Messages.cards.proxyParameters.description}
+          cardContent={
+            <Stack>
+              {proxyConfigEnabled && (
+                <TextInput
+                  name={AdvancedConfigurationFields.proxyConfig}
+                  textFieldProps={{
+                    placeholder: getProxyConfigPlaceholderFromDbType(dbType),
+                    multiline: true,
+                    minRows: 3,
+                  }}
+                />
+              )}
+            </Stack>
+          }
+          controlComponent={
+            <SwitchInput
+              label={Messages.enable}
+              name={AdvancedConfigurationFields.proxyConfigEnabled}
+            />
+          }
+        />
+      )}
       {policyDialogOpen && (
         <PoliciesDialog
           engineType={selectedPolicy.current!.spec.engineType}

--- a/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.types.ts
+++ b/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.types.ts
@@ -26,6 +26,8 @@ export enum AdvancedConfigurationFields {
   loadBalancerConfigName = 'loadBalancerConfigName',
   splitHorizonDNS = 'splitHorizonDNS',
   splitHorizonDNSEnabled = 'splitHorizonDNSEnabled',
+  proxyConfigEnabled = 'proxyConfigEnabled',
+  proxyConfig = 'proxyConfig',
 }
 
 export const PROXY_EXPOSE_TYPE_TO_LABEL: Record<ProxyExposeType, string> = {

--- a/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.utils.ts
+++ b/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.utils.ts
@@ -18,6 +18,8 @@ import { DbCluster, ProxyExposeType } from 'shared-types/dbCluster.types';
 import { AdvancedConfigurationFields } from './advanced-configuration.types';
 import { AdvancedConfigurationFormType } from './advanced-configuration-schema';
 import { EMPTY_LOAD_BALANCER_CONFIGURATION } from 'consts';
+import { capitalize } from '@mui/material';
+import { getProxyUnitNamesFromDbType } from 'utils/db';
 
 export const getParamsPlaceholderFromDbType = (dbType: DbType) => {
   let dynamicText = '';
@@ -38,6 +40,29 @@ export const getParamsPlaceholderFromDbType = (dbType: DbType) => {
   }
 
   return dynamicText;
+};
+
+export const getProxyConfigPlaceholderFromDbType = (dbType: DbType) => {
+  let dynamicText = '';
+
+  switch (dbType) {
+    case DbType.Mongo:
+      dynamicText = 'net:\n  port: 27017';
+      break;
+    case DbType.Mysql:
+      dynamicText = '[proxysql]\nmax_connections=2000';
+      break;
+    case DbType.Postresql:
+    default:
+      dynamicText = '[pgbouncer]\npool_mode = session\nmax_client_conn = 100';
+      break;
+  }
+
+  return dynamicText;
+};
+
+export const getProxyConfigLabelFromDbType = (dbType: DbType) => {
+  return `${capitalize(getProxyUnitNamesFromDbType(dbType).singular)} Configuration`;
 };
 
 export const mapDeprecatedExposeType = (
@@ -90,5 +115,8 @@ export const advancedConfigurationModalDefaultValues = (
       !!dbCluster?.spec.engineFeatures?.psmdb?.splitHorizonDnsConfigName,
     [AdvancedConfigurationFields.splitHorizonDNS]:
       dbCluster?.spec.engineFeatures?.psmdb?.splitHorizonDnsConfigName || '',
+    [AdvancedConfigurationFields.proxyConfigEnabled]:
+      !!dbCluster?.spec?.proxy?.config,
+    [AdvancedConfigurationFields.proxyConfig]: dbCluster?.spec?.proxy?.config,
   };
 };

--- a/ui/apps/everest/src/components/cluster-form/advanced-configuration/messages.ts
+++ b/ui/apps/everest/src/components/cluster-form/advanced-configuration/messages.ts
@@ -57,6 +57,10 @@ export const Messages = {
       description:
         'Set your database engine configuration to adjust your database system to your workload and performance needs. For configuration format and specific parameters, check your database type documentation.',
     },
+    proxyParameters: {
+      description:
+        'Set your proxy configuration to adjust the proxy to your workload and performance needs. For configuration format and specific parameters, check your proxy type documentation.',
+    },
     splitHorizonDNS: {
       title: 'Split-Horizon DNS',
       description:

--- a/ui/apps/everest/src/hooks/api/db-cluster/useCreateDbCluster.ts
+++ b/ui/apps/everest/src/hooks/api/db-cluster/useCreateDbCluster.ts
@@ -134,7 +134,9 @@ const formValuesToPayloadMapping = (
         dbPayload.exposureMethod === ProxyExposeType.LoadBalancer ||
           dbPayload.loadBalancerConfigName === EMPTY_LOAD_BALANCER_CONFIGURATION
           ? dbPayload.loadBalancerConfigName
-          : undefined
+          : undefined,
+        dbPayload.proxyConfigEnabled,
+        dbPayload.proxyConfig
       ),
       ...(dbPayload.dbType === DbType.Mongo && {
         sharding: {

--- a/ui/apps/everest/src/hooks/api/db-cluster/utils.ts
+++ b/ui/apps/everest/src/hooks/api/db-cluster/utils.ts
@@ -36,10 +36,13 @@ export const getProxySpec = (
   memory: number,
   sharding: boolean,
   sourceRanges?: Array<{ sourceRange?: string }>,
-  loadBalancerConfigName?: string
+  loadBalancerConfigName?: string,
+  proxyConfigEnabled?: boolean,
+  proxyConfig?: string
 ): Proxy => {
   if (dbType === DbType.Mongo && !sharding) {
     return {
+      config: proxyConfigEnabled ? proxyConfig : undefined,
       expose: getExposteConfig(
         exposureMethod,
         loadBalancerConfigName !== EMPTY_LOAD_BALANCER_CONFIGURATION
@@ -63,6 +66,7 @@ export const getProxySpec = (
       cpu: `${cpu}`,
       memory: `${memory}G`,
     },
+    config: proxyConfigEnabled ? proxyConfig : undefined,
     expose: getExposteConfig(
       exposureMethod,
       loadBalancerConfigName !== EMPTY_LOAD_BALANCER_CONFIGURATION

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/advanced-configurations/advanced-configurations.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/advanced-configurations/advanced-configurations.tsx
@@ -20,6 +20,7 @@ import { DbWizardFormFields } from 'consts.ts';
 import { StepHeader } from '../step-header/step-header.tsx';
 import AdvancedConfigurationForm from 'components/cluster-form/advanced-configuration/advanced-configuration.tsx';
 import { StepProps } from 'pages/database-form/database-form.types.ts';
+import { DbType } from '@percona/types';
 import { useDatabasePageMode } from 'pages/database-form/useDatabasePageMode.ts';
 import { WizardMode } from 'shared-types/wizard.types.ts';
 import { useMemo } from 'react';
@@ -31,6 +32,7 @@ export const AdvancedConfigurations = ({
   const { watch, getValues } = useFormContext();
   const dbType = watch(DbWizardFormFields.dbType);
   const namespace = getValues(DbWizardFormFields.k8sNamespace);
+  const sharding = getValues(DbWizardFormFields.sharding);
   const mode = useDatabasePageMode();
   const allowedFieldsToInitiallyLoadDefaults: AllowedFieldsToInitiallyLoadDefaults[] =
     useMemo(() => {
@@ -57,7 +59,8 @@ export const AdvancedConfigurations = ({
           allowedFieldsToInitiallyLoadDefaults
         }
         namespace={namespace}
-        showSplitHorizonDNS={!getValues(DbWizardFormFields.sharding)}
+        showSplitHorizonDNS={!sharding}
+        showProxyConfig={dbType !== DbType.Mongo || sharding}
       />
     </>
   );

--- a/ui/apps/everest/src/pages/database-form/database-preview/sections/advanced-configurations-section.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-preview/sections/advanced-configurations-section.tsx
@@ -8,6 +8,8 @@ export const AdvancedConfigurationsPreviewSection = ({
   loadBalancerConfigName,
   engineParametersEnabled,
   engineParameters,
+  proxyConfigEnabled,
+  proxyConfig,
   storageClass,
   podSchedulingPolicyEnabled,
   podSchedulingPolicy,
@@ -30,6 +32,9 @@ export const AdvancedConfigurationsPreviewSection = ({
       )}
       {engineParametersEnabled && engineParameters && (
         <PreviewContentText text="Database engine parameters set" />
+      )}
+      {proxyConfigEnabled && proxyConfig && (
+        <PreviewContentText text="Proxy configuration parameters set" />
       )}
       {podSchedulingPolicyEnabled && podSchedulingPolicy && (
         <PreviewContentText

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/card.types.ts
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/card.types.ts
@@ -45,6 +45,7 @@ export type ConnectionDetailsOverviewCardProps = {
 export type AdvancedConfigurationOverviewCardProps = {
   externalAccess: boolean;
   parameters: boolean;
+  proxyConfig?: boolean;
   storageClass: string;
   podSchedulingPolicy?: string;
   loadBalancerConfig?: string;

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/advanced-configuration/advanced-configuration.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/advanced-configuration/advanced-configuration.tsx
@@ -26,6 +26,8 @@ import {
   changeDbClusterAdvancedConfig,
   shouldDbActionsBeBlocked,
 } from 'utils/db';
+import { getProxyConfigLabelFromDbType } from 'components/cluster-form/advanced-configuration/advanced-configuration.utils';
+import { dbEngineToDbType } from '@percona/utils';
 import { Link } from 'react-router-dom';
 import { useRBACPermissions } from 'hooks/rbac';
 import { EMPTY_LOAD_BALANCER_CONFIGURATION } from 'consts';
@@ -38,6 +40,7 @@ export const AdvancedConfiguration = ({
   loading,
   externalAccess,
   parameters,
+  proxyConfig,
   storageClass,
   podSchedulingPolicy,
   loadBalancerConfig,
@@ -79,6 +82,8 @@ export const AdvancedConfiguration = ({
     sourceRanges,
     engineParametersEnabled,
     engineParameters,
+    proxyConfigEnabled,
+    proxyConfig,
     podSchedulingPolicyEnabled,
     podSchedulingPolicy,
     exposureMethod,
@@ -96,7 +101,9 @@ export const AdvancedConfiguration = ({
         podSchedulingPolicyEnabled,
         podSchedulingPolicy,
         loadBalancerConfigName,
-        splitHorizonDNS
+        splitHorizonDNS,
+        proxyConfigEnabled,
+        proxyConfig
       )
     );
   };
@@ -131,6 +138,16 @@ export const AdvancedConfiguration = ({
           parameters ? Messages.fields.enabled : Messages.fields.disabled
         }
       />
+      {dbCluster?.spec.engine.type && (
+        <OverviewSectionRow
+          label={getProxyConfigLabelFromDbType(
+            dbEngineToDbType(dbCluster?.spec?.engine?.type)
+          )}
+          content={
+            proxyConfig ? Messages.fields.enabled : Messages.fields.disabled
+          }
+        />
+      )}
       <OverviewSectionRow
         label={Messages.fields.storageClass}
         content={storageClass}

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/advanced-configuration/edit-advanced-configuration/edit-advanced-configuration.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/advanced-configuration/edit-advanced-configuration/edit-advanced-configuration.tsx
@@ -40,6 +40,8 @@ export const AdvancedConfigurationEditModal = ({
     exposureMethod,
     engineParametersEnabled,
     engineParameters,
+    proxyConfigEnabled,
+    proxyConfig,
     sourceRanges,
     storageClass,
     podSchedulingPolicyEnabled,
@@ -51,6 +53,8 @@ export const AdvancedConfigurationEditModal = ({
     handleSubmitModal({
       engineParametersEnabled,
       engineParameters,
+      proxyConfigEnabled,
+      proxyConfig,
       sourceRanges,
       storageClass,
       podSchedulingPolicyEnabled,
@@ -101,6 +105,10 @@ export const AdvancedConfigurationEditModal = ({
         activePolicy={dbCluster?.spec.podSchedulingPolicyName}
         namespace={dbCluster?.metadata.namespace}
         showSplitHorizonDNS={false}
+        showProxyConfig={
+          dbEngineToDbType(dbCluster?.spec?.engine?.type) !== DbType.Mongo ||
+          dbCluster?.spec.sharding?.enabled
+        }
       />
     </FormDialog>
   );

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/db-details.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/db-details.tsx
@@ -41,6 +41,7 @@ export const DbDetails = ({
   monitoring,
   externalAccess,
   parameters,
+  proxyConfig,
   storageClass,
   podSchedulingPolicy,
   loadBalancerConfig,
@@ -100,6 +101,7 @@ export const DbDetails = ({
         <AdvancedConfiguration
           externalAccess={externalAccess}
           parameters={parameters}
+          proxyConfig={proxyConfig}
           storageClass={storageClass}
           podSchedulingPolicy={podSchedulingPolicy}
           loadBalancerConfig={loadBalancerConfig}

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cluster-overview.messages.ts
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cluster-overview.messages.ts
@@ -55,5 +55,6 @@ export const Messages = {
     exposureMethod: 'Exposure Method',
     loadBalancerConfig: 'Load balancer config',
     splitHorizonDNS: 'Split-Horizon DNS',
+    proxyConfig: 'Proxy parameters',
   },
 };

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cluster-overview.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cluster-overview.tsx
@@ -103,6 +103,7 @@ export const ClusterOverview = () => {
           exposeType={dbCluster.spec.proxy?.expose?.type}
           monitoring={dbCluster?.spec.monitoring?.monitoringConfigName}
           parameters={!!dbCluster?.spec.engine.config}
+          proxyConfig={!!dbCluster?.spec?.proxy?.config}
           storageClass={dbCluster?.spec.engine.storage.class!}
           podSchedulingPolicy={dbCluster?.spec.podSchedulingPolicyName}
           splitHorizonDNS={

--- a/ui/apps/everest/src/shared-types/dbCluster.types.ts
+++ b/ui/apps/everest/src/shared-types/dbCluster.types.ts
@@ -90,6 +90,7 @@ export interface Proxy {
   expose: ProxyExposeConfig;
   resources?: Resources;
   type: ProxyType;
+  config?: string;
 }
 
 export interface DataImporter {

--- a/ui/apps/everest/src/utils/db.tsx
+++ b/ui/apps/everest/src/utils/db.tsx
@@ -749,7 +749,9 @@ export const changeDbClusterAdvancedConfig = (
   podSchedulingPolicyEnabled = false,
   podSchedulingPolicy = '',
   loadBalancerConfigName = '',
-  splitHorizonDnsConfigName = ''
+  splitHorizonDnsConfigName = '',
+  proxyConfigEnabled = false,
+  proxyConfig = ''
 ) => ({
   ...dbCluster,
   spec: {
@@ -772,6 +774,7 @@ export const changeDbClusterAdvancedConfig = (
     },
     proxy: {
       ...dbCluster.spec.proxy,
+      config: proxyConfigEnabled ? proxyConfig : undefined,
       expose: {
         loadBalancerConfigName:
           (exposureMethod === ProxyExposeType.LoadBalancer &&


### PR DESCRIPTION
## Summary
This PR exposes `spec.proxy.config` in the Advanced Configuration UI, enabling users to configure proxy-related settings directly from the UI. Fixes #2093

## Changes
- Added support for `proxyConfigEnabled` and `proxyConfig` in schema and interfaces
- Integrated new `<FormCard>` under Engine Configuration
- Added dynamic labels (PG Bouncer / Router / Proxy)
- Implemented conditional rendering using `showProxyConfig`
- Persisted state via:
  - `changeDbClusterAdvancedConfig`
  - `getProxySpec`
- Updated Overview & Preview sections

## UI Behavior
- Toggle enables/disables proxy config
- Field hidden for MongoDB when sharding is disabled
- Unsetting toggle removes config from CR

## Files Changed
- Updated ~16 files across schema, UI, state, and utils
- Main logic in: `advanced-configuration.utils.ts`

## Testing
- Verified UI rendering across engines
- Tested toggle persistence
- Checked conditional visibility logic
- Validated preview and overview display