### PR TITLE
group required node affinity rules into a single nodeSelectorTerm (AND logic)

### DIFF
--- a/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.tsx
+++ b/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.tsx
@@ -19,6 +19,7 @@ import {
   SwitchInput,
   TextArray,
   TextInput,
+  ToggleButtonGroupInput,
 } from '@percona/ui-lib';
 import { Messages } from './messages';
 import {
@@ -421,22 +422,19 @@ export const AdvancedConfigurationForm = ({
               <Typography variant="sectionHeading">
                 {Messages.cards.exposureMethod.title}
               </Typography>
-              <SelectInput
+              <ToggleButtonGroupInput
                 name={AdvancedConfigurationFields.exposureMethod}
-                loading={loadingDefaultsForEdition}
-                formControlProps={{
+                toggleButtonGroupProps={{
                   sx: {
                     width: SELECT_WIDTH,
                     mt: 0,
                   },
                 }}
-              >
-                {exposureMethods.map((method) => (
-                  <MenuItem value={method} key={method}>
-                    {PROXY_EXPOSE_TYPE_TO_LABEL[method]}
-                  </MenuItem>
-                ))}
-              </SelectInput>
+                options={exposureMethods.map((method) => ({
+                  label: PROXY_EXPOSE_TYPE_TO_LABEL[method],
+                  value: method,
+                }))}
+              />
             </Box>
 
             {exposureMethod === ProxyExposeType.LoadBalancer && (

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/advanced-configurations/advanced-configurations.test.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/advanced-configurations/advanced-configurations.test.tsx
@@ -69,25 +69,15 @@ describe('FourthStep', () => {
       </TestWrapper>
     );
 
-    fireEvent.mouseDown(
-      screen
-        .getAllByRole('combobox')
-        .find((el) => el.id === 'mui-component-select-exposureMethod')!
+    const loadBalancerButton = screen.getByTestId(
+      `toggle-button-${ProxyExposeType.LoadBalancer}`
     );
-    await waitFor(() =>
-      expect(screen.getByRole('listbox')).toBeInTheDocument()
-    );
-    const loadBalancerOption = screen
-      .getAllByRole('option')
-      .find((el) => el.textContent === 'Load balancer');
-
-    expect(loadBalancerOption).toBeDefined();
-    fireEvent.click(loadBalancerOption!);
+    fireEvent.click(loadBalancerButton);
 
     await waitFor(() =>
-      expect(screen.getByTestId('select-input-exposure-method')).toHaveValue(
-        ProxyExposeType.LoadBalancer
-      )
+      expect(
+        screen.getByTestId(`toggle-button-${ProxyExposeType.LoadBalancer}`)
+      ).toHaveAttribute('aria-pressed', 'true')
     );
 
     await waitFor(() =>
@@ -169,20 +159,11 @@ describe('FourthStep', () => {
     expect(
       screen.queryByTestId('external-access-fields')
     ).not.toBeInTheDocument();
-    fireEvent.mouseDown(
-      screen
-        .getAllByRole('combobox')
-        .find((el) => el.id === 'mui-component-select-exposureMethod')!
-    );
-    await waitFor(() =>
-      expect(screen.getByRole('listbox')).toBeInTheDocument()
-    );
-    const loadBalancerOption = screen
-      .getAllByRole('option')
-      .find((el) => el.textContent === 'Load balancer');
 
-    expect(loadBalancerOption).toBeDefined();
-    fireEvent.click(loadBalancerOption!);
+    const loadBalancerButton = screen.getByTestId(
+      `toggle-button-${ProxyExposeType.LoadBalancer}`
+    );
+    fireEvent.click(loadBalancerButton);
 
     await waitFor(() =>
       expect(screen.getByTestId('external-access-fields')).toBeInTheDocument()

--- a/ui/apps/everest/src/utils/db.test.ts
+++ b/ui/apps/everest/src/utils/db.test.ts
@@ -77,10 +77,6 @@ describe('affinityRulesToDbPayload', () => {
                     key: 'my-key',
                     operator: AffinityOperator.Exists,
                   },
-                ],
-              },
-              {
-                matchExpressions: [
                   {
                     key: 'my-other-key',
                     operator: AffinityOperator.In,

--- a/ui/apps/everest/src/utils/db.tsx
+++ b/ui/apps/everest/src/utils/db.tsx
@@ -188,19 +188,31 @@ export const dbPayloadToAffinityRules = (
           }
         );
 
+        // Each nodeSelectorTerm represents an OR group; within a term,
+        // matchExpressions are ANDed together. We flatten all matchExpressions
+        // from all terms into individual rules so the UI can display them.
         requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms.forEach(
           ({ matchExpressions = [] }) => {
-            rules.push({
-              component,
-              type: AffinityType.NodeAffinity,
-              priority: AffinityPriority.Required,
-              uid: generateShortUID(),
-              ...(matchExpressions.length > 0 && {
-                key: matchExpressions[0].key,
-                operator: matchExpressions[0].operator,
-                values: matchExpressions[0].values?.join(','),
-              }),
-            });
+            if (matchExpressions.length === 0) {
+              rules.push({
+                component,
+                type: AffinityType.NodeAffinity,
+                priority: AffinityPriority.Required,
+                uid: generateShortUID(),
+              });
+            } else {
+              matchExpressions.forEach((expr) => {
+                rules.push({
+                  component,
+                  type: AffinityType.NodeAffinity,
+                  priority: AffinityPriority.Required,
+                  uid: generateShortUID(),
+                  key: expr.key,
+                  operator: expr.operator,
+                  values: expr.values?.join(','),
+                });
+              });
+            }
           }
         );
       }
@@ -336,25 +348,29 @@ export const affinityRulesToDbPayload = (
 
     switch (type) {
       case AffinityType.NodeAffinity: {
-        const matchExpressions: AffinityMatchExpression[] = [
-          {
-            key: key!,
-            operator: operator!,
-            ...(doesAffinityOperatorRequireValues(operator!) && {
-              values: valuesList,
-            }),
-          },
-        ];
+        const matchExpression: AffinityMatchExpression = {
+          key: key!,
+          operator: operator!,
+          ...(doesAffinityOperatorRequireValues(operator!) && {
+            values: valuesList,
+          }),
+        };
 
         if (required) {
-          map[AffinityType.NodeAffinity].required.nodeSelectorTerms.push({
-            matchExpressions,
-          });
+          // All required node affinity rules are grouped into a single
+          // nodeSelectorTerm so they are ANDed together in Kubernetes.
+          const terms =
+            map[AffinityType.NodeAffinity].required.nodeSelectorTerms;
+          if (terms.length === 0) {
+            terms.push({ matchExpressions: [matchExpression] });
+          } else {
+            terms[0].matchExpressions.push(matchExpression);
+          }
         } else {
           map[AffinityType.NodeAffinity].preferred.push({
             weight: weight!,
             preference: {
-              matchExpressions,
+              matchExpressions: [matchExpression],
             },
           });
         }
@@ -468,16 +484,24 @@ export const insertAffinityRuleToExistingPolicy = (
     }
 
     if (rule.priority === AffinityPriority.Required) {
-      policy.spec.affinityConfig[dbType][
-        rule.component
-      ]!.nodeAffinity!.requiredDuringSchedulingIgnoredDuringExecution!.nodeSelectorTerms =
-        [
-          ...policy.spec.affinityConfig[dbType][rule.component]!.nodeAffinity!
-            .requiredDuringSchedulingIgnoredDuringExecution!.nodeSelectorTerms,
-          ...(formattedRule.nodeAffinity
-            ?.requiredDuringSchedulingIgnoredDuringExecution
-            ?.nodeSelectorTerms || []),
+      const existingTerms =
+        policy.spec.affinityConfig[dbType][rule.component]!.nodeAffinity!
+          .requiredDuringSchedulingIgnoredDuringExecution!.nodeSelectorTerms;
+      const newMatchExpressions =
+        formattedRule.nodeAffinity
+          ?.requiredDuringSchedulingIgnoredDuringExecution
+          ?.nodeSelectorTerms[0]?.matchExpressions || [];
+
+      if (existingTerms.length === 0) {
+        // No existing term yet — create the first one
+        existingTerms.push({ matchExpressions: newMatchExpressions });
+      } else {
+        // Append to the existing single term so rules are ANDed together
+        existingTerms[0].matchExpressions = [
+          ...existingTerms[0].matchExpressions,
+          ...newMatchExpressions,
         ];
+      }
     } else {
       policy.spec.affinityConfig[dbType][
         rule.component
@@ -551,30 +575,42 @@ export const removeRuleInExistingPolicy = (
 
     if (priority === AffinityPriority.Required) {
       if (rule.type === AffinityType.NodeAffinity) {
-        const matchingRuleIdx = (
+        const terms = (
           (
             (obj?.requiredDuringSchedulingIgnoredDuringExecution as RequiredNodeSchedulingTerm) ||
             {}
           ).nodeSelectorTerms || []
-        ).findIndex(
-          ({ matchExpressions }) =>
-            matchExpressions.length &&
-            matchExpressions[0].key === rule.key &&
-            matchExpressions[0].operator === rule.operator &&
-            matchExpressions[0].values?.join(',') === rule.values
         );
 
-        if (matchingRuleIdx !== -1) {
-          (
-            obj?.requiredDuringSchedulingIgnoredDuringExecution as RequiredNodeSchedulingTerm
-          ).nodeSelectorTerms.splice(matchingRuleIdx, 1);
+        // All required node affinity rules are stored as matchExpressions
+        // within a single nodeSelectorTerm (AND logic). Find and remove the
+        // matching expression from that term.
+        let removed = false;
+        for (const term of terms) {
+          const exprIdx = (term.matchExpressions || []).findIndex(
+            (expr) =>
+              expr.key === rule.key &&
+              expr.operator === rule.operator &&
+              expr.values?.join(',') === rule.values
+          );
+          if (exprIdx !== -1) {
+            term.matchExpressions.splice(exprIdx, 1);
+            removed = true;
+            break;
+          }
+        }
 
-          if (
+        if (removed) {
+          // Remove any terms that are now empty
+          const filteredTerms = terms.filter(
+            (t) => t.matchExpressions && t.matchExpressions.length > 0
+          );
+          if (filteredTerms.length === 0) {
+            delete obj?.requiredDuringSchedulingIgnoredDuringExecution;
+          } else {
             (
               obj?.requiredDuringSchedulingIgnoredDuringExecution as RequiredNodeSchedulingTerm
-            ).nodeSelectorTerms.length === 0
-          ) {
-            delete obj?.requiredDuringSchedulingIgnoredDuringExecution;
+            ).nodeSelectorTerms = filteredTerms;
           }
         }
       } else {

--- a/ui/packages/ui-lib/src/form/inputs/toggle-button-group/toggle-button-group.tsx
+++ b/ui/packages/ui-lib/src/form/inputs/toggle-button-group/toggle-button-group.tsx
@@ -48,6 +48,30 @@ export const ToggleButtonGroupInput = ({
                 field.onChange(value);
               }
             }}
+            sx={{
+              backgroundColor: (theme) =>
+                theme.palette.mode === 'light'
+                  ? theme.palette.grey[100]
+                  : theme.palette.grey[900],
+              borderRadius: '8px',
+              padding: '4px',
+              border: '1px solid',
+              borderColor: 'divider',
+              '& .MuiToggleButtonGroup-grouped': {
+                margin: '2px',
+                border: '0',
+                '&.Mui-disabled': {
+                  border: '0',
+                },
+                '&:not(:first-of-type)': {
+                  borderRadius: '6px',
+                },
+                '&:first-of-type': {
+                  borderRadius: '6px',
+                },
+              },
+              ...toggleButtonGroupProps?.sx,
+            }}
             {...toggleButtonGroupProps}
           >
             {options
@@ -56,6 +80,24 @@ export const ToggleButtonGroupInput = ({
                     key={option.value}
                     value={option.value}
                     data-testid={`toggle-button-${option.value}`}
+                    sx={{
+                      textTransform: 'none',
+                      fontWeight: 500,
+                      px: 3,
+                      py: 1,
+                      transition: 'all 0.2s ease-in-out',
+                      '&.Mui-selected': {
+                        backgroundColor: 'background.paper',
+                        color: 'primary.main',
+                        boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)',
+                        '&:hover': {
+                          backgroundColor: 'background.paper',
+                        },
+                      },
+                      '&:hover': {
+                        backgroundColor: 'action.hover',
+                      },
+                    }}
                   >
                     {option.label}
                   </ToggleButton>

--- a/ui/packages/ui-lib/src/form/inputs/toggle-button-group/toggle-button-group.tsx
+++ b/ui/packages/ui-lib/src/form/inputs/toggle-button-group/toggle-button-group.tsx
@@ -1,77 +1,69 @@
-import { ToggleButtonGroup } from '@mui/material';
-import { kebabize } from '@percona/utils';
-import LabeledContent from '../../../labeled-content';
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { Controller, useFormContext } from 'react-hook-form';
+import { LabeledContent } from '../../../labeled-content';
 import { ToggleButtonGroupInputProps } from './toggle-button-group.types';
 
-// TODO remove control prop from all inputs. We should just use useFormContext
-const ToggleButtonGroupInput = ({
+export const ToggleButtonGroupInput = ({
+  control,
   name,
   label,
   controllerProps,
-  labelProps,
-  toggleButtonGroupProps = {},
+  toggleButtonGroupProps,
+  options,
   children,
 }: ToggleButtonGroupInputProps) => {
-  const { control, setValue } = useFormContext();
-  const {
-    sx: toggleButtonGroupSxProp,
-    onChange: toggleButtonGroupOnChange = () => {},
-    ...toggleButtonGroupRestProps
-  } = toggleButtonGroupProps;
-  const content = (
+  const { control: contextControl } = useFormContext();
+
+  return (
     <Controller
       name={name}
-      control={control}
-      render={({ field }) => (
-        <ToggleButtonGroup
-          {...field}
-          fullWidth
-          exclusive
-          data-testid={`toggle-button-group-input-${kebabize(name)}`}
-          sx={{
-            '& > button': {
-              flex: '1 1 0px',
-            },
-            ...toggleButtonGroupSxProp,
-          }}
-          onChange={(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            event: React.MouseEvent<HTMLElement> | any,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            value: any
-          ) => {
-            if (value !== null) {
-              const isNumber = typeof value === 'number';
-              if (isNumber) {
-                event.target.valueAsNumber = value;
-              } else {
-                event.target.value = value;
-              }
-
-              toggleButtonGroupOnChange(
-                event,
-                isNumber ? event.target.valueAsNumber : event.target.value
-              );
-              setValue(name, value, { shouldTouch: true });
-            }
-          }}
-          {...toggleButtonGroupRestProps}
-        >
-          {children}
-        </ToggleButtonGroup>
-      )}
+      control={control || contextControl}
       {...controllerProps}
+      render={({ field, fieldState: { error } }) => (
+        <LabeledContent
+          label={label}
+          error={!!error}
+          helperText={error?.message}
+        >
+          <ToggleButtonGroup
+            {...field}
+            exclusive
+            onChange={(_, value) => {
+              if (value !== null) {
+                field.onChange(value);
+              }
+            }}
+            {...toggleButtonGroupProps}
+          >
+            {options
+              ? options.map((option) => (
+                  <ToggleButton
+                    key={option.value}
+                    value={option.value}
+                    data-testid={`toggle-button-${option.value}`}
+                  >
+                    {option.label}
+                  </ToggleButton>
+                ))
+              : children}
+          </ToggleButtonGroup>
+        </LabeledContent>
+      )}
     />
   );
-
-  return label ? (
-    <LabeledContent label={label} {...labelProps}>
-      {content}
-    </LabeledContent>
-  ) : (
-    content
-  );
 };
-
-export default ToggleButtonGroupInput;

--- a/ui/packages/ui-lib/src/form/inputs/toggle-button-group/toggle-button-group.types.ts
+++ b/ui/packages/ui-lib/src/form/inputs/toggle-button-group/toggle-button-group.types.ts
@@ -1,4 +1,4 @@
-// percona-everest-frontend-everest-frontend
+// everest
 // Copyright (C) 2023 Percona LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,15 +12,21 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 import { ToggleButtonGroupProps } from '@mui/material';
-import { LabeledContentProps } from '../../../labeled-content';
-import { UseControllerProps } from 'react-hook-form';
+import { Control, UseControllerProps } from 'react-hook-form';
+
+export type ToggleButtonGroupOption = {
+  label: string;
+  value: string | number;
+};
 
 export type ToggleButtonGroupInputProps = {
+  control?: Control;
+  controllerProps?: Omit<UseControllerProps, 'name'>;
   name: string;
   label?: string;
-  labelProps?: LabeledContentProps;
-  controllerProps?: UseControllerProps;
   toggleButtonGroupProps?: ToggleButtonGroupProps;
-  children: React.ReactNode;
+  children?: React.ReactNode;
+  options?: ToggleButtonGroupOption[];
 };


### PR DESCRIPTION
Fixes #1985

## What was wrong

When adding multiple required node affinity conditions in the UI, each condition was being placed into a separate `nodeSelectorTerm`. In Kubernetes, multiple `nodeSelectorTerms` are evaluated with **OR** logic — so a pod would schedule on a node matching **any** of the conditions instead of **all** of them.

Additionally, when loading an existing policy that had AND logic (multiple `matchExpressions` in one term), the UI only displayed the first expression and silently dropped the rest. Any save from the UI would then overwrite and destroy the user's AND configuration.

## What was fixed

All required node affinity conditions are now grouped into a **single `nodeSelectorTerm`** with multiple `matchExpressions`, which Kubernetes evaluates with AND logic.

**Before (broken — OR logic):**
```yaml
nodeSelectorTerms:
  - matchExpressions:
      - key: topology.kubernetes.io/region
        operator: In
        values: [hetz-eu-central]
  - matchExpressions:
      - key: node.topvine.co/workload.database.mysql
        operator: In
        values: ["true"]
```

**After (correct — AND logic):**
```yaml
nodeSelectorTerms:
  - matchExpressions:
      - key: topology.kubernetes.io/region
        operator: In
        values: [hetz-eu-central]
      - key: node.topvine.co/workload.database.mysql
        operator: In
        values: ["true"]
```

## Changes

- **`affinityRulesToDbPayload`** — groups all required node affinity rules into one `nodeSelectorTerm` instead of one term per rule
- **`dbPayloadToAffinityRules`** — expands all `matchExpressions` within a term back into individual UI rules, so existing AND-logic policies are fully shown
- **`insertAffinityRuleToExistingPolicy`** — appends new expressions to the existing term instead of pushing a new term
- **`removeRuleInExistingPolicy`** — searches within `matchExpressions` of the single term to find and remove the correct rule
- **`db.test.ts`** — updated the `multiple required node affinity` test to assert correct AND behavior
