### PR TITLE
refactor(cli): centralize shouldAskOperators logic for consistent skip-wizard behavior

### DIFF
--- a/commands/install.go
+++ b/commands/install.go
@@ -109,8 +109,7 @@ func installPreRun(cmd *cobra.Command, _ []string) { //nolint:revive
 func checkDBNamespaceParameters(cmd *cobra.Command) error {
 	// Check DB namespaces parameters
 	// If user doesn't pass --namespaces flag - need to ask explicitly.
-	askNamespaces := !(cmd.Flags().Lookup(cli.FlagNamespaces).Changed ||
-		installCfg.NamespaceAddConfig.SkipWizard)
+	askNamespaces := shouldAskNamespaces(cmd, installCfg.NamespaceAddConfig.SkipWizard)
 
 	// Note: there are the following cases possible:
 	// - user doesn't provide '--namespaces' flag -> namespacesToAdd="everest" (default).
@@ -131,13 +130,7 @@ func checkDBNamespaceParameters(cmd *cobra.Command) error {
 	}
 
 	// If user doesn't pass any --operator.* flags - need to ask explicitly.
-	askOperators := !(cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed ||
-		cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed ||
-		cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed ||
-		cmd.Flags().Lookup(cli.FlagOperatorMySQL).Changed ||
-		installCfg.NamespaceAddConfig.SkipWizard)
-
-	if askOperators {
+	if cli.ShouldAskOperators(cmd, installCfg.NamespaceAddConfig.SkipWizard) {
 		// need to ask user to provide operators to be installed in interactive mode.
 		if err := installCfg.NamespaceAddConfig.PopulateOperators(cmd.Context()); err != nil {
 			return err
@@ -145,6 +138,10 @@ func checkDBNamespaceParameters(cmd *cobra.Command) error {
 	}
 
 	return nil
+}
+
+func shouldAskNamespaces(cmd *cobra.Command, skipWizard bool) bool {
+	return !skipWizard && !cmd.Flags().Lookup(cli.FlagNamespaces).Changed
 }
 
 func installRun(cmd *cobra.Command, _ []string) { //nolint:revive

--- a/commands/namespaces/add.go
+++ b/commands/namespaces/add.go
@@ -94,13 +94,7 @@ func namespacesAddPreRun(cmd *cobra.Command, args []string) { //nolint:revive
 	}
 
 	// If user doesn't pass any --operator.* flags - need to ask explicitly.
-	askOperators := !(cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed ||
-		cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed ||
-		cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed ||
-		cmd.Flags().Lookup(cli.FlagOperatorMySQL).Changed ||
-		namespacesAddCfg.SkipWizard)
-
-	if askOperators {
+	if cli.ShouldAskOperators(cmd, namespacesAddCfg.SkipWizard) {
 		// need to ask user to provide operators to be installed in interactive mode.
 		if err := namespacesAddCfg.PopulateOperators(cmd.Context()); err != nil {
 			output.PrintError(err, logger.GetLogger(), namespacesAddCfg.Pretty)

--- a/commands/skip_wizard_test.go
+++ b/commands/skip_wizard_test.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/percona/everest/pkg/cli"
+	"github.com/percona/everest/pkg/common"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func newSkipWizardTestCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String(cli.FlagNamespaces, common.DefaultDBNamespaceName, "Comma-separated namespaces list")
+	cmd.Flags().Bool(cli.FlagOperatorMongoDB, true, "Install MongoDB operator")
+	cmd.Flags().Bool(cli.FlagOperatorPostgresql, true, "Install PostgreSQL operator")
+	cmd.Flags().Bool(cli.FlagOperatorXtraDBCluster, true, "Install XtraDB Cluster operator")
+	cmd.Flags().Bool(cli.FlagOperatorMySQL, true, "Install MySQL operator")
+	return cmd
+}
+
+func TestShouldAskNamespaces(t *testing.T) {
+	t.Parallel()
+
+	cmd := newSkipWizardTestCommand()
+	assert.True(t, shouldAskNamespaces(cmd, false), "should ask namespaces when skip-wizard is disabled and namespaces flag was not explicitly set")
+	assert.False(t, shouldAskNamespaces(cmd, true), "should not ask namespaces when skip-wizard is enabled")
+
+	assert.NoError(t, cmd.Flags().Set(cli.FlagNamespaces, "custom-ns"))
+	assert.False(t, shouldAskNamespaces(cmd, false), "should not ask namespaces when namespaces flag is explicitly set")
+}
+
+func TestShouldAskOperators(t *testing.T) {
+	t.Parallel()
+
+	cmd := newSkipWizardTestCommand()
+	assert.True(t, cli.ShouldAskOperators(cmd, false), "should ask operators when skip-wizard is disabled and no operator flag was explicitly set")
+	assert.False(t, cli.ShouldAskOperators(cmd, true), "should not ask operators when skip-wizard is enabled")
+
+	assert.NoError(t, cmd.Flags().Set(cli.FlagOperatorMongoDB, "false"))
+	assert.False(t, cli.ShouldAskOperators(cmd, false), "should not ask operators when any operator flag was explicitly set")
+}

--- a/pkg/cli/interactive.go
+++ b/pkg/cli/interactive.go
@@ -1,0 +1,28 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cli contains interactive CLI helpers.
+package cli
+
+import "github.com/spf13/cobra"
+
+// ShouldAskOperators determines if the CLI should prompt for operator selection.
+// It returns true if skipWizard is false and no operator flags were explicitly set.
+func ShouldAskOperators(cmd *cobra.Command, skipWizard bool) bool {
+	return !skipWizard && !(cmd.Flags().Lookup(FlagOperatorMongoDB).Changed ||
+		cmd.Flags().Lookup(FlagOperatorPostgresql).Changed ||
+		cmd.Flags().Lookup(FlagOperatorXtraDBCluster).Changed ||
+		cmd.Flags().Lookup(FlagOperatorMySQL).Changed)
+}


### PR DESCRIPTION
This PR refactors the CLI codebase to remove duplicated shouldAskOperators logic and centralize the decision-making for operator prompts under a shared implementation. This improves maintainability and ensures consistent behavior across all command paths that support --skip-wizard.

Changes Made:
Introduced a shared implementation of shouldAskOperators in the CLI layer
Replaced duplicated inline logic in:
commands/install.go
commands/namespaces/add.go
Ensured both install and namespace flows use the same prompt decision logic
Removed redundant local implementations to avoid drift between command behaviors.

Fixes #2176 