### PR TITLE
feat(ui): expose spec.proxy.config in Advanced Configuration (#2093)

### DIFF
--- a/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration-schema.ts
+++ b/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration-schema.ts
@@ -38,6 +38,8 @@ export const advancedConfigurationsSchema = () =>
       ),
       [AdvancedConfigurationFields.engineParametersEnabled]: z.boolean(),
       [AdvancedConfigurationFields.engineParameters]: z.string().optional(),
+      [AdvancedConfigurationFields.proxyParametersEnabled]: z.boolean(),
+      [AdvancedConfigurationFields.proxyParameters]: z.string().optional(),
       [AdvancedConfigurationFields.podSchedulingPolicyEnabled]: z.boolean(),
       [AdvancedConfigurationFields.podSchedulingPolicy]: z.string().optional(),
       [AdvancedConfigurationFields.loadBalancerConfigName]: z

--- a/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.tsx
+++ b/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.tsx
@@ -29,7 +29,10 @@ import {
 import { ProxyExposeType } from 'shared-types/dbCluster.types';
 import { useFormContext } from 'react-hook-form';
 import { DbEngineType, DbType } from '@percona/types';
-import { getParamsPlaceholderFromDbType } from './advanced-configuration.utils';
+import {
+  getParamsPlaceholderFromDbType,
+  getProxyParamsPlaceholderFromDbType,
+} from './advanced-configuration.utils';
 import {
   Box,
   FormGroup,
@@ -64,6 +67,7 @@ import ToggableFormCard from 'components/toggable-form-card';
 interface AdvancedConfigurationFormProps {
   dbType: DbType;
   showSplitHorizonDNS: boolean;
+  showProxyConfig?: boolean;
   loadingDefaultsForEdition?: boolean;
   automaticallyTogglePodSchedulingPolicySwitch?: boolean;
   allowedFieldsToInitiallyLoadDefaults?: AllowedFieldsToInitiallyLoadDefaults[];
@@ -81,6 +85,7 @@ export const AdvancedConfigurationForm = ({
   activePolicy,
   namespace,
   showSplitHorizonDNS,
+  showProxyConfig = true,
 }: AdvancedConfigurationFormProps) => {
   const { watch, setValue, getFieldState, getValues, trigger } =
     useFormContext();
@@ -96,11 +101,13 @@ export const AdvancedConfigurationForm = ({
   >(null);
   const [
     engineParametersEnabled,
+    proxyParametersEnabled,
     policiesEnabled,
     exposureMethod,
     splitHorizonDNSEnabled,
   ] = watch([
     AdvancedConfigurationFields.engineParametersEnabled,
+    AdvancedConfigurationFields.proxyParametersEnabled,
     AdvancedConfigurationFields.podSchedulingPolicyEnabled,
     AdvancedConfigurationFields.exposureMethod,
     AdvancedConfigurationFields.splitHorizonDNSEnabled,
@@ -591,6 +598,32 @@ export const AdvancedConfigurationForm = ({
           />
         }
       />
+      {showProxyConfig && (
+        <FormCard
+          title={Messages.cards.proxyParameters.title(dbType)}
+          description={Messages.cards.proxyParameters.description}
+          cardContent={
+            <Stack>
+              {proxyParametersEnabled && (
+                <TextInput
+                  name={AdvancedConfigurationFields.proxyParameters}
+                  textFieldProps={{
+                    placeholder: getProxyParamsPlaceholderFromDbType(dbType),
+                    multiline: true,
+                    minRows: 3,
+                  }}
+                />
+              )}
+            </Stack>
+          }
+          controlComponent={
+            <SwitchInput
+              label={Messages.enable}
+              name={AdvancedConfigurationFields.proxyParametersEnabled}
+            />
+          }
+        />
+      )}
       {policyDialogOpen && (
         <PoliciesDialog
           engineType={selectedPolicy.current!.spec.engineType}

--- a/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.types.ts
+++ b/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.types.ts
@@ -19,6 +19,8 @@ export enum AdvancedConfigurationFields {
   sourceRanges = 'sourceRanges',
   engineParametersEnabled = 'engineParametersEnabled',
   engineParameters = 'engineParameters',
+  proxyParametersEnabled = 'proxyParametersEnabled',
+  proxyParameters = 'proxyParameters',
   storageClass = 'storageClass',
   podSchedulingPolicyEnabled = 'podSchedulingPolicyEnabled',
   podSchedulingPolicy = 'podSchedulingPolicy',

--- a/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.utils.ts
+++ b/ui/apps/everest/src/components/cluster-form/advanced-configuration/advanced-configuration.utils.ts
@@ -40,6 +40,18 @@ export const getParamsPlaceholderFromDbType = (dbType: DbType) => {
   return dynamicText;
 };
 
+export const getProxyParamsPlaceholderFromDbType = (dbType: DbType) => {
+  switch (dbType) {
+    case DbType.Mongo:
+      return 'net:\n  port: 27017\n  bindIp: 0.0.0.0';
+    case DbType.Mysql:
+      return '[haproxy]\nbind-address=0.0.0.0\nmaxconn=1024';
+    case DbType.Postresql:
+    default:
+      return '[databases]\n*=host=localhost port=5432\n[pgbouncer]\nmax_client_conn=100\npool_mode=transaction';
+  }
+};
+
 export const mapDeprecatedExposeType = (
   type: string | undefined
 ): ProxyExposeType => {
@@ -74,6 +86,10 @@ export const advancedConfigurationModalDefaultValues = (
       !!dbCluster?.spec?.engine?.config,
     [AdvancedConfigurationFields.engineParameters]:
       dbCluster?.spec?.engine?.config,
+    [AdvancedConfigurationFields.proxyParametersEnabled]:
+      !!dbCluster?.spec?.proxy?.config,
+    [AdvancedConfigurationFields.proxyParameters]:
+      dbCluster?.spec?.proxy?.config,
     [AdvancedConfigurationFields.sourceRanges]: sourceRangesSource
       ? sourceRangesSource.map((sourceRange) => ({ sourceRange }))
       : [{ sourceRange: '' }],

--- a/ui/apps/everest/src/components/cluster-form/advanced-configuration/messages.ts
+++ b/ui/apps/everest/src/components/cluster-form/advanced-configuration/messages.ts
@@ -57,6 +57,15 @@ export const Messages = {
       description:
         'Set your database engine configuration to adjust your database system to your workload and performance needs. For configuration format and specific parameters, check your database type documentation.',
     },
+    proxyParameters: {
+      title: (dbType: string) => {
+        if (dbType === 'mysql') return 'Proxy Configuration';
+        if (dbType === 'postgresql') return 'PG Bouncer Configuration';
+        return 'Router Configuration';
+      },
+      description:
+        'Set your proxy configuration to tune connection handling and routing behavior. For configuration format and specific parameters, check your proxy type documentation.',
+    },
     splitHorizonDNS: {
       title: 'Split-Horizon DNS',
       description:

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/advanced-configurations/advanced-configurations.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/advanced-configurations/advanced-configurations.tsx
@@ -16,6 +16,7 @@
 import { useFormContext } from 'react-hook-form';
 import { Messages } from './advanced-configurations.messages.ts';
 
+import { DbType } from '@percona/types';
 import { DbWizardFormFields } from 'consts.ts';
 import { StepHeader } from '../step-header/step-header.tsx';
 import AdvancedConfigurationForm from 'components/cluster-form/advanced-configuration/advanced-configuration.tsx';
@@ -29,7 +30,10 @@ export const AdvancedConfigurations = ({
   loadingDefaultsForEdition,
 }: StepProps) => {
   const { watch, getValues } = useFormContext();
-  const dbType = watch(DbWizardFormFields.dbType);
+  const [dbType, sharding] = watch([
+    DbWizardFormFields.dbType,
+    DbWizardFormFields.sharding,
+  ]);
   const namespace = getValues(DbWizardFormFields.k8sNamespace);
   const mode = useDatabasePageMode();
   const allowedFieldsToInitiallyLoadDefaults: AllowedFieldsToInitiallyLoadDefaults[] =
@@ -58,6 +62,7 @@ export const AdvancedConfigurations = ({
         }
         namespace={namespace}
         showSplitHorizonDNS={!getValues(DbWizardFormFields.sharding)}
+        showProxyConfig={dbType !== DbType.Mongo || !!sharding}
       />
     </>
   );

--- a/ui/apps/everest/src/pages/database-form/database-preview/sections/advanced-configurations-section.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-preview/sections/advanced-configurations-section.tsx
@@ -8,6 +8,7 @@ export const AdvancedConfigurationsPreviewSection = ({
   loadBalancerConfigName,
   engineParametersEnabled,
   engineParameters,
+  proxyParametersEnabled,
   storageClass,
   podSchedulingPolicyEnabled,
   podSchedulingPolicy,
@@ -30,6 +31,9 @@ export const AdvancedConfigurationsPreviewSection = ({
       )}
       {engineParametersEnabled && engineParameters && (
         <PreviewContentText text="Database engine parameters set" />
+      )}
+      {proxyParametersEnabled && (
+        <PreviewContentText text="Proxy parameters set" />
       )}
       {podSchedulingPolicyEnabled && podSchedulingPolicy && (
         <PreviewContentText

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/card.types.ts
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/card.types.ts
@@ -45,6 +45,7 @@ export type ConnectionDetailsOverviewCardProps = {
 export type AdvancedConfigurationOverviewCardProps = {
   externalAccess: boolean;
   parameters: boolean;
+  proxyParameters: boolean;
   storageClass: string;
   podSchedulingPolicy?: string;
   loadBalancerConfig?: string;

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/advanced-configuration/advanced-configuration.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/advanced-configuration/advanced-configuration.tsx
@@ -38,6 +38,7 @@ export const AdvancedConfiguration = ({
   loading,
   externalAccess,
   parameters,
+  proxyParameters,
   storageClass,
   podSchedulingPolicy,
   loadBalancerConfig,
@@ -79,6 +80,8 @@ export const AdvancedConfiguration = ({
     sourceRanges,
     engineParametersEnabled,
     engineParameters,
+    proxyParametersEnabled,
+    proxyParameters,
     podSchedulingPolicyEnabled,
     podSchedulingPolicy,
     exposureMethod,
@@ -96,7 +99,9 @@ export const AdvancedConfiguration = ({
         podSchedulingPolicyEnabled,
         podSchedulingPolicy,
         loadBalancerConfigName,
-        splitHorizonDNS
+        splitHorizonDNS,
+        proxyParametersEnabled,
+        proxyParameters
       )
     );
   };
@@ -129,6 +134,12 @@ export const AdvancedConfiguration = ({
         label={Messages.fields.parameters}
         content={
           parameters ? Messages.fields.enabled : Messages.fields.disabled
+        }
+      />
+      <OverviewSectionRow
+        label={Messages.fields.proxyParameters}
+        content={
+          proxyParameters ? Messages.fields.enabled : Messages.fields.disabled
         }
       />
       <OverviewSectionRow

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/advanced-configuration/edit-advanced-configuration/edit-advanced-configuration.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/advanced-configuration/edit-advanced-configuration/edit-advanced-configuration.tsx
@@ -22,6 +22,7 @@ import {
   advancedConfigurationsSchema,
 } from 'components/cluster-form/advanced-configuration/advanced-configuration-schema';
 import { Messages } from './edit-advanced-configuration.messages';
+import { DbType } from '@percona/types';
 import { dbEngineToDbType } from '@percona/utils';
 import { advancedConfigurationModalDefaultValues } from 'components/cluster-form/advanced-configuration/advanced-configuration.utils';
 import { EMPTY_LOAD_BALANCER_CONFIGURATION } from 'consts';
@@ -40,6 +41,8 @@ export const AdvancedConfigurationEditModal = ({
     exposureMethod,
     engineParametersEnabled,
     engineParameters,
+    proxyParametersEnabled,
+    proxyParameters,
     sourceRanges,
     storageClass,
     podSchedulingPolicyEnabled,
@@ -51,6 +54,8 @@ export const AdvancedConfigurationEditModal = ({
     handleSubmitModal({
       engineParametersEnabled,
       engineParameters,
+      proxyParametersEnabled,
+      proxyParameters,
       sourceRanges,
       storageClass,
       podSchedulingPolicyEnabled,
@@ -101,6 +106,10 @@ export const AdvancedConfigurationEditModal = ({
         activePolicy={dbCluster?.spec.podSchedulingPolicyName}
         namespace={dbCluster?.metadata.namespace}
         showSplitHorizonDNS={false}
+        showProxyConfig={
+          dbEngineToDbType(dbCluster?.spec?.engine?.type) !== DbType.Mongo ||
+          !!dbCluster?.spec?.sharding?.enabled
+        }
       />
     </FormDialog>
   );

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/db-details.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/db-details.tsx
@@ -41,6 +41,7 @@ export const DbDetails = ({
   monitoring,
   externalAccess,
   parameters,
+  proxyParameters,
   storageClass,
   podSchedulingPolicy,
   loadBalancerConfig,
@@ -100,6 +101,7 @@ export const DbDetails = ({
         <AdvancedConfiguration
           externalAccess={externalAccess}
           parameters={parameters}
+          proxyParameters={proxyParameters}
           storageClass={storageClass}
           podSchedulingPolicy={podSchedulingPolicy}
           loadBalancerConfig={loadBalancerConfig}

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cluster-overview.messages.ts
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cluster-overview.messages.ts
@@ -41,6 +41,7 @@ export const Messages = {
     status: 'Status',
     externalAccess: 'Ext.access',
     parameters: 'Parameters',
+    proxyParameters: 'Proxy parameters',
     enabled: 'Enabled',
     disabled: 'Disabled',
     noSchedules: '0 active schedules',

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cluster-overview.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cluster-overview.tsx
@@ -103,6 +103,7 @@ export const ClusterOverview = () => {
           exposeType={dbCluster.spec.proxy?.expose?.type}
           monitoring={dbCluster?.spec.monitoring?.monitoringConfigName}
           parameters={!!dbCluster?.spec.engine.config}
+          proxyParameters={!!dbCluster?.spec.proxy?.config}
           storageClass={dbCluster?.spec.engine.storage.class!}
           podSchedulingPolicy={dbCluster?.spec.podSchedulingPolicyName}
           splitHorizonDNS={

--- a/ui/apps/everest/src/shared-types/dbCluster.types.ts
+++ b/ui/apps/everest/src/shared-types/dbCluster.types.ts
@@ -90,6 +90,7 @@ export interface Proxy {
   expose: ProxyExposeConfig;
   resources?: Resources;
   type: ProxyType;
+  config?: string;
 }
 
 export interface DataImporter {

--- a/ui/apps/everest/src/utils/db.tsx
+++ b/ui/apps/everest/src/utils/db.tsx
@@ -763,7 +763,9 @@ export const changeDbClusterAdvancedConfig = (
   podSchedulingPolicyEnabled = false,
   podSchedulingPolicy = '',
   loadBalancerConfigName = '',
-  splitHorizonDnsConfigName = ''
+  splitHorizonDnsConfigName = '',
+  proxyParametersEnabled = false,
+  proxyParameters = ''
 ) => ({
   ...dbCluster,
   spec: {
@@ -786,6 +788,7 @@ export const changeDbClusterAdvancedConfig = (
     },
     proxy: {
       ...dbCluster.spec.proxy,
+      config: proxyParametersEnabled ? proxyParameters : '',
       expose: {
         loadBalancerConfigName:
           (exposureMethod === ProxyExposeType.LoadBalancer &&


### PR DESCRIPTION
## What

Implements [#2093](https://github.com/openeverest/openeverest/issues/2093) — exposes `spec.proxy.config` in the Advanced Configuration step of the database wizard and the cluster overview edit modal.

## Why

Plugin developers and advanced users need a way to tune proxy behavior (connection pooling for PGBouncer, routing rules for mongos, HAProxy tuning for PXC) without dropping to `kubectl patch`. The engine parameters card already provides this pattern for the database engine; this PR extends it to the proxy layer using the same UX.

## Changes

### Core type and schema
- `shared-types/dbCluster.types.ts` — add `config?: string` to the `Proxy` interface
- `advanced-configuration.types.ts` — add `proxyParametersEnabled` / `proxyParameters` to `AdvancedConfigurationFields`
- `advanced-configuration-schema.ts` — add both fields to the Zod schema

### Form component (`components/cluster-form/advanced-configuration/`)
- `messages.ts` — DB-type-specific card titles: **Router Configuration** (PSMDB), **PG Bouncer Configuration** (PostgreSQL), **Proxy Configuration** (PXC)
- `advanced-configuration.utils.ts` — add `getProxyParamsPlaceholderFromDbType()` with realistic placeholder text per DB type; read `spec.proxy.config` into form defaults in `advancedConfigurationModalDefaultValues`
- `advanced-configuration.tsx` — add `showProxyConfig` prop (default `true`); watch `proxyParametersEnabled`; render the proxy config toggle + textarea card, gated by `showProxyConfig`

### Sharding gate
The proxy config card is hidden for PSMDB when sharding is disabled (`showProxyConfig={dbType !== DbType.Mongo || !!sharding}`), because the mongos router only exists in sharded clusters. PG and PXC always show the card.

### Write path
- `utils/db.tsx` — `changeDbClusterAdvancedConfig` receives `proxyParametersEnabled` and `proxyParameters` and writes `proxy.config` (cleared to `''` when disabled)

### Cluster overview
- `card.types.ts` — add `proxyParameters: boolean` to `AdvancedConfigurationOverviewCardProps`
- `cluster-overview.messages.ts` — add `proxyParameters: 'Proxy parameters'` label
- `cluster-overview/cards/db-details/advanced-configuration/advanced-configuration.tsx` — add **Proxy parameters** row; update `handleSubmit` to forward both new fields
- `cluster-overview.tsx` + `db-details.tsx` — pass `proxyParameters={!!dbCluster?.spec.proxy?.config}` through the tree

### Wizard preview and edit modal
- `advanced-configurations-section.tsx` — show "Proxy parameters set" line in the wizard summary preview
- `advanced-configurations.tsx` (wizard step) — pass `showProxyConfig` based on `DbWizardFormFields.sharding`
- `edit-advanced-configuration.tsx` — destructure and forward both new fields in `onSubmit`; pass `showProxyConfig` based on `dbCluster.spec.sharding?.enabled`

## Screenshots

> Note: Screenshots cannot be captured in this environment as `node_modules` are not installed locally. The UI renders a new **"Router / PG Bouncer / Proxy Configuration"** card in the Advanced Configuration step, identical in layout to the existing "Set database engine parameters" card — a toggle switch on the right and a multiline textarea that appears when enabled.
>
> **Before:** Advanced Configuration step has one engine parameters card at the bottom.
> **After:** A second proxy parameters card appears below it (hidden for standalone PSMDB without sharding).

## Testing

- [ ] Wizard (New DB) — proxy config card visible for PG and MySQL; hidden for standalone Mongo; visible for sharded Mongo
- [ ] Cluster overview — Proxy parameters row shows Enabled/Disabled correctly
- [ ] Edit modal — toggling the switch and saving writes `spec.proxy.config`; disabling clears it
- [ ] Wizard preview panel — "Proxy parameters set" appears when enabled

## Checklist

- [x] Copyright headers present on all modified files (all were pre-existing files with headers)
- [x] Commit signed off (`-s`) with DCO
- [x] No new external dependencies introduced
- [x] Follows existing form pattern (mirrors engine parameters card exactly)
