### PR TITLE
feat: improve backup card empty state with direct tab navigation

### DIFF
--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/old-cards/backups-details.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/old-cards/backups-details.tsx
@@ -22,11 +22,12 @@ import { BackupsDetailsOverviewCardProps } from './card.types';
 import OverviewSectionRow from '../overview-section-row';
 import { Messages } from '../cluster-overview.messages';
 import { Button, Stack } from '@mui/material';
-// import { Link, useMatch } from 'react-router-dom';
-// import { DBClusterDetailsTabs } from '../../db-cluster-details.types';
+import { Link, useMatch } from 'react-router-dom';
+import { DBClusterDetailsTabs } from '../../db-cluster-details.types';
 import OverviewSectionText from '../overview-section-text/overview-section-text';
 import { getTimeSelectionPreviewMessage } from '../../../database-form/database-preview/database.preview.messages';
 import { getFormValuesFromCronExpression } from '../../../../components/time-selection/time-selection.utils';
+
 // import { useDbBackups, useUpdateDbClusterWithConflictRetry } from 'hooks';
 // import { Table } from '@percona/ui-lib';
 // import { Backup, BackupStatus } from 'shared-types/backups.types';
@@ -51,7 +52,7 @@ export const BackupsDetails = ({
   loading,
   showStorage = true,
 }: BackupsDetailsOverviewCardProps) => {
-  // const { canUpdateDb, dbCluster } = useContext(DbClusterContext);
+  const routeMatch = useMatch('/databases/:namespace/:instanceName/:tabs');
   // const editable =
   //   canUpdateDb && !shouldDbActionsBeBlocked(dbCluster?.status?.status);
 
@@ -137,9 +138,9 @@ export const BackupsDetails = ({
         avatar: <NetworkNodeIcon />,
         action: (
           <Button
-            // component={Link}
+            component={Link}
             size="small"
-            // to={`/databases/${routeMatch?.params?.namespace}/${routeMatch?.params?.dbClusterName}/${DBClusterDetailsTabs.backups}`}
+            to={`/databases/${routeMatch?.params?.namespace}/${routeMatch?.params?.instanceName}/${DBClusterDetailsTabs.backups}`}
           >
             {Messages.actions.details}
           </Button>

--- a/ui/apps/everest/src/pages/db-cluster-details/db-cluster-details.types.ts
+++ b/ui/apps/everest/src/pages/db-cluster-details/db-cluster-details.types.ts
@@ -14,9 +14,10 @@
 
 export enum DBClusterDetailsTabs {
   overview = 'overview',
+  backups = 'backups',
   // TODO: Re-enable once connected to the new instance API
   // components = 'components',
-  // backups = 'backups',
   // restores = 'restores',
   // logs = 'logs',
 }
+

--- a/ui/apps/everest/src/router/router.tsx
+++ b/ui/apps/everest/src/router/router.tsx
@@ -19,7 +19,7 @@ import { DBClusterDetailsTabs } from 'pages/db-cluster-details/db-cluster-detail
 import { SettingsTabs } from 'pages/settings/settings.types';
 import { DbInstanceContextProvider } from 'pages/db-cluster-details/dbCluster.context';
 import {
-  // Backups,
+  Backups,
   InstanceOverview,
   // Components,
   DatabasePage,
@@ -88,10 +88,10 @@ const router = createBrowserRouter([
             index: true,
             element: <Navigate to={DBClusterDetailsTabs.overview} replace />,
           },
-          // {
-          //   path: DBClusterDetailsTabs.backups,
-          //   element: withSuspense(<Backups />),
-          // },
+          {
+            path: DBClusterDetailsTabs.backups,
+            element: withSuspense(<Backups />),
+          },
           {
             path: DBClusterDetailsTabs.overview,
             element: withSuspense(<InstanceOverview />),


### PR DESCRIPTION
Re-enable the Backups tab (DBClusterDetailsTabs.backups) and its router entry so the details page is reachable again. Wire the 'Details' button in BackupsDetails overview card to navigate directly to the backups tab using Link + useMatch, eliminating the dead no-op button that was left when backups were temporarily commented out.

- Add backups = 'backups' to DBClusterDetailsTabs enum
- Uncomment Backups import and route in router.tsx
- Replace placeholder Button with Link-based navigation in Ba## Summary
- Fixes #2185 - the "Details" button in the Backups overview card was a dead no-op that didn't navigate anywhere, leaving users stranded on the overview tab with no way to reach the Backups section.
- 
- ## Changes
- - Re-enable `backups = 'backups'` in `DBClusterDetailsTabs` enum
- - Uncomment the `Backups` component import and its route entry in `router.tsx`
- - Replace the placeholder <Button> in `BackupsDetails` card with a `Link`-based button using `useMatch` to build the correct /databases/:namespace/:instanceName/backups URL
- 
- ## Testing
- 1. Open any database cluster detail page
- 2. On the Overview tab, the Backups card now shows a working "Details" link
- 3. Clicking it navigates to the Backups tab (/databases/<ns>/<name>/backups)ckupsDetails
- Use useMatch('/databases/:namespace/:instanceName/:tabs') for params

Closes #2185