### PR TITLE
fix: add unsubscribe to prevent stale observers in v2

### DIFF
--- a/ui/apps/everest/src/hooks/rbac/rbac.ts
+++ b/ui/apps/everest/src/hooks/rbac/rbac.ts
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useNamespaces } from 'hooks/api/namespaces';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -105,6 +119,7 @@ export const useNamespacePermissionsForResource = (
   useEffect(() => {
     AuthorizerObservable.subscribe(checkPermissions);
     checkPermissions();
+    return () => AuthorizerObservable.unsubscribe(checkPermissions);
   }, [checkPermissions]);
 
   return {


### PR DESCRIPTION
Cherry-pick of #2166 into v2 so the RBAC observer cleanup fix is not lost during the migration.

Adds the missing unsubscribe cleanup in `useNamespacePermissionsForResource` to prevent stale callbacks from accumulating across re-renders/unmounts.