### PR TITLE
Fix API tests

### DIFF
--- a/api-tests/tests/auth.spec.ts
+++ b/api-tests/tests/auth.spec.ts
@@ -38,7 +38,7 @@ test.describe.parallel('Auth tests', () => {
     test('auth header fails with no content', async ({request}) => {
       const version = await request.get('/v1/version');
 
-      expect(version.status()).toEqual(400);
+      expect(version.status()).toEqual(401);
     });
   });
 


### PR DESCRIPTION
PR #2142 updated the echo-jwt package to 4.4.0 that reverted the change introduced in 4.3.0 that would return a 400 instead of a 401 if no token was provided. This PR fixes the API tests to reflect that.