### PR TITLE
fix(ui): complete local logout when DELETE /session fails

### DIFF
--- a/ui/apps/everest/src/contexts/auth/auth.provider.tsx
+++ b/ui/apps/everest/src/contexts/auth/auth.provider.tsx
@@ -98,7 +98,14 @@ const AuthProvider = ({ children, isSsoEnabled }: AuthProviderProps) => {
 
   const logout = async () => {
     const token = localStorage.getItem('everestToken');
-    await api.delete('/session', { headers: { token: token } });
+    try {
+      await api.delete('/session', { headers: { token: token } });
+    } catch (error) {
+      enqueueSnackbar(
+        'Server sign-out failed. Proceeding with local sign-out.',
+        { variant: 'warning' }
+      );
+    }
     if (isSsoEnabled) {
       await userManager.clearStaleState();
       await setLogoutStatus();


### PR DESCRIPTION
Fixes #2236 by wrapping the server session revoke call in a try/catch block. This ensures local token deletion and redirect occurs even if the server is unreachable or returns an error.