### PR TITLE
fix(cli): correct exported function name CheckEverestAlreadyInstalled

### DIFF
--- a/commands/install.go
+++ b/commands/install.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,7 +91,7 @@ func installPreRun(cmd *cobra.Command, _ []string) { //nolint:revive
 	installCfg.NamespaceAddConfig.KubeconfigPath = rootCmdFlags.KubeconfigPath
 
 	// Check if Everest is already installed.
-	if err := install.CheckEverestAlreadyinstalled(cmd.Context(), logger.GetLogger(), installCfg.KubeconfigPath); err != nil {
+	if err := install.CheckEverestAlreadyInstalled(cmd.Context(), logger.GetLogger(), installCfg.KubeconfigPath); err != nil {
 		output.PrintError(err, logger.GetLogger(), installCfg.Pretty)
 		os.Exit(1)
 	}

--- a/pkg/cli/install/install.go
+++ b/pkg/cli/install/install.go
@@ -392,8 +392,8 @@ func (o *Installer) namespaceExists(ctx context.Context, namespace string) (bool
 	return true, nil
 }
 
-// CheckEverestAlreadyinstalled checks if Everest is already installed.
-func CheckEverestAlreadyinstalled(ctx context.Context, l *zap.SugaredLogger, kubeConfig string) error {
+// CheckEverestAlreadyInstalled checks if Everest is already installed.
+func CheckEverestAlreadyInstalled(ctx context.Context, l *zap.SugaredLogger, kubeConfig string) error {
 	kubeClient, err := cliutils.NewKubeConnector(l, kubeConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)


### PR DESCRIPTION
## Summary

Fixes #2249

The exported function `CheckEverestAlreadyinstalled` had a lowercase `'i'` in `Installed`, violating Go's CamelCase convention for exported identifiers. `golint` flags this as:

```
pkg/cli/install/install.go:396:6: exported function CheckEverestAlreadyinstalled should be CheckEverestAlreadyInstalled
```

## Changes

| File | Change |
|------|--------|
| `pkg/cli/install/install.go` | Rename `CheckEverestAlreadyinstalled` → `CheckEverestAlreadyInstalled` (function + doc comment) |
| `commands/install.go` | Update the single call site; add missing OpenEverest copyright line |

## Before / After

**Before**
```go
// pkg/cli/install/install.go
func CheckEverestAlreadyinstalled(ctx context.Context, l *zap.SugaredLogger, kubeConfig string) error {

// commands/install.go
if err := install.CheckEverestAlreadyinstalled(cmd.Context(), logger.GetLogger(), installCfg.KubeconfigPath); err != nil {
```

**After**
```go
// pkg/cli/install/install.go
func CheckEverestAlreadyInstalled(ctx context.Context, l *zap.SugaredLogger, kubeConfig string) error {

// commands/install.go
if err := install.CheckEverestAlreadyInstalled(cmd.Context(), logger.GetLogger(), installCfg.KubeconfigPath); err != nil {
```

## Test plan

- [x] `go build ./commands/... ./pkg/cli/install/...` — compiles cleanly
- [ ] Existing CI passes