### PR TITLE
feat: improve backup empty state with actionable CTA

### DIFF
--- a/ui/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list.tsx
@@ -28,8 +28,9 @@ import {
 } from 'hooks';
 import { MRT_ColumnDef } from 'material-react-table';
 import { Alert, Typography } from '@mui/material';
+import { useSearchParams } from 'react-router-dom';
 import { RestoreDbModal } from 'modals/index.ts';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import {
   Backup,
   BackupStatus,
@@ -181,6 +182,16 @@ export const BackupsList = () => {
     setScheduleModalMode(WizardMode.New);
     setOpenScheduleModal(true);
   };
+
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get('createBackup') === 'true') {
+      handleManualBackup();
+      searchParams.delete('createBackup');
+      setSearchParams(searchParams);
+    }
+  }, [searchParams]);
 
   const handleCloseDeleteDialog = () => {
     setOpenDeleteDialog(false);

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/backups-details.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/backups-details.tsx
@@ -20,7 +20,7 @@ import { BackupsDetailsOverviewCardProps } from './card.types';
 import OverviewSectionRow from '../overview-section-row';
 import { Messages } from '../cluster-overview.messages';
 import { Alert, Box, Button, Stack, Typography } from '@mui/material';
-import { Link, useMatch } from 'react-router-dom';
+import { Link, useMatch, useNavigate } from 'react-router-dom';
 import { DBClusterDetailsTabs } from '../../db-cluster-details.types';
 import OverviewSectionText from '../overview-section-text/overview-section-text';
 import { getTimeSelectionPreviewMessage } from '../../../database-form/database-preview/database.preview.messages';
@@ -30,6 +30,7 @@ import { Table } from '@percona/ui-lib';
 import { Backup, BackupStatus } from 'shared-types/backups.types';
 import { BACKUP_STATUS_TO_BASE_STATUS } from 'pages/db-cluster-details/backups/backups-list/backups-list.constants';
 import StatusField from 'components/status-field';
+import EmptyState from 'components/empty-state/empty-state';
 import { useContext, useMemo, useState } from 'react';
 import { MRT_ColumnDef } from 'material-react-table';
 import { DATE_FORMAT } from 'consts';
@@ -87,6 +88,13 @@ export const BackupsDetails = ({
 
   const handleCloseModal = () => {
     setOpenEditModal(false);
+  };
+
+  const navigate = useNavigate();
+  const handleCreateBackup = () => {
+    navigate(
+      `/databases/${routeMatch?.params?.namespace}/${routeMatch?.params?.dbClusterName}/${DBClusterDetailsTabs.backups}?createBackup=true`
+    );
   };
 
   const handleSubmit = (enabled: boolean, backupStorageName: string) => {
@@ -193,7 +201,13 @@ export const BackupsDetails = ({
             />
           </OverviewSection>
         ) : (
-          <Alert severity="info">{Messages.titles.noData}</Alert>
+          <EmptyState
+            contentSlot={
+              <Typography variant="body1">{Messages.titles.noData}</Typography>
+            }
+            buttonText="Create backup"
+            onButtonClick={handleCreateBackup}
+          />
         )}
         <OverviewSection
           dataTestId="schedules"


### PR DESCRIPTION
The current 'No backup found' state in the cluster overview is a passive Alert that doesn't help the user. This PR refactors it to use the existing `EmptyState` component and adds a 'Create backup' button.

I've also added query parameter handling in the Backups list so that clicking the CTA automatically opens the backup creation modal on the destination page. This improves the user flow and leverages our existing design patterns.