### PR TITLE
feat: Implement buttonSwitchGroup UI component (POC)

### DIFF
--- a/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.tsx
+++ b/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.tsx
@@ -19,6 +19,7 @@ import {
   SwitchInput,
   TextArray,
   TextInput,
+  ToggleButtonGroupInput,
 } from '@percona/ui-lib';
 import { Messages } from './messages';
 import {
@@ -421,22 +422,19 @@ export const AdvancedConfigurationForm = ({
               <Typography variant="sectionHeading">
                 {Messages.cards.exposureMethod.title}
               </Typography>
-              <SelectInput
+              <ToggleButtonGroupInput
                 name={AdvancedConfigurationFields.exposureMethod}
-                loading={loadingDefaultsForEdition}
-                formControlProps={{
+                toggleButtonGroupProps={{
                   sx: {
                     width: SELECT_WIDTH,
                     mt: 0,
                   },
                 }}
-              >
-                {exposureMethods.map((method) => (
-                  <MenuItem value={method} key={method}>
-                    {PROXY_EXPOSE_TYPE_TO_LABEL[method]}
-                  </MenuItem>
-                ))}
-              </SelectInput>
+                options={exposureMethods.map((method) => ({
+                  label: PROXY_EXPOSE_TYPE_TO_LABEL[method],
+                  value: method,
+                }))}
+              />
             </Box>
 
             {exposureMethod === ProxyExposeType.LoadBalancer && (

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/advanced-configurations/advanced-configurations.test.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/advanced-configurations/advanced-configurations.test.tsx
@@ -69,25 +69,15 @@ describe('FourthStep', () => {
       </TestWrapper>
     );
 
-    fireEvent.mouseDown(
-      screen
-        .getAllByRole('combobox')
-        .find((el) => el.id === 'mui-component-select-exposureMethod')!
+    const loadBalancerButton = screen.getByTestId(
+      `toggle-button-${ProxyExposeType.LoadBalancer}`
     );
-    await waitFor(() =>
-      expect(screen.getByRole('listbox')).toBeInTheDocument()
-    );
-    const loadBalancerOption = screen
-      .getAllByRole('option')
-      .find((el) => el.textContent === 'Load balancer');
-
-    expect(loadBalancerOption).toBeDefined();
-    fireEvent.click(loadBalancerOption!);
+    fireEvent.click(loadBalancerButton);
 
     await waitFor(() =>
-      expect(screen.getByTestId('select-input-exposure-method')).toHaveValue(
-        ProxyExposeType.LoadBalancer
-      )
+      expect(
+        screen.getByTestId(`toggle-button-${ProxyExposeType.LoadBalancer}`)
+      ).toHaveAttribute('aria-pressed', 'true')
     );
 
     await waitFor(() =>
@@ -169,20 +159,11 @@ describe('FourthStep', () => {
     expect(
       screen.queryByTestId('external-access-fields')
     ).not.toBeInTheDocument();
-    fireEvent.mouseDown(
-      screen
-        .getAllByRole('combobox')
-        .find((el) => el.id === 'mui-component-select-exposureMethod')!
-    );
-    await waitFor(() =>
-      expect(screen.getByRole('listbox')).toBeInTheDocument()
-    );
-    const loadBalancerOption = screen
-      .getAllByRole('option')
-      .find((el) => el.textContent === 'Load balancer');
 
-    expect(loadBalancerOption).toBeDefined();
-    fireEvent.click(loadBalancerOption!);
+    const loadBalancerButton = screen.getByTestId(
+      `toggle-button-${ProxyExposeType.LoadBalancer}`
+    );
+    fireEvent.click(loadBalancerButton);
 
     await waitFor(() =>
       expect(screen.getByTestId('external-access-fields')).toBeInTheDocument()

--- a/ui/packages/ui-lib/src/form/inputs/toggle-button-group/toggle-button-group.tsx
+++ b/ui/packages/ui-lib/src/form/inputs/toggle-button-group/toggle-button-group.tsx
@@ -48,6 +48,30 @@ export const ToggleButtonGroupInput = ({
                 field.onChange(value);
               }
             }}
+            sx={{
+              backgroundColor: (theme) =>
+                theme.palette.mode === 'light'
+                  ? theme.palette.grey[100]
+                  : theme.palette.grey[900],
+              borderRadius: '8px',
+              padding: '4px',
+              border: '1px solid',
+              borderColor: 'divider',
+              '& .MuiToggleButtonGroup-grouped': {
+                margin: '2px',
+                border: '0',
+                '&.Mui-disabled': {
+                  border: '0',
+                },
+                '&:not(:first-of-type)': {
+                  borderRadius: '6px',
+                },
+                '&:first-of-type': {
+                  borderRadius: '6px',
+                },
+              },
+              ...toggleButtonGroupProps?.sx,
+            }}
             {...toggleButtonGroupProps}
           >
             {options
@@ -56,6 +80,24 @@ export const ToggleButtonGroupInput = ({
                     key={option.value}
                     value={option.value}
                     data-testid={`toggle-button-${option.value}`}
+                    sx={{
+                      textTransform: 'none',
+                      fontWeight: 500,
+                      px: 3,
+                      py: 1,
+                      transition: 'all 0.2s ease-in-out',
+                      '&.Mui-selected': {
+                        backgroundColor: 'background.paper',
+                        color: 'primary.main',
+                        boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)',
+                        '&:hover': {
+                          backgroundColor: 'background.paper',
+                        },
+                      },
+                      '&:hover': {
+                        backgroundColor: 'action.hover',
+                      },
+                    }}
                   >
                     {option.label}
                   </ToggleButton>

--- a/ui/packages/ui-lib/src/form/inputs/toggle-button-group/toggle-button-group.tsx
+++ b/ui/packages/ui-lib/src/form/inputs/toggle-button-group/toggle-button-group.tsx
@@ -1,77 +1,69 @@
-import { ToggleButtonGroup } from '@mui/material';
-import { kebabize } from '@percona/utils';
-import LabeledContent from '../../../labeled-content';
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { Controller, useFormContext } from 'react-hook-form';
+import { LabeledContent } from '../../../labeled-content';
 import { ToggleButtonGroupInputProps } from './toggle-button-group.types';
 
-// TODO remove control prop from all inputs. We should just use useFormContext
-const ToggleButtonGroupInput = ({
+export const ToggleButtonGroupInput = ({
+  control,
   name,
   label,
   controllerProps,
-  labelProps,
-  toggleButtonGroupProps = {},
+  toggleButtonGroupProps,
+  options,
   children,
 }: ToggleButtonGroupInputProps) => {
-  const { control, setValue } = useFormContext();
-  const {
-    sx: toggleButtonGroupSxProp,
-    onChange: toggleButtonGroupOnChange = () => {},
-    ...toggleButtonGroupRestProps
-  } = toggleButtonGroupProps;
-  const content = (
+  const { control: contextControl } = useFormContext();
+
+  return (
     <Controller
       name={name}
-      control={control}
-      render={({ field }) => (
-        <ToggleButtonGroup
-          {...field}
-          fullWidth
-          exclusive
-          data-testid={`toggle-button-group-input-${kebabize(name)}`}
-          sx={{
-            '& > button': {
-              flex: '1 1 0px',
-            },
-            ...toggleButtonGroupSxProp,
-          }}
-          onChange={(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            event: React.MouseEvent<HTMLElement> | any,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            value: any
-          ) => {
-            if (value !== null) {
-              const isNumber = typeof value === 'number';
-              if (isNumber) {
-                event.target.valueAsNumber = value;
-              } else {
-                event.target.value = value;
-              }
-
-              toggleButtonGroupOnChange(
-                event,
-                isNumber ? event.target.valueAsNumber : event.target.value
-              );
-              setValue(name, value, { shouldTouch: true });
-            }
-          }}
-          {...toggleButtonGroupRestProps}
-        >
-          {children}
-        </ToggleButtonGroup>
-      )}
+      control={control || contextControl}
       {...controllerProps}
+      render={({ field, fieldState: { error } }) => (
+        <LabeledContent
+          label={label}
+          error={!!error}
+          helperText={error?.message}
+        >
+          <ToggleButtonGroup
+            {...field}
+            exclusive
+            onChange={(_, value) => {
+              if (value !== null) {
+                field.onChange(value);
+              }
+            }}
+            {...toggleButtonGroupProps}
+          >
+            {options
+              ? options.map((option) => (
+                  <ToggleButton
+                    key={option.value}
+                    value={option.value}
+                    data-testid={`toggle-button-${option.value}`}
+                  >
+                    {option.label}
+                  </ToggleButton>
+                ))
+              : children}
+          </ToggleButtonGroup>
+        </LabeledContent>
+      )}
     />
   );
-
-  return label ? (
-    <LabeledContent label={label} {...labelProps}>
-      {content}
-    </LabeledContent>
-  ) : (
-    content
-  );
 };
-
-export default ToggleButtonGroupInput;

--- a/ui/packages/ui-lib/src/form/inputs/toggle-button-group/toggle-button-group.types.ts
+++ b/ui/packages/ui-lib/src/form/inputs/toggle-button-group/toggle-button-group.types.ts
@@ -1,4 +1,4 @@
-// percona-everest-frontend-everest-frontend
+// everest
 // Copyright (C) 2023 Percona LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,15 +12,21 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 import { ToggleButtonGroupProps } from '@mui/material';
-import { LabeledContentProps } from '../../../labeled-content';
-import { UseControllerProps } from 'react-hook-form';
+import { Control, UseControllerProps } from 'react-hook-form';
+
+export type ToggleButtonGroupOption = {
+  label: string;
+  value: string | number;
+};
 
 export type ToggleButtonGroupInputProps = {
+  control?: Control;
+  controllerProps?: Omit<UseControllerProps, 'name'>;
   name: string;
   label?: string;
-  labelProps?: LabeledContentProps;
-  controllerProps?: UseControllerProps;
   toggleButtonGroupProps?: ToggleButtonGroupProps;
-  children: React.ReactNode;
+  children?: React.ReactNode;
+  options?: ToggleButtonGroupOption[];
 };


### PR DESCRIPTION
## Task Description
This PR implements the `buttonSwitchGroup` UI component (as `ToggleButtonGroupInput`) and integrates it into the OpenEverest UI Generator as a Proof of Concept (POC). 

The new component has been integrated into the **Advanced Configurations** step for the `exposureMethod` field, replacing the legacy dropdown.

### Key Features Implemented:
- **UI Generator Integration:** Successfully mapped and rendered within the `AdvancedConfigurationForm`.
- **Adaptive Display:** Utilizes MUI's `ToggleButtonGroup` for responsive, adaptive layout.
- **Theme Support:** Fully supports light and dark themes with premium, customized styling (rounded tray design, subtle shadows, and smooth transitions).
- **Validation:** Wrapped in `LabeledContent` to correctly display Zod validation errors.
- **Unit Testing:** `advanced-configurations.test.tsx` has been fully updated to test the new toggle button interactions and conditional rendering.

## Reasoning / Benefit
This refactoring introduces a more modern and intuitive interface for selecting between limited options (Cluster IP, Load Balancer, Node Port), reducing clicks and improving the overall user experience. It also establishes the pattern for using `buttonSwitchGroup` fields elsewhere in the application.
