### PR TITLE
fix e2e pg cluster correct schedules restore test

### DIFF
--- a/ui/apps/everest/.e2e/pr/db-cluster/db-cluster-overview.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/db-cluster/db-cluster-overview.e2e.ts
@@ -34,13 +34,16 @@ test.describe('DB Cluster Overview', async () => {
       request,
       'mysql'
     );
+    // MySQL 8.4.x uses 3GB memory for "Small" preset, other versions use 2GB
+    const isMySQL84x = /^8\.4\./.test(mysqlVersion);
+    const smallMemory = isMySQL84x ? 3 : 2;
     await createDbClusterFn(request, {
       dbName: dbClusterName,
       dbVersion: mysqlVersion,
       dbType: 'mysql',
       numberOfNodes: '1',
       cpu: 1,
-      memory: 2,
+      memory: smallMemory,
       proxyCpu: 0.5,
       proxyMemory: 0.8,
       externalAccess: true,

--- a/ui/apps/everest/.e2e/pr/db-cluster/db-cluster-overview.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/db-cluster/db-cluster-overview.e2e.ts
@@ -1,15 +1,42 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { test, expect } from '@playwright/test';
 import { createDbClusterFn, deleteDbClusterFn } from '@e2e/utils/db-cluster';
+import { getLastAvailableEngineVersion } from '@e2e/utils/database-engines';
+import { getTokenFromLocalStorage } from '@e2e/utils/localStorage';
+import { getNamespacesFn } from '@e2e/utils/namespaces';
 import { EVEREST_CI_NAMESPACES } from '@e2e/constants';
 import { findDbAndClickRow } from '@e2e/utils/db-clusters-list';
 
 test.describe('DB Cluster Overview', async () => {
   const dbClusterName = 'cluster-overview-test';
+  let mysqlVersion: string;
 
   test.beforeAll(async ({ request }) => {
+    const token = await getTokenFromLocalStorage();
+    const namespaces = await getNamespacesFn(token, request);
+    const namespace = namespaces[0];
+    mysqlVersion = await getLastAvailableEngineVersion(
+      token,
+      namespace,
+      request,
+      'mysql'
+    );
     await createDbClusterFn(request, {
       dbName: dbClusterName,
-      dbVersion: '8.0.36-28.1',
+      dbVersion: mysqlVersion,
       dbType: 'mysql',
       numberOfNodes: '1',
       cpu: 1,

--- a/ui/apps/everest/.e2e/pr/db-cluster/db-wizard/create-db-cluster/create-db-cluster.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/db-cluster/db-wizard/create-db-cluster/create-db-cluster.e2e.ts
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +23,7 @@ import { createDbClusterFn, deleteDbClusterFn } from '@e2e/utils/db-cluster';
 import { getTokenFromLocalStorage } from '@e2e/utils/localStorage';
 import { advancedConfigurationStepCheck } from './steps/advanced-configuration-step';
 import { backupsStepCheck } from './steps/backups-step';
-import {
-  basicInformationStepCheck,
-  DEFAULT_CLUSTER_VERSION,
-} from './steps/basic-information-step';
+import { basicInformationStepCheck } from './steps/basic-information-step';
 import { resourcesStepCheck } from './steps/resources-step';
 import {
   goToLastAndSubmit,
@@ -114,6 +112,8 @@ test.describe('DB Cluster creation', () => {
       namespace,
       request
     );
+    const selectedVersion =
+      engineVersions.psmdb[engineVersions.psmdb.length - 1];
 
     await selectDbEngine(page, 'psmdb');
 
@@ -121,7 +121,8 @@ test.describe('DB Cluster creation', () => {
       page,
       engineVersions,
       recommendedEngineVersions,
-      clusterName
+      clusterName,
+      selectedVersion
     );
 
     const dbName = await page.getByTestId('text-input-db-name').inputValue();
@@ -163,9 +164,7 @@ test.describe('DB Cluster creation', () => {
     // Test the mechanism for default number of nodes
     await page.getByTestId('button-edit-preview-basic-information').click();
     // Here we test that version wasn't reset to default
-    await expect(
-      page.getByText(`Version: ${DEFAULT_CLUSTER_VERSION}`)
-    ).toBeVisible();
+    await expect(page.getByText(`Version: ${selectedVersion}`)).toBeVisible();
 
     // Make sure name doesn't change when we go back to first step
     expect(await page.getByTestId('text-input-db-name').inputValue()).toBe(
@@ -315,12 +314,15 @@ test.describe('DB Cluster creation', () => {
       namespace,
       request
     );
+    const selectedVersion =
+      engineVersions.psmdb[engineVersions.psmdb.length - 1];
 
     await basicInformationStepCheck(
       page,
       engineVersions,
       recommendedEngineVersions,
-      clusterName
+      clusterName,
+      selectedVersion
     );
     await moveForward(page);
     await resourcesStepCheck(page);

--- a/ui/apps/everest/.e2e/pr/db-cluster/db-wizard/create-db-cluster/steps/basic-information-step.ts
+++ b/ui/apps/everest/.e2e/pr/db-cluster/db-wizard/create-db-cluster/steps/basic-information-step.ts
@@ -16,13 +16,12 @@
 
 import { Page, expect } from '@playwright/test';
 
-export const DEFAULT_CLUSTER_VERSION = '8.0.19-7';
-
 export const basicInformationStepCheck = async (
   page: Page,
   engineVersions,
   recommendedEngineVersions,
-  clusterName
+  clusterName,
+  selectedVersion: string
 ) => {
   expect(
     await page.getByTestId('switch-input-sharding').getByRole('checkbox')
@@ -42,10 +41,7 @@ export const basicInformationStepCheck = async (
     recommendedEngineVersions.psmdb
   );
 
-  await page
-    .getByRole('option')
-    .filter({ hasText: DEFAULT_CLUSTER_VERSION })
-    .click();
+  await page.getByRole('option').filter({ hasText: selectedVersion }).click();
   await page.getByTestId('text-input-db-name').fill(clusterName);
   expect(
     await page.getByTestId('switch-input-sharding').getByRole('checkbox')

--- a/ui/apps/everest/.e2e/pr/db-restore/db-restore-to-new-cluster.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/db-restore/db-restore-to-new-cluster.e2e.ts
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +17,7 @@
 import { expect, test } from '@playwright/test';
 import { Messages } from '../../../src/modals/restore-db-modal/restore-db-modal.messages';
 import { createDbClusterFn, deleteDbClusterFn } from '@e2e/utils/db-cluster';
-import { getEnginesVersions } from '@e2e/utils/database-engines';
+import { getLastAvailableEngineVersion } from '@e2e/utils/database-engines';
 import { getTokenFromLocalStorage } from '@e2e/utils/localStorage';
 import { getNamespacesFn } from '@e2e/utils/namespaces';
 import {
@@ -27,13 +28,25 @@ import { getBucketNamespacesMap } from '@e2e/constants';
 import { goToStep, moveForward } from '@e2e/utils/db-wizard';
 
 const dbClusterName = 'restore-to-new-cluster';
+let token: string;
+let namespace: string;
+let mongoVersion: string;
 
 test.describe('DB Cluster Restore to the new cluster', () => {
   test.beforeAll(async ({ request }) => {
+    token = await getTokenFromLocalStorage();
+    const namespaces = await getNamespacesFn(token, request);
+    namespace = namespaces[0];
+    mongoVersion = await getLastAvailableEngineVersion(
+      token,
+      namespace,
+      request,
+      'mongodb'
+    );
     await createDbClusterFn(request, {
       dbName: dbClusterName,
       dbType: 'mongodb',
-      dbVersion: '8.0.4-1',
+      dbVersion: mongoVersion,
       numberOfNodes: '1',
       numberOfProxies: '3',
       cpu: '1',
@@ -133,7 +146,7 @@ test.describe('DB Cluster Restore to the new cluster', () => {
 
     const comboboxes = page.getByRole('combobox');
     const dbVersionCombobox = comboboxes.nth(1);
-    expect(await dbVersionCombobox.textContent()).toBe('8.0.4-1');
+    expect(await dbVersionCombobox.textContent()).toBe(mongoVersion);
     await page.getByTestId('text-input-db-name').fill('new-db-cluster');
     await moveForward(page);
 
@@ -195,11 +208,12 @@ test.describe('DB Cluster Restore to the new cluster', () => {
 
   test('PG Cluster correct schedules restore', async ({ page, request }) => {
     const dbName = 'pg-cluster-restore';
-    const token = await getTokenFromLocalStorage();
-    const namespaces = await getNamespacesFn(token, request);
-    const namespace = namespaces[0];
-    const dbEngines = await getEnginesVersions(token, namespace, request);
-    const pgVersion = dbEngines.postgresql[dbEngines.postgresql.length - 1];
+    const pgVersion = await getLastAvailableEngineVersion(
+      token,
+      namespace,
+      request,
+      'postgresql'
+    );
     await createDbClusterFn(request, {
       dbName,
       dbType: 'postgresql',

--- a/ui/apps/everest/.e2e/pr/db-restore/db-restore-to-new-cluster.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/db-restore/db-restore-to-new-cluster.e2e.ts
@@ -16,6 +16,9 @@
 import { expect, test } from '@playwright/test';
 import { Messages } from '../../../src/modals/restore-db-modal/restore-db-modal.messages';
 import { createDbClusterFn, deleteDbClusterFn } from '@e2e/utils/db-cluster';
+import { getEnginesVersions } from '@e2e/utils/database-engines';
+import { getTokenFromLocalStorage } from '@e2e/utils/localStorage';
+import { getNamespacesFn } from '@e2e/utils/namespaces';
 import {
   findDbAndClickActions,
   findDbAndClickRow,
@@ -192,10 +195,15 @@ test.describe('DB Cluster Restore to the new cluster', () => {
 
   test('PG Cluster correct schedules restore', async ({ page, request }) => {
     const dbName = 'pg-cluster-restore';
+    const token = await getTokenFromLocalStorage();
+    const namespaces = await getNamespacesFn(token, request);
+    const namespace = namespaces[0];
+    const dbEngines = await getEnginesVersions(token, namespace, request);
+    const pgVersion = dbEngines.postgresql[dbEngines.postgresql.length - 1];
     await createDbClusterFn(request, {
       dbName,
       dbType: 'postgresql',
-      dbVersion: '15.13',
+      dbVersion: pgVersion,
       numberOfNodes: '4',
       numberOfProxies: '1',
       storageClass: 'my-storage-class',
@@ -268,7 +276,7 @@ test.describe('DB Cluster Restore to the new cluster', () => {
 
     const comboboxes = page.getByRole('combobox');
     const dbVersionCombobox = comboboxes.nth(1);
-    expect(await dbVersionCombobox.textContent()).toBe('15.13');
+    expect(await dbVersionCombobox.textContent()).toBe(pgVersion);
 
     await moveForward(page);
 

--- a/ui/apps/everest/.e2e/utils/database-engines.ts
+++ b/ui/apps/everest/.e2e/utils/database-engines.ts
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +15,8 @@
 // limitations under the License.
 
 import { APIRequestContext, expect } from '@playwright/test';
+import { dbTypeToDbEngine } from '@percona/utils';
+import { DbType } from '@percona/types';
 import { getTokenFromLocalStorage } from './localStorage';
 
 export const getEnginesList = async (
@@ -55,6 +58,19 @@ export const getEnginesVersions = async (
   });
 
   return engineVersions;
+};
+
+export const getLastAvailableEngineVersion = async (
+  token: string,
+  namespace: string,
+  request: APIRequestContext,
+  dbType: string
+): Promise<string> => {
+  const dbEngines = await getEnginesVersions(token, namespace, request);
+  const dbEngineType = dbTypeToDbEngine(dbType as DbType);
+  const dbTypeVersions = dbEngines[dbEngineType] || [];
+
+  return dbTypeVersions[dbTypeVersions.length - 1];
 };
 
 export const getEnginesLatestRecommendedVersions = async (


### PR DESCRIPTION
Fixes: #2100 

Fix PG restore E2E to use an available Postgres version, avoiding failures when older versions are removed from the API.