### PR TITLE
fix(ui): complete local logout when DELETE /session fails

### DIFF
--- a/ui/apps/everest/src/contexts/auth/auth.provider.tsx
+++ b/ui/apps/everest/src/contexts/auth/auth.provider.tsx
@@ -98,7 +98,21 @@ const AuthProvider = ({ children, isSsoEnabled }: AuthProviderProps) => {
 
   const logout = async () => {
     const token = localStorage.getItem('everestToken');
-    await api.delete('/session', { headers: { token: token } });
+    removeApiErrorInterceptor();
+
+    if (token) {
+      try {
+        await api.delete('/session', {
+          headers: { token },
+        });
+      } catch {
+        enqueueSnackbar(
+          'Signed out on this device, but the server did not end your session. If others use this machine, change your password when you can.',
+          { variant: 'warning' }
+        );
+      }
+    }
+
     if (isSsoEnabled) {
       await userManager.clearStaleState();
       await setLogoutStatus();
@@ -108,7 +122,6 @@ const AuthProvider = ({ children, isSsoEnabled }: AuthProviderProps) => {
     localStorage.removeItem('everestToken');
     sessionStorage.clear();
     setRedirect(null);
-    removeApiErrorInterceptor();
     removeApiAuthInterceptor();
   };
 


### PR DESCRIPTION
Ensures local logout completes when `DELETE /session` fails; removes the error interceptor before revoke and warns if server session could not be ended.

Closes  #2236 