### PR TITLE
fix: ensure logout cleanup runs even if session delete fails

### DIFF
--- a/ui/apps/everest/src/contexts/auth/auth.provider.test.tsx
+++ b/ui/apps/everest/src/contexts/auth/auth.provider.test.tsx
@@ -1,4 +1,8 @@
-/// <reference types="vitest" />
+// Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0
+
 
 import { describe, it, vi } from 'vitest';
 
@@ -18,11 +22,12 @@ vi.mock('./auth.provider', async () => {
   const actual = await vi.importActual<typeof import('./auth.provider')>('./auth.provider');
   return {
     ...actual,
-    default: ({ children }: any) => children, // skip auth logic
+    default: ({ children }: { children: ReactNode }) => children
   };
 });
 
 //Now import everything
+import type { ReactNode } from 'react';
 import { render } from '@testing-library/react';
 import AuthProvider from './auth.provider';
 import * as apiModule from '../../api/api';

--- a/ui/apps/everest/src/contexts/auth/auth.provider.test.tsx
+++ b/ui/apps/everest/src/contexts/auth/auth.provider.test.tsx
@@ -1,45 +1,87 @@
+// everest
 // Copyright (C) 2023 Percona LLC
 // Copyright (C) 2026 The OpenEverest Contributors
 //
-// Licensed under the Apache License, Version 2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-
-import { describe, it, vi } from 'vitest';
-
-//Mock before imports
-vi.mock('oidc-client-ts', () => ({
-  UserManager: vi.fn(() => ({
-    signinRedirect: vi.fn(),
-    signoutRedirect: vi.fn(),
+// Mocks must be declared before imports
+vi.mock('oidc-react', () => {
+  const userManager = {
+    clearStaleState: vi.fn().mockResolvedValue(undefined),
+    removeUser: vi.fn().mockResolvedValue(undefined),
+    signinSilent: vi.fn().mockResolvedValue(null),
+    signinSilentCallback: vi.fn(),
     getUser: vi.fn().mockResolvedValue(null),
-    removeUser: vi.fn(),
-  })),
-  WebStorageStateStore: vi.fn(),
-}));
-
-//Mock AuthProvider before importing it
-vi.mock('./auth.provider', async () => {
-  const actual = await vi.importActual<typeof import('./auth.provider')>('./auth.provider');
+    events: {
+      addUserLoaded: vi.fn(),
+      addAccessTokenExpiring: vi.fn(),
+    },
+  };
   return {
-    ...actual,
-    default: ({ children }: { children: ReactNode }) => children
+    AuthProvider: ({ children }: { children: ReactNode }) => children,
+    useAuth: () => ({ signIn: vi.fn(), userManager }),
   };
 });
 
-//Now import everything
+vi.mock('utils/rbac', () => ({
+  initializeAuthorizerFetchLoop: vi.fn(),
+  stopAuthorizerFetchLoop: vi.fn(),
+}));
+
+vi.mock('notistack', () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
 import type { ReactNode } from 'react';
-import { render } from '@testing-library/react';
+import { useContext } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import AuthProvider from './auth.provider';
+import AuthContext from './auth.context';
 import * as apiModule from '../../api/api';
 
+const LogoutConsumer = () => {
+  const { logout } = useContext(AuthContext);
+  return <button onClick={logout}>logout</button>;
+};
+
 describe('AuthProvider logout behavior', () => {
-  it('does not crash if api.delete fails', async () => {
-    vi.spyOn(apiModule.api, 'delete').mockRejectedValue(new Error('fail'));
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('runs cleanup even when api.delete fails', async () => {
+    vi.spyOn(apiModule.api, 'delete').mockRejectedValueOnce(new Error('fail'));
+    const removeErrorSpy = vi.spyOn(apiModule, 'removeApiErrorInterceptor');
+    const removeAuthSpy = vi.spyOn(apiModule, 'removeApiAuthInterceptor');
 
     render(
       <AuthProvider>
-        <div />
+        <LogoutConsumer />
       </AuthProvider>
     );
+
+    localStorage.setItem('everestToken', 'test-token');
+    sessionStorage.setItem('auth-data', 'some-value');
+
+    fireEvent.click(screen.getByRole('button', { name: 'logout' }));
+
+    await waitFor(() => {
+      expect(localStorage.getItem('everestToken')).toBeNull();
+    });
+    expect(sessionStorage.length).toBe(0);
+    expect(removeErrorSpy).toHaveBeenCalled();
+    expect(removeAuthSpy).toHaveBeenCalled();
   });
 });

--- a/ui/apps/everest/src/contexts/auth/auth.provider.test.tsx
+++ b/ui/apps/everest/src/contexts/auth/auth.provider.test.tsx
@@ -1,0 +1,40 @@
+/// <reference types="vitest" />
+
+import { describe, it, vi } from 'vitest';
+
+//Mock before imports
+vi.mock('oidc-client-ts', () => ({
+  UserManager: vi.fn(() => ({
+    signinRedirect: vi.fn(),
+    signoutRedirect: vi.fn(),
+    getUser: vi.fn().mockResolvedValue(null),
+    removeUser: vi.fn(),
+  })),
+  WebStorageStateStore: vi.fn(),
+}));
+
+//Mock AuthProvider before importing it
+vi.mock('./auth.provider', async () => {
+  const actual = await vi.importActual<typeof import('./auth.provider')>('./auth.provider');
+  return {
+    ...actual,
+    default: ({ children }: any) => children, // skip auth logic
+  };
+});
+
+//Now import everything
+import { render } from '@testing-library/react';
+import AuthProvider from './auth.provider';
+import * as apiModule from '../../api/api';
+
+describe('AuthProvider logout behavior', () => {
+  it('does not crash if api.delete fails', async () => {
+    vi.spyOn(apiModule.api, 'delete').mockRejectedValue(new Error('fail'));
+
+    render(
+      <AuthProvider>
+        <div />
+      </AuthProvider>
+    );
+  });
+});

--- a/ui/apps/everest/src/contexts/auth/auth.provider.tsx
+++ b/ui/apps/everest/src/contexts/auth/auth.provider.tsx
@@ -110,7 +110,7 @@ const AuthProvider = ({ children, isSsoEnabled }: AuthProviderProps) => {
     }
   };
 
-  const logout = async () => {
+  const logout = async () => { 
     const token = localStorage.getItem('everestToken');
     try {
       await api.delete('/session', { headers: { token } });

--- a/ui/apps/everest/src/contexts/auth/auth.provider.tsx
+++ b/ui/apps/everest/src/contexts/auth/auth.provider.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   AuthProvider as OidcAuthProvider,
@@ -98,7 +112,11 @@ const AuthProvider = ({ children, isSsoEnabled }: AuthProviderProps) => {
 
   const logout = async () => {
     const token = localStorage.getItem('everestToken');
-    await api.delete('/session', { headers: { token: token } });
+    try {
+      await api.delete('/session', { headers: { token } });
+    } catch {
+      // best-effort server-side session deletion; always clean up locally
+    }
     if (isSsoEnabled) {
       await userManager.clearStaleState();
       await setLogoutStatus();

--- a/ui/apps/everest/src/contexts/auth/auth.provider.tsx
+++ b/ui/apps/everest/src/contexts/auth/auth.provider.tsx
@@ -110,7 +110,7 @@ const AuthProvider = ({ children, isSsoEnabled }: AuthProviderProps) => {
     }
   };
 
-  const logout = async () => { 
+  const logout = async () => {
     const token = localStorage.getItem('everestToken');
     try {
       await api.delete('/session', { headers: { token } });


### PR DESCRIPTION
### SUMMARY

This PR fixes a logout flow issue where local session cleanup was skipped if the API call failed. The change ensures logout always completes on the client side, regardless of server response. The update primarily affects `ui/apps/everest/src/contexts/auth/auth.provider.tsx` within the `logout()` function.

### FIX

```ts
// Before 
await api.delete('/session', { headers: { token } });

// After 
try {
  await api.delete('/session', { headers: { token } });
} catch {
  // 
}
```
