### PR TITLE
fix(ui): prevent UI generator from producing invalid field paths

### DIFF
--- a/ui/apps/everest/src/components/ui-generator/utils/component-renderer/render-component.tsx
+++ b/ui/apps/everest/src/components/ui-generator/utils/component-renderer/render-component.tsx
@@ -47,7 +47,7 @@ export const renderComponent = ({
       (item as ComponentGroup).components,
       (item as ComponentGroup).componentsOrder
     ).map(([childKey, childItem]) => {
-      const childFieldName = `${fieldName}.${childKey}`;
+      const childFieldName = fieldName ? `${fieldName}.${childKey}` : childKey;
       return (
         <React.Fragment key={childFieldName}>
           {renderComponent({


### PR DESCRIPTION
Fixes #2232 by avoiding leading dots when parent path is empty.
