### PR TITLE
feat: expose backupJobResources in DatabaseClusterBackup API

### DIFF
--- a/api/everest-server.gen.go
+++ b/api/everest-server.gen.go
@@ -1110,6 +1110,16 @@ type DatabaseClusterBackup struct {
 		// The BackupStorage must be created in the same namespace as the DatabaseCluster.
 		BackupStorageName string `json:"backupStorageName"`
 
+		// BackupJobResources defines resource limits for the backup job container.
+		// If not set, operator defaults are used (600m CPU, 1G memory).
+		BackupJobResources *struct {
+			// Cpu CPU is the CPU resource requirements
+			Cpu *string `json:"cpu,omitempty"`
+
+			// Memory Memory is the memory resource requirements
+			Memory *string `json:"memory,omitempty"`
+		} `json:"backupJobResources,omitempty"`
+
 		// DbClusterName DBClusterName is the original database cluster name.
 		DbClusterName string `json:"dbClusterName"`
 	} `json:"spec,omitempty"`

--- a/docs/spec/openapi.yml
+++ b/docs/spec/openapi.yml
@@ -4100,6 +4100,26 @@ components:
             dbClusterName:
               description: DBClusterName is the original database cluster name.
               type: string
+            backupJobResources:
+              description: |-
+                BackupJobResources defines resource limits for the backup job container.
+                If not set, operator defaults are used (600m CPU, 1G memory).
+              properties:
+                cpu:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: CPU is the CPU resource requirements
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                memory:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: Memory is the memory resource requirements
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              type: object
           required:
             - backupStorageName
             - dbClusterName

--- a/go.mod
+++ b/go.mod
@@ -441,3 +441,5 @@ tool (
 	helm.sh/helm/v3/cmd/helm
 	mvdan.cc/gofumpt
 )
+
+replace github.com/percona/everest-operator => ../everest-operator

--- a/internal/server/handlers/validation/database_cluster_backup.go
+++ b/internal/server/handlers/validation/database_cluster_backup.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"context"
+	"errors"
 
 	everestv1alpha1 "github.com/percona/everest-operator/api/everest/v1alpha1"
 	"github.com/percona/everest/api"
@@ -12,7 +13,24 @@ func (h *validateHandler) ListDatabaseClusterBackups(ctx context.Context, namesp
 }
 
 func (h *validateHandler) CreateDatabaseClusterBackup(ctx context.Context, req *everestv1alpha1.DatabaseClusterBackup) (*everestv1alpha1.DatabaseClusterBackup, error) {
+	if err := validateBackupJobResources(req); err != nil {
+		return nil, errors.Join(ErrInvalidRequest, err)
+	}
 	return h.next.CreateDatabaseClusterBackup(ctx, req)
+}
+
+func validateBackupJobResources(req *everestv1alpha1.DatabaseClusterBackup) error {
+	res := req.Spec.BackupJobResources
+	if res == nil {
+		return nil
+	}
+	if !res.CPU.IsZero() && res.CPU.Sign() < 0 {
+		return errors.New("backupJobResources.cpu must be a positive quantity")
+	}
+	if !res.Memory.IsZero() && res.Memory.Sign() < 0 {
+		return errors.New("backupJobResources.memory must be a positive quantity")
+	}
+	return nil
 }
 
 func (h *validateHandler) DeleteDatabaseClusterBackup(ctx context.Context, namespace, name string, req *api.DeleteDatabaseClusterBackupParams) error {


### PR DESCRIPTION
Allows users to set CPU and memory limits on the backup job container. The default 600m CPU is too low for large 1TB+ database backups.

Fixes #1905