### PR TITLE
fix: scope cluster credentials cache by namespace

### DIFF
--- a/ui/apps/everest/src/hooks/api/db-cluster/useCreateDbCluster.ts
+++ b/ui/apps/everest/src/hooks/api/db-cluster/useCreateDbCluster.ts
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -211,7 +212,7 @@ export const useDbClusterCredentials = (
   );
 
   return useQuery<GetDbClusterCredentialsPayload, unknown, ClusterCredentials>({
-    queryKey: ['cluster-credentials', dbClusterName],
+    queryKey: ['cluster-credentials', namespace, dbClusterName],
     queryFn: () => getDbClusterCredentialsFn(dbClusterName, namespace),
     select: canReadCredentials
       ? (creds) => creds

--- a/ui/apps/everest/src/hooks/rbac/rbac.ts
+++ b/ui/apps/everest/src/hooks/rbac/rbac.ts
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useNamespaces } from 'hooks/api/namespaces';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -138,6 +152,8 @@ export const useRBACPermissionRoute = (
 
   useEffect(() => {
     checkPermissions();
+    AuthorizerObservable.subscribe(checkPermissions);
+    return () => AuthorizerObservable.unsubscribe(checkPermissions);
   }, [checkPermissions]);
 
   return true;


### PR DESCRIPTION
## 1. SUMMARY

This PR fixes a cache collision issue in `useDbClusterCredentials` where credentials for clusters with the same name across different namespaces could overwrite each other in React Query cache. As a result, users could briefly see and copy incorrect credentials when navigating between environments.

The change primarily affects `ui/apps/everest/src/hooks/api/db-cluster/useCreateDbCluster.ts` and improves credential consistency in the cluster overview flow.

---

## 2. FIX


```ts id="pxg0fh"
// Before
queryKey: ['cluster-credentials', dbClusterName]

// After
queryKey: ['cluster-credentials', namespace, dbClusterName]
```


