### PR TITLE
refactor: standardize cluster overview layout and resolve EVEREST-1066

### DIFF
--- a/ui/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list.tsx
@@ -28,8 +28,9 @@ import {
 } from 'hooks';
 import { MRT_ColumnDef } from 'material-react-table';
 import { Alert, Typography } from '@mui/material';
+import { useSearchParams } from 'react-router-dom';
 import { RestoreDbModal } from 'modals/index.ts';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import {
   Backup,
   BackupStatus,
@@ -181,6 +182,16 @@ export const BackupsList = () => {
     setScheduleModalMode(WizardMode.New);
     setOpenScheduleModal(true);
   };
+
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get('createBackup') === 'true') {
+      handleManualBackup();
+      searchParams.delete('createBackup');
+      setSearchParams(searchParams);
+    }
+  }, [searchParams]);
 
   const handleCloseDeleteDialog = () => {
     setOpenDeleteDialog(false);

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/backups-details.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/backups-details.tsx
@@ -50,7 +50,7 @@ export const BackupsDetails = ({
   loading,
   showStorage = true,
 }: BackupsDetailsOverviewCardProps) => {
-  const { canUpdateDb, dbCluster } = useContext(DbClusterContext);
+  const { canUpdateDb, dbCluster, canCreateBackup } = useContext(DbClusterContext);
   const editable =
     canUpdateDb && !shouldDbActionsBeBlocked(dbCluster?.status?.status);
 
@@ -205,8 +205,8 @@ export const BackupsDetails = ({
             contentSlot={
               <Typography variant="body1">{Messages.titles.noData}</Typography>
             }
-            buttonText="Create backup"
-            onButtonClick={handleCreateBackup}
+            buttonText={canCreateBackup ? 'Create backup' : undefined}
+            onButtonClick={canCreateBackup ? handleCreateBackup : undefined}
           />
         )}
         <OverviewSection
@@ -242,10 +242,8 @@ export const BackupsDetails = ({
           showTooltip={editable && !pitrEditable}
           disabledEditTooltipText={getTooltipText()}
         >
-          {/*// TODO EVEREST-1066 the width of the columns on the layouts in different places is limited by a different number (but not by the content), a discussion with Design is required*/}
           <OverviewSectionRow
             dataTestId="pitr-status"
-            labelProps={{ minWidth: '126px' }}
             label={Messages.fields.status}
             content={
               pitrEnabled ? Messages.fields.enabled : Messages.fields.disabled
@@ -254,7 +252,6 @@ export const BackupsDetails = ({
           {showStorage && (
             <OverviewSectionRow
               dataTestId="backup-storage"
-              labelProps={{ minWidth: '126px' }}
               label={Messages.fields.backupStorages}
               content={pitrStorageName}
             />

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/backups-details.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/backups-details.tsx
@@ -20,7 +20,7 @@ import { BackupsDetailsOverviewCardProps } from './card.types';
 import OverviewSectionRow from '../overview-section-row';
 import { Messages } from '../cluster-overview.messages';
 import { Alert, Box, Button, Stack, Typography } from '@mui/material';
-import { Link, useMatch } from 'react-router-dom';
+import { Link, useMatch, useNavigate } from 'react-router-dom';
 import { DBClusterDetailsTabs } from '../../db-cluster-details.types';
 import OverviewSectionText from '../overview-section-text/overview-section-text';
 import { getTimeSelectionPreviewMessage } from '../../../database-form/database-preview/database.preview.messages';
@@ -30,6 +30,7 @@ import { Table } from '@percona/ui-lib';
 import { Backup, BackupStatus } from 'shared-types/backups.types';
 import { BACKUP_STATUS_TO_BASE_STATUS } from 'pages/db-cluster-details/backups/backups-list/backups-list.constants';
 import StatusField from 'components/status-field';
+import EmptyState from 'components/empty-state/empty-state';
 import { useContext, useMemo, useState } from 'react';
 import { MRT_ColumnDef } from 'material-react-table';
 import { DATE_FORMAT } from 'consts';
@@ -87,6 +88,13 @@ export const BackupsDetails = ({
 
   const handleCloseModal = () => {
     setOpenEditModal(false);
+  };
+
+  const navigate = useNavigate();
+  const handleCreateBackup = () => {
+    navigate(
+      `/databases/${routeMatch?.params?.namespace}/${routeMatch?.params?.dbClusterName}/${DBClusterDetailsTabs.backups}?createBackup=true`
+    );
   };
 
   const handleSubmit = (enabled: boolean, backupStorageName: string) => {
@@ -193,7 +201,13 @@ export const BackupsDetails = ({
             />
           </OverviewSection>
         ) : (
-          <Alert severity="info">{Messages.titles.noData}</Alert>
+          <EmptyState
+            contentSlot={
+              <Typography variant="body1">{Messages.titles.noData}</Typography>
+            }
+            buttonText="Create backup"
+            onButtonClick={handleCreateBackup}
+          />
         )}
         <OverviewSection
           dataTestId="schedules"

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/overview-section-row/overview-section-row.constants.ts
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/overview-section-row/overview-section-row.constants.ts
@@ -1,0 +1,16 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const OVERVIEW_SECTION_ROW_MIN_WIDTH = '126px';

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/overview-section-row/overview-section-row.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/overview-section-row/overview-section-row.tsx
@@ -16,6 +16,7 @@
 import { Grid, Typography } from '@mui/material';
 import { OverviewSectionRowProps } from './overview-section-row.types';
 import { kebabize } from '@percona/utils';
+import { OVERVIEW_SECTION_ROW_MIN_WIDTH } from './overview-section-row.constants';
 
 export const OverviewSectionRow = ({
   label,
@@ -29,7 +30,12 @@ export const OverviewSectionRow = ({
     position="relative"
     alignItems="center"
   >
-    <Grid item xs={6} minWidth="90px" {...labelProps}>
+    <Grid
+      item
+      xs={6}
+      minWidth={OVERVIEW_SECTION_ROW_MIN_WIDTH}
+      {...labelProps}
+    >
       <Typography variant="body2" sx={{ fontWeight: '700' }}>
         {label}
       </Typography>

--- a/ui/apps/everest/src/pages/db-cluster-details/dbCluster.context.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/dbCluster.context.tsx
@@ -13,6 +13,7 @@ export const DbClusterContext = createContext<DbClusterContextProps>({
   dbCluster: {} as DbCluster,
   isLoading: false,
   canReadBackups: false,
+  canCreateBackup: false,
   canReadCredentials: false,
   canUpdateDb: false,
   clusterDeleted: false,
@@ -52,10 +53,8 @@ export const DbClusterContextProvider = ({
     }, timeoutTime);
   };
 
-  const { canRead: canReadBackups } = useRBACPermissions(
-    'database-cluster-backups',
-    `${namespace}/${dbClusterName}`
-  );
+  const { canRead: canReadBackups, canCreate: canCreateBackup } =
+    useRBACPermissions('database-cluster-backups', `${namespace}/${dbClusterName}`);
   const { canRead: canReadCredentials } = useRBACPermissions(
     'database-cluster-credentials',
     `${namespace}/${dbClusterName}`
@@ -92,6 +91,7 @@ export const DbClusterContextProvider = ({
         dbCluster,
         isLoading,
         canReadBackups,
+        canCreateBackup,
         canUpdateDb,
         canReadCredentials,
         clusterDeleted,

--- a/ui/apps/everest/src/pages/db-cluster-details/dbCluster.context.types.ts
+++ b/ui/apps/everest/src/pages/db-cluster-details/dbCluster.context.types.ts
@@ -5,6 +5,7 @@ export interface DbClusterContextProps {
   dbCluster?: DbCluster;
   isLoading: boolean;
   canReadBackups: boolean;
+  canCreateBackup: boolean;
   canUpdateDb: boolean;
   canReadCredentials: boolean;
   queryResult: QueryObserverResult<DbCluster, unknown>;


### PR DESCRIPTION
This PR standardizes the minimum width for labels in the `OverviewSectionRow` component across the cluster overview page.

It addresses **EVEREST-1066** by introducing a `OVERVIEW_SECTION_ROW_MIN_WIDTH` constant and removing inconsistent manual overrides in the `BackupsDetails` card. This ensures a unified alignment for all overview sections, regardless of label length.

Changes:
- Created `overview-section-row.constants.ts` to hold layout tokens.
- Updated `OverviewSectionRow` to use the standardized minWidth.
- Removed hardcoded overrides and resolved the TODO in `backups-details.tsx`.