### PR TITLE
fix: stop RBAC polling loop on non-SSO logout

### DIFF
--- a/ui/apps/everest/src/contexts/auth/auth.provider.tsx
+++ b/ui/apps/everest/src/contexts/auth/auth.provider.tsx
@@ -112,10 +112,17 @@ const AuthProvider = ({ children, isSsoEnabled }: AuthProviderProps) => {
 
   const logout = async () => {
     const token = localStorage.getItem('everestToken');
-    await api.delete('/session', { headers: { token: token } });
+
+    try {
+      await api.delete('/session', { headers: { token: token } });
+    } catch {
+      // continue logout cleanup even if session deletion fails
+    }
+
     if (isSsoEnabled) {
       await userManager.clearStaleState();
     }
+
     await setLogoutStatus();
     sessionStorage.clear();
     setRedirect(null);

--- a/ui/apps/everest/src/contexts/auth/auth.provider.tsx
+++ b/ui/apps/everest/src/contexts/auth/auth.provider.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   AuthProvider as OidcAuthProvider,
@@ -101,11 +115,8 @@ const AuthProvider = ({ children, isSsoEnabled }: AuthProviderProps) => {
     await api.delete('/session', { headers: { token: token } });
     if (isSsoEnabled) {
       await userManager.clearStaleState();
-      await setLogoutStatus();
     }
-
-    setAuthStatus('loggedOut');
-    localStorage.removeItem('everestToken');
+    await setLogoutStatus();
     sessionStorage.clear();
     setRedirect(null);
     removeApiErrorInterceptor();


### PR DESCRIPTION
##  SUMMARY

This PR fixes a cleanup issue in the logout flow where the RBAC polling loop continued running after non-SSO logout. The issue caused repeated unauthenticated `/permissions` requests and unhandled promise rejections every 5 seconds after users logged out. 

The changes are focused in `ui/apps/everest/src/contexts/auth/auth.provider.tsx`, specifically around the `logout()` and `setLogoutStatus()` flow.

---

##  FIX

```ts 
//Before
if (isSsoEnabled) {
  await userManager.clearStaleState();
  await setLogoutStatus();
}

setAuthStatus('loggedOut');
localStorage.removeItem('everestToken');

//After
ts 
if (isSsoEnabled) {
  await userManager.clearStaleState();
}

await setLogoutStatus();
```
