### PR TITLE
fix(cli): replace http.DefaultClient with a timeout-aware client in version service

### DIFF
--- a/pkg/version_service/client.go
+++ b/pkg/version_service/client.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/version_service/client.go
+++ b/pkg/version_service/client.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package versionservice provides an interface for the Perocona version service.
+// Package versionservice provides an interface for the Percona version service.
 package versionservice
 
 import (
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"time"
 
 	perconavs "github.com/Percona-Lab/percona-version-service/versionpb"
 	goversion "github.com/hashicorp/go-version"
@@ -58,13 +59,19 @@ type Interface interface {
 	GetEverestMetadata(ctx context.Context) (*perconavs.MetadataResponse, error)
 }
 
+const defaultHTTPTimeout = 30 * time.Second
+
 type versionServiceClient struct {
-	url string
+	url        string
+	httpClient *http.Client
 }
 
 // New returns a new version service client.
 func New(url string) Interface { //nolint:ireturn
-	return &versionServiceClient{url: url}
+	return &versionServiceClient{
+		url:        url,
+		httpClient: &http.Client{Timeout: defaultHTTPTimeout},
+	}
 }
 
 //nolint:gochecknoglobals
@@ -86,7 +93,7 @@ func (c *versionServiceClient) GetSupportedEngineVersions(ctx context.Context, o
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not create version service request"))
 	}
-	res, err := http.DefaultClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not retrieve version response"))
 	}
@@ -147,7 +154,7 @@ func (c *versionServiceClient) GetEverestMetadata(ctx context.Context) (*percona
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not create Everest metadata request"))
 	}
-	res, err := http.DefaultClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not retrieve Everest metadata"))
 	}

--- a/pkg/version_service/client_test.go
+++ b/pkg/version_service/client_test.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/version_service/client_test.go
+++ b/pkg/version_service/client_test.go
@@ -1,0 +1,87 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versionservice
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// slowServer returns a test server that delays every response by the given duration.
+func slowServer(delay time.Duration) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(delay)
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func TestNew_HasTimeout(t *testing.T) {
+	t.Parallel()
+	c := New("http://example.com").(*versionServiceClient)
+	if c.httpClient == nil {
+		t.Fatal("httpClient must not be nil")
+	}
+	if c.httpClient.Timeout != defaultHTTPTimeout {
+		t.Fatalf("expected timeout %v, got %v", defaultHTTPTimeout, c.httpClient.Timeout)
+	}
+}
+
+func TestGetEverestMetadata_RespectsClientTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Server responds slower than the client timeout we set below.
+	srv := slowServer(200 * time.Millisecond)
+	defer srv.Close()
+
+	// Create a client whose HTTP timeout is shorter than the server delay.
+	c := &versionServiceClient{
+		url:        srv.URL,
+		httpClient: &http.Client{Timeout: 50 * time.Millisecond},
+	}
+
+	_, err := c.GetEverestMetadata(context.Background())
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	// The error wraps a context deadline / timeout error from net/http.
+	if !strings.Contains(err.Error(), "could not retrieve Everest metadata") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+func TestGetSupportedEngineVersions_RespectsClientTimeout(t *testing.T) {
+	t.Parallel()
+
+	srv := slowServer(200 * time.Millisecond)
+	defer srv.Close()
+
+	c := &versionServiceClient{
+		url:        srv.URL,
+		httpClient: &http.Client{Timeout: 50 * time.Millisecond},
+	}
+
+	_, err := c.GetSupportedEngineVersions(context.Background(), PXCOperatorName, "1.0.0")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "could not retrieve version response") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2247

- `GetSupportedEngineVersions` and `GetEverestMetadata` both used `http.DefaultClient` (Timeout: 0). If the version service endpoint is slow or unreachable during `everestctl install` / `everestctl upgrade`, the CLI hung indefinitely with no error.
- Adds a dedicated `*http.Client` with a 30-second timeout to `versionServiceClient`, initialized in `New()`.
- Fixes a typo in the package doc comment: `"Perocona"` → `"Percona"`.
- Adds `client_test.go` with unit tests using `httptest.Server` to verify the timeout fires for both methods.

## Changes

| File | Change |
|------|--------|
| `pkg/version_service/client.go` | Add `httpClient *http.Client` field; initialize with 30s timeout in `New()`; replace both `http.DefaultClient.Do` calls |
| `pkg/version_service/client_test.go` | New — tests that `New()` sets the timeout and that slow servers are rejected within the deadline |

## Test plan

- [ ] `go test ./pkg/version_service/... -v` — all three new tests pass
  - `TestNew_HasTimeout` — asserts `New()` sets `defaultHTTPTimeout`
  - `TestGetEverestMetadata_RespectsClientTimeout` — slow httptest server, 50 ms client timeout → error returned
  - `TestGetSupportedEngineVersions_RespectsClientTimeout` — same pattern for engine versions endpoint
- [ ] `go build ./...` — no compilation errors
- [ ] Existing CI passes