### PR TITLE
fix: update helm targets to use openeverest instead of percona organization

### DIFF
--- a/ui/apps/everest/src/components/empty-state-namespaces/empty-state-namespaces.tsx
+++ b/ui/apps/everest/src/components/empty-state-namespaces/empty-state-namespaces.tsx
@@ -30,7 +30,7 @@ const EmptyStateNamespaces = () => {
           />
           <CommandInstructions
             message="If you are using Helm, run the following command:"
-            command="helm install everest percona/everest-db-namespace --create-namespace --namespace <NAMESPACE>"
+            command="helm install everest openeverest/everest-db-namespace --create-namespace --namespace <NAMESPACE>"
           />
         </>
       }

--- a/ui/packages/ui-lib/src/code-copy-block/code-copy-block.stories.ts
+++ b/ui/packages/ui-lib/src/code-copy-block/code-copy-block.stories.ts
@@ -16,14 +16,14 @@ type Story = StoryObj<CodeCopyBlockProps>;
 export const WithCopyButtonCommand: Story = {
   args: {
     message:
-      'helm install everest percona/everest-db-namespace --create-namespace --namespace <NAMESPACE>',
+      'helm install everest openeverest/everest-db-namespace --create-namespace --namespace <NAMESPACE>',
     showCopyButtonText: true,
   },
 };
 export const WithoutCopyButtonCommand: Story = {
   args: {
     message:
-      'helm install everest percona/everest-db-namespace --create-namespace --namespace <NAMESPACE>',
+      'helm install everest openeverest/everest-db-namespace --create-namespace --namespace <NAMESPACE>',
     showCopyButtonText: false,
   },
 };


### PR DESCRIPTION
Following documentation here: https://github.com/openeverest/helm-charts/tree/main/charts/everest#4-deploy-additional-database-namespaces

Converting `percona/everest-db-namespace` Helm chart to `openeverest/everest-db-namespace`.