### PR TITLE
Chore/fix field id generation

### DIFF
--- a/ui/apps/everest/src/components/ui-generator/utils/component-renderer/render-component.tsx
+++ b/ui/apps/everest/src/components/ui-generator/utils/component-renderer/render-component.tsx
@@ -47,7 +47,7 @@ export const renderComponent = ({
       (item as ComponentGroup).components,
       (item as ComponentGroup).componentsOrder
     ).map(([childKey, childItem]) => {
-      const childFieldName = `${fieldName}.${childKey}`;
+      const childFieldName = fieldName ? `${fieldName}.${childKey}` : childKey;
       return (
         <React.Fragment key={childFieldName}>
           {renderComponent({


### PR DESCRIPTION
As discussed in #2232, the field path generation in the UI generator could produce malformed paths when components were nested in pathless groups.

This PR implements a safe path join that ensures the dot separator is only added when a parent path exists.

Closes #2232