### PR TITLE
fix: add unsubscribe to prevent stale observers

### DIFF
--- a/ui/apps/everest/src/hooks/rbac/rbac.ts
+++ b/ui/apps/everest/src/hooks/rbac/rbac.ts
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useNamespaces } from 'hooks/api/namespaces';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -105,6 +119,7 @@ export const useNamespacePermissionsForResource = (
   useEffect(() => {
     AuthorizerObservable.subscribe(checkPermissions);
     checkPermissions();
+    return () => AuthorizerObservable.unsubscribe(checkPermissions);
   }, [checkPermissions]);
 
   return {


### PR DESCRIPTION
## 1. SUMMARY

This PR fixes a missing cleanup in `useNamespacePermissionsForResource` that caused subscriptions to `AuthorizerObservable` to accumulate across re-renders. The change ensures callbacks are properly unsubscribed, preventing stale executions and memory growth.

Primary changes are in `ui/apps/everest/src/hooks/rbac/rbac.ts` within the `useNamespacePermissionsForResource` hook.

---

## 2. FIX

```ts
// Before
useEffect(() => {
  AuthorizerObservable.subscribe(checkPermissions);
  checkPermissions();
}, [checkPermissions]);

// After
useEffect(() => {
  AuthorizerObservable.subscribe(checkPermissions);
  checkPermissions();
  return () => AuthorizerObservable.unsubscribe(checkPermissions);
}, [checkPermissions]);
```

