### PR TITLE
feat(ui-generator): add info field param with InfoOutlined icon tooltip (#1858)

### DIFF
--- a/docs/ui/ui-generator/Readme.md
+++ b/docs/ui/ui-generator/Readme.md
@@ -16,6 +16,7 @@
   - [FieldParams-level modes](#fieldparams-level-modes)
   - [Validation-level modes](#validation-level-modes)
 - Field Types
+  - [Common Field Parameters](components/common-field-params.md)
   - [Number Field](components/number-field.md)
   - [Select Field](components/select-field.md)
   - [Text Field](components/text-field.md)

--- a/docs/ui/ui-generator/components/common-field-params.md
+++ b/docs/ui/ui-generator/components/common-field-params.md
@@ -1,0 +1,199 @@
+# Common Field Parameters
+
+All UIGenerator field types (`text`, `number`, `select`, `hidden`) share a base set of `fieldParams`
+properties documented here. Field-specific parameters are documented separately.
+
+## Table of Contents
+
+- [label](#label)
+- [defaultValue](#defaultvalue)
+- [disabled](#disabled)
+- [autoFocus](#autofocus)
+- [helperText](#helpertext)
+- [info](#info)
+- [tooltip](#tooltip)
+- [badge / badgeToApi](#badge--badgetoapitrue)
+- [modes](#modes)
+
+---
+
+## `label`
+
+Display label rendered above (or floating inside) the field.
+
+```yaml
+fieldParams:
+  label: Storage Class
+```
+
+---
+
+## `defaultValue`
+
+Initial value pre-filled when the form opens in `New` mode (or any mode that does not have an
+`extractInstanceValues` result for this field).
+
+```yaml
+fieldParams:
+  defaultValue: "local-path"
+```
+
+---
+
+## `disabled`
+
+Prevents the user from interacting with the field. The value is still submitted with the form.
+
+```yaml
+fieldParams:
+  disabled: true
+```
+
+Use `fieldParams.modes` to disable only in specific form modes (e.g., prevent editing a field
+after creation):
+
+```yaml
+fieldParams:
+  label: Database name
+  modes:
+    edit:
+      disabled: true
+```
+
+---
+
+## `autoFocus`
+
+Moves browser focus to this field when the form step renders. Use at most once per step.
+
+```yaml
+fieldParams:
+  autoFocus: true
+```
+
+---
+
+## `helperText`
+
+Short guidance text rendered below the field (similar to a MUI `FormHelperText`). Replaced by
+the validation error message when the field is in an error state.
+
+```yaml
+fieldParams:
+  helperText: "Must be unique within the namespace"
+```
+
+---
+
+## `info`
+
+Informational text shown as a small **`ℹ`** (`InfoOutlined`) icon button next to the field.
+Hovering or focusing the icon reveals the text in a tooltip.
+
+Use `info` to surface additional context — explanations of why a setting exists, links to
+documentation concepts, or guidance that is too long for `helperText` — without cluttering the
+visible field area.
+
+```yaml
+fieldParams:
+  label: Storage Class
+  info: >
+    The storage class determines how persistent volumes are provisioned.
+    Choose "local-path" for single-node clusters or a cloud-provider class
+    for production deployments.
+```
+
+### When to use `info` vs `helperText`
+
+| | `helperText` | `info` |
+|---|---|---|
+| **Visibility** | Always visible below the field | Hidden behind an icon, shown on hover |
+| **Length** | Keep it short (one line) | Can be a full sentence or two |
+| **Error interaction** | Replaced by the validation error | Not affected by validation errors |
+| **Best for** | Format hints, units, constraints | Background context, rationale, docs links |
+
+### Accessibility
+
+The icon button has `aria-label="Field information"` so screen-reader users can discover and
+activate it with keyboard navigation.
+
+### Example — plugin developer context
+
+```yaml
+storageClass:
+  uiType: select
+  path: spec.components.engine.storage.storageClass
+  fieldParams:
+    label: Storage Class
+    info: >
+      "local-path" is pre-installed in most Kubernetes distributions.
+      For production, use a cloud-provider storage class that supports
+      ReadWriteOnce (RWO) access mode.
+    options:
+      - label: local-path
+        value: local-path
+```
+
+---
+
+## `tooltip`
+
+> **Note:** The `tooltip` feature wraps the entire field in an MUI `<Tooltip>` that activates
+> on hover. For most use cases, prefer `info` (an icon button) which avoids the layout
+> compensation currently required by `tooltip`. Active tracking issue: [#2007].
+
+Text shown when the user hovers anywhere over the field. Useful for explaining why a field is
+disabled.
+
+```yaml
+fieldParams:
+  disabled: true
+  tooltip: "Storage class cannot be changed after the cluster is created."
+```
+
+---
+
+## `badge` / `badgeToApi: true`
+
+Appends a unit suffix (e.g. `Gi`, `Mi`) to the right of the input.
+
+- `badge: "Gi"` — displays the suffix in the input adornment.
+- `badgeToApi: true` — appends the badge string to the submitted value before sending it to the
+  API (e.g. the user types `25` and the API receives `"25Gi"`).
+
+```yaml
+fieldParams:
+  label: Disk
+  badge: "Gi"
+  badgeToApi: true
+```
+
+---
+
+## `modes`
+
+Per-mode overrides for a subset of `fieldParams` properties. Supported overrides:
+
+| Property | Type | Description |
+|---|---|---|
+| `disabled` | `boolean` | Override disabled state for this mode |
+| `readOnly` | `boolean` | Override readOnly state for this mode |
+| `label` | `string` | Override the field label |
+| `helperText` | `string` | Override the helper text |
+| `defaultValue` | `unknown` | Override the default value |
+| `autoFocus` | `boolean` | Override autoFocus |
+
+```yaml
+dbName:
+  uiType: text
+  path: metadata.name
+  fieldParams:
+    label: Database name
+    helperText: Must be unique within the namespace
+    modes:
+      edit:
+        disabled: true
+        helperText: Name cannot be changed after creation
+```
+
+See [Readme.md — Mode-Aware Overrides](../Readme.md#mode-aware-overrides) for full details.

--- a/docs/ui/ui-generator/components/text-field.md
+++ b/docs/ui/ui-generator/components/text-field.md
@@ -14,6 +14,8 @@
 
 A flexible single-line or multi-line text input field. Suitable for names, descriptions, URLs, email addresses, passwords, and any other free-form text.
 
+> Common `fieldParams` properties (`label`, `defaultValue`, `disabled`, `helperText`, `info`, `tooltip`, `badge`, `modes`) apply to all field types and are documented in [Common Field Parameters](common-field-params.md).
+
 ## Properties:
 
 - `uiType`: `"text"` (**Required**)

--- a/ui/apps/everest/src/components/ui-generator/ui-component/utils/field-wrappers.tsx
+++ b/ui/apps/everest/src/components/ui-generator/ui-component/utils/field-wrappers.tsx
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import React from 'react';
-import { Box, Tooltip } from '@mui/material';
+import { Box, IconButton, Tooltip } from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import {
   Component,
   FieldType,
@@ -68,7 +69,57 @@ const tooltipWrapper: FieldWrapper = (element, item) => {
   );
 };
 
-const fieldWrappers: FieldWrapper[] = [tooltipWrapper];
+const infoWrapper: FieldWrapper = (element, item) => {
+  const info = item.fieldParams?.info;
+  if (!info) return element;
+
+  const shouldCompensateMargin =
+    item.uiType === FieldType.Number || item.uiType === FieldType.Text;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        flex: '1 1 0',
+        minWidth: 0,
+        width: '100%',
+      }}
+    >
+      <Box
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          ...(shouldCompensateMargin && {
+            '& > *': { minWidth: 0, width: '100%' },
+          }),
+        }}
+      >
+        {element}
+      </Box>
+      <Tooltip title={info} placement="right" arrow>
+        <IconButton
+          size="small"
+          data-testid="field-info-button"
+          aria-label="Field information"
+          sx={{
+            flexShrink: 0,
+            color: 'action.active',
+            p: 0.5,
+            // Align the icon visually with the input control area.
+            // Text/number fields own a marginTop of ~15px via formControlProps;
+            // add the same offset so the icon sits beside the label row.
+            ...(shouldCompensateMargin && { mt: '15px' }),
+          }}
+        >
+          <InfoOutlinedIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+};
+
+const fieldWrappers: FieldWrapper[] = [tooltipWrapper, infoWrapper];
 
 export const applyFieldWrappers = (
   element: React.ReactElement,

--- a/ui/apps/everest/src/components/ui-generator/ui-component/utils/get-mapped-params.ts
+++ b/ui/apps/everest/src/components/ui-generator/ui-component/utils/get-mapped-params.ts
@@ -67,7 +67,8 @@ const mapNumberFieldParams = (
   fieldParams: NumberFieldParams,
   validation?: ValidationMap[FieldType.Number]
 ) => {
-  const { disabled, helperText, badge, autoFocus, placeholder, step, ...rest } =
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { disabled, helperText, badge, autoFocus, placeholder, step, tooltip, info, ...rest } =
     fieldParams;
 
   const textFieldProps: Partial<TextFieldProps> = filterDefined({
@@ -125,7 +126,8 @@ const mapNumberFieldParams = (
 };
 
 const mapSelectFieldParams = (fieldParams: SelectFieldParams) => {
-  const { label, defaultValue, options, helperText, badge, ...selectProps } =
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { label, defaultValue, options, helperText, badge, tooltip, info, ...selectProps } =
     fieldParams;
 
   const selectFieldProps: Partial<SelectProps> = filterDefined(
@@ -143,7 +145,8 @@ const mapSelectFieldParams = (fieldParams: SelectFieldParams) => {
 };
 
 const mapTextFieldParams = (fieldParams: TextFieldParams) => {
-  const { label, defaultValue, readOnly, badge, ...textProps } = fieldParams;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { label, defaultValue, readOnly, badge, tooltip, info, ...textProps } = fieldParams;
 
   const textFieldProps: Partial<TextFieldProps> = filterDefined(
     textProps as Record<string, unknown>

--- a/ui/apps/everest/src/components/ui-generator/ui-generator.types.ts
+++ b/ui/apps/everest/src/components/ui-generator/ui-generator.types.ts
@@ -72,6 +72,13 @@ interface CommonFieldParams {
   helperText?: string;
   // TODO support tooltip in the ui-schema for all components + documentation
   tooltip?: string;
+  /**
+   * Informational text shown as an InfoOutlined icon next to the field.
+   * Hovering over the icon reveals the text in a tooltip.
+   * Use this to provide additional context or guidance to the plugin developer
+   * without cluttering the field label or helperText.
+   */
+  info?: string;
   badge?: string;
   badgeToApi?: boolean;
   modes?: FieldParamsModeOverrides;

--- a/ui/apps/everest/src/components/ui-generator/unit-tests/field-extra-information.test.tsx
+++ b/ui/apps/everest/src/components/ui-generator/unit-tests/field-extra-information.test.tsx
@@ -1,0 +1,273 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { TestWrapper } from 'utils/test';
+import { UIGenerator } from '../ui-generator';
+import {
+  Component,
+  FieldType,
+  TopologyUISchemas,
+} from '../ui-generator.types';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { buildZodSchema } from '../utils/schema-builder';
+import { getDefaultValues } from '../utils/default-values';
+
+vi.mock('../utils/cel-validation', () => ({
+  extractCelFieldPaths: vi.fn(() => []),
+  validateCelExpression: vi.fn(() => true),
+}));
+
+vi.mock('../utils/schema-builder/cel-validation', () => ({
+  extractCelFieldPaths: vi.fn(() => []),
+  validateCelExpression: vi.fn(() => true),
+}));
+
+const createSchemaWithInfo = (
+  uiType: FieldType.Text | FieldType.Number | FieldType.Select,
+  info?: string
+): TopologyUISchemas => {
+  const baseComponent: Partial<Component> = {
+    path: 'spec.testField',
+    fieldParams: {
+      label: 'Test Field',
+      ...(info !== undefined ? { info } : {}),
+    },
+  };
+
+  let component: Component;
+
+  switch (uiType) {
+    case FieldType.Number:
+      component = {
+        ...(baseComponent as Omit<Component, 'uiType'>),
+        uiType: FieldType.Number,
+        fieldParams: { label: 'Test Field', ...(info ? { info } : {}) },
+      } as Component;
+      break;
+    case FieldType.Select:
+      component = {
+        ...(baseComponent as Omit<Component, 'uiType'>),
+        uiType: FieldType.Select,
+        fieldParams: {
+          label: 'Test Field',
+          options: [{ label: 'Option A', value: 'a' }],
+          ...(info ? { info } : {}),
+        },
+      } as Component;
+      break;
+    default:
+      component = {
+        ...(baseComponent as Omit<Component, 'uiType'>),
+        uiType: FieldType.Text,
+        fieldParams: { label: 'Test Field', ...(info ? { info } : {}) },
+      } as Component;
+  }
+
+  return {
+    testTopology: {
+      sections: {
+        basicInfo: {
+          label: 'Basic Information',
+          components: { testField: component },
+        },
+      },
+      sectionsOrder: ['basicInfo'],
+    },
+  };
+};
+
+interface FormWrapperProps {
+  children: React.ReactNode;
+  schema: TopologyUISchemas;
+}
+
+const FormWrapper = ({ children, schema }: FormWrapperProps) => {
+  const { schema: zodSchema } = buildZodSchema(schema, 'testTopology');
+  const defaultValues = getDefaultValues(schema, 'testTopology');
+
+  const methods = useForm({
+    resolver: zodResolver(zodSchema),
+    mode: 'onChange',
+    defaultValues,
+    reValidateMode: 'onChange',
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <form>{children}</form>
+    </FormProvider>
+  );
+};
+
+const renderField = (
+  uiType: FieldType.Text | FieldType.Number | FieldType.Select,
+  info?: string
+) => {
+  const schema = createSchemaWithInfo(uiType, info);
+  render(
+    <TestWrapper>
+      <FormWrapper schema={schema}>
+        <UIGenerator
+          sections={schema.testTopology!.sections}
+          sectionKey="basicInfo"
+        />
+      </FormWrapper>
+    </TestWrapper>
+  );
+};
+
+describe('UIGenerator - Field Extra Information (info property)', () => {
+  describe('Text field', () => {
+    it('does not render the info button when info is not set', () => {
+      renderField(FieldType.Text);
+      expect(
+        screen.queryByTestId('field-info-button')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the info button when info is set', () => {
+      renderField(FieldType.Text, 'This is extra context for the text field.');
+      expect(screen.getByTestId('field-info-button')).toBeInTheDocument();
+    });
+
+    it('info button has correct aria-label for accessibility', () => {
+      renderField(FieldType.Text, 'Accessible info text');
+      expect(
+        screen.getByRole('button', { name: 'Field information' })
+      ).toBeInTheDocument();
+    });
+
+    it('shows the info text in a tooltip on hover', async () => {
+      const infoText = 'Hover tooltip content for text field';
+      renderField(FieldType.Text, infoText);
+
+      const infoButton = screen.getByTestId('field-info-button');
+      await act(async () => {
+        fireEvent.mouseOver(infoButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('tooltip')).toHaveTextContent(infoText);
+      });
+    });
+
+    it('still renders the field label when info is set', () => {
+      renderField(FieldType.Text, 'Some info');
+      expect(screen.getByLabelText('Test Field')).toBeInTheDocument();
+    });
+  });
+
+  describe('Number field', () => {
+    it('does not render the info button when info is not set', () => {
+      renderField(FieldType.Number);
+      expect(
+        screen.queryByTestId('field-info-button')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the info button when info is set', () => {
+      renderField(FieldType.Number, 'Must be between 1 and 100.');
+      expect(screen.getByTestId('field-info-button')).toBeInTheDocument();
+    });
+
+    it('shows the info text in a tooltip on hover', async () => {
+      const infoText = 'Number field tooltip content';
+      renderField(FieldType.Number, infoText);
+
+      const infoButton = screen.getByTestId('field-info-button');
+      await act(async () => {
+        fireEvent.mouseOver(infoButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('tooltip')).toHaveTextContent(infoText);
+      });
+    });
+  });
+
+  describe('Select field', () => {
+    it('does not render the info button when info is not set', () => {
+      renderField(FieldType.Select);
+      expect(
+        screen.queryByTestId('field-info-button')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the info button when info is set', () => {
+      renderField(FieldType.Select, 'Choose the appropriate storage class.');
+      expect(screen.getByTestId('field-info-button')).toBeInTheDocument();
+    });
+
+    it('shows the info text in a tooltip on hover', async () => {
+      const infoText = 'Select field tooltip content';
+      renderField(FieldType.Select, infoText);
+
+      const infoButton = screen.getByTestId('field-info-button');
+      await act(async () => {
+        fireEvent.mouseOver(infoButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('tooltip')).toHaveTextContent(infoText);
+      });
+    });
+  });
+
+  describe('info does not interfere with other field features', () => {
+    it('renders both info button and disabled state correctly', () => {
+      const schema = createSchemaWithInfo(FieldType.Text, 'Some info');
+      const textComponent = schema.testTopology!.sections.basicInfo
+        .components.testField as Component;
+      (textComponent.fieldParams as { disabled?: boolean }).disabled = true;
+
+      render(
+        <TestWrapper>
+          <FormWrapper schema={schema}>
+            <UIGenerator
+              sections={schema.testTopology!.sections}
+              sectionKey="basicInfo"
+            />
+          </FormWrapper>
+        </TestWrapper>
+      );
+
+      expect(screen.getByTestId('field-info-button')).toBeInTheDocument();
+      expect(screen.getByLabelText('Test Field')).toBeDisabled();
+    });
+
+    it('renders both info and tooltip wrappers when both are set', () => {
+      const schema = createSchemaWithInfo(FieldType.Text, 'Info text');
+      const textComponent = schema.testTopology!.sections.basicInfo
+        .components.testField as Component;
+      (textComponent.fieldParams as { tooltip?: string }).tooltip =
+        'Tooltip text';
+
+      render(
+        <TestWrapper>
+          <FormWrapper schema={schema}>
+            <UIGenerator
+              sections={schema.testTopology!.sections}
+              sectionKey="basicInfo"
+            />
+          </FormWrapper>
+        </TestWrapper>
+      );
+
+      expect(screen.getByTestId('field-info-button')).toBeInTheDocument();
+      expect(screen.getByTestId('field-tooltip')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1858

Adds an `info?: string` property to `CommonFieldParams` — a clean alternative to the existing
`tooltip` wrapper for surfacing extra context to plugin developers.

## What changed

### `ui-generator.types.ts`
- Added `info?: string` to `CommonFieldParams` with JSDoc explaining its purpose

### `field-wrappers.tsx`
- Added `infoWrapper` that renders a small `InfoOutlined` icon button next to the field
- Uses a flex side-by-side layout (field takes `flex: 1`, icon is `flexShrink: 0`), which avoids
  the full-field-wrap margin issue that the existing `tooltip` wrapper requires workarounds for
- Applies a `mt: '15px'` offset on text/number fields to align the icon with the input control area

### `get-mapped-params.ts`
- Explicitly extracts `tooltip` and `info` from all three field mappers (`mapNumberFieldParams`,
  `mapTextFieldParams`, `mapSelectFieldParams`) so they are not forwarded to MUI components as
  unknown DOM props (they were previously leaking via `...rest`)

### Tests
- 13 unit tests in `field-extra-information.test.tsx`:
  - Render/no-render for text, number, and select fields
  - Correct `aria-label` for accessibility
  - Tooltip content displayed on hover
  - Coexistence with `disabled` state
  - Coexistence with the existing `tooltip` wrapper

### Docs
- New `docs/ui/ui-generator/components/common-field-params.md` documenting all shared
  `CommonFieldParams` including `info`, with a table comparing `info` vs `helperText`
- Updated `Readme.md` table of contents and `text-field.md` to cross-link

## Schema example

```yaml
storageClass:
  uiType: select
  path: spec.components.engine.storage.storageClass
  fieldParams:
    label: Storage Class
    info: >
      "local-path" works for single-node clusters. For production, use a
      cloud-provider storage class that supports ReadWriteOnce (RWO) access.
    options:
      - label: local-path
        value: local-path
```
        
## Notes
info and tooltip can coexist on the same field — `tooltipWrapper` runs first, `infoWrapper` runs second in the `fieldWrappers` pipeline
The open question from my issue comment (should info also render in the cluster overview `SchemaDrivenCard`?) is out of scope here — happy to follow up in a separate issue if useful