### PR TITLE
fix(ui): truncate long text values in Database Summary preview

### DIFF
--- a/ui/apps/everest/src/pages/database-form/database-preview/database-preview.types.ts
+++ b/ui/apps/everest/src/pages/database-form/database-preview/database-preview.types.ts
@@ -38,3 +38,9 @@ export type PreviewContentTextProps = {
   text: string;
   dataTestId?: string;
 } & TypographyProps;
+
+export type TruncatedPreviewTextProps = {
+  text: string;
+  dataTestId?: string;
+  maxLines?: number;
+} & Omit<TypographyProps, 'children'>;

--- a/ui/apps/everest/src/pages/database-form/database-preview/database.preview.messages.ts
+++ b/ui/apps/everest/src/pages/database-form/database-preview/database.preview.messages.ts
@@ -22,6 +22,8 @@ import { addZeroToSingleDigit } from 'components/time-selection/time-selection.u
 
 export const Messages = {
   title: 'Database Summary',
+  showMore: 'Show more',
+  showLess: 'Show less',
 };
 
 export const getTimeSelectionPreviewMessage = ({

--- a/ui/apps/everest/src/pages/database-form/database-preview/preview-section.test.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-preview/preview-section.test.tsx
@@ -1,6 +1,6 @@
 import { screen, render, fireEvent } from '@testing-library/react';
 import { TestWrapper } from 'utils/test';
-import { PreviewSection } from './preview-section';
+import { PreviewSection, TruncatedPreviewText } from './preview-section';
 
 describe('PreviewSection', () => {
   it('should show order number and title', () => {
@@ -93,5 +93,247 @@ describe('PreviewSection', () => {
 
     fireEvent.click(screen.getByTestId('edit-section-2'));
     expect(cb).toHaveBeenCalled();
+  });
+});
+
+describe('TruncatedPreviewText', () => {
+  let originalResizeObserver: typeof ResizeObserver | undefined;
+
+  beforeAll(() => {
+    originalResizeObserver = global.ResizeObserver;
+    // Mock ResizeObserver
+    class ResizeObserverMock implements ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    global.ResizeObserver = ResizeObserverMock;
+  });
+
+  afterAll(() => {
+    if (originalResizeObserver !== undefined) {
+      global.ResizeObserver = originalResizeObserver;
+    } else {
+      Reflect.deleteProperty(global, 'ResizeObserver');
+    }
+  });
+
+  it('should render the provided text', () => {
+    render(
+      <TestWrapper>
+        <TruncatedPreviewText text="Short value" dataTestId="test" />
+      </TestWrapper>
+    );
+
+    expect(
+      screen.getByTestId('test-preview-content')
+    ).toHaveTextContent('Short value');
+  });
+
+  it('should use default test id when dataTestId is not provided', () => {
+    render(
+      <TestWrapper>
+        <TruncatedPreviewText text="Some text" />
+      </TestWrapper>
+    );
+
+    expect(screen.getByTestId('preview-content')).toBeInTheDocument();
+    expect(screen.getByTestId('truncated-wrapper')).toBeInTheDocument();
+  });
+
+  it('should use custom test ids when dataTestId is provided', () => {
+    render(
+      <TestWrapper>
+        <TruncatedPreviewText text="Some text" dataTestId="engine" />
+      </TestWrapper>
+    );
+
+    expect(screen.getByTestId('engine-preview-content')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('engine-truncated-wrapper')
+    ).toBeInTheDocument();
+  });
+
+  it('should toggle expanded state when clicking the toggle', () => {
+    // Mock scrollHeight to simulate overflow
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollHeight'
+    );
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return 100;
+      },
+    });
+    const originalClientHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'clientHeight'
+    );
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return 20;
+      },
+    });
+
+    render(
+      <TestWrapper>
+        <TruncatedPreviewText
+          text="A very long text that should overflow"
+          dataTestId="test"
+        />
+      </TestWrapper>
+    );
+
+    const toggle = screen.getByTestId('test-truncated-toggle');
+
+    // Initially collapsed
+    expect(toggle).toHaveTextContent('Show more');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    // Click to expand
+    fireEvent.click(toggle);
+    expect(toggle).toHaveTextContent('Show less');
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    // Click to collapse again
+    fireEvent.click(toggle);
+    expect(toggle).toHaveTextContent('Show more');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    // Restore original property descriptors
+    if (originalScrollHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'scrollHeight',
+        originalScrollHeight
+      );
+    }
+    if (originalClientHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'clientHeight',
+        originalClientHeight
+      );
+    }
+  });
+
+  it('should not render toggle when text does not overflow', () => {
+    // Mock scrollHeight equal to clientHeight to simulate no overflow
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollHeight'
+    );
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return 20;
+      },
+    });
+    const originalClientHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'clientHeight'
+    );
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return 20;
+      },
+    });
+
+    render(
+      <TestWrapper>
+        <TruncatedPreviewText text="Short" dataTestId="test" />
+      </TestWrapper>
+    );
+
+    expect(
+      screen.queryByTestId('test-truncated-toggle')
+    ).not.toBeInTheDocument();
+
+    // Restore original property descriptors
+    if (originalScrollHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'scrollHeight',
+        originalScrollHeight
+      );
+    }
+    if (originalClientHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'clientHeight',
+        originalClientHeight
+      );
+    }
+  });
+
+  it('should reset expanded state when text prop changes', () => {
+    // Mock scrollHeight > clientHeight
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollHeight'
+    );
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return 100;
+      },
+    });
+    const originalClientHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'clientHeight'
+    );
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return 20;
+      },
+    });
+
+    const { rerender } = render(
+      <TestWrapper>
+        <TruncatedPreviewText
+          text="Initial long text"
+          dataTestId="reset-test"
+        />
+      </TestWrapper>
+    );
+
+    const toggle = screen.getByTestId('reset-test-truncated-toggle');
+
+    // Expand
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    // Re-render with new text
+    rerender(
+      <TestWrapper>
+        <TruncatedPreviewText text="New long text" dataTestId="reset-test" />
+      </TestWrapper>
+    );
+
+    // Should be collapsed again
+    expect(screen.getByTestId('reset-test-truncated-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+
+    // Restore mocks
+    if (originalScrollHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'scrollHeight',
+        originalScrollHeight
+      );
+    }
+    if (originalClientHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'clientHeight',
+        originalClientHeight
+      );
+    }
   });
 });

--- a/ui/apps/everest/src/pages/database-form/database-preview/preview-section.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-preview/preview-section.tsx
@@ -1,12 +1,15 @@
+import { useLayoutEffect, useRef, useState } from 'react';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import { IconButton, Stack, Typography, useTheme } from '@mui/material';
+import { IconButton, Link, Stack, Typography, useTheme } from '@mui/material';
 import { useActiveBreakpoint } from 'hooks/utils/useActiveBreakpoint';
 import {
   PreviewContentTextProps,
   PreviewSectionProps,
+  TruncatedPreviewTextProps,
 } from './database-preview.types';
 import { kebabize } from '@percona/utils';
+import { Messages } from './database.preview.messages';
 
 export const PreviewSection = ({
   title,
@@ -113,3 +116,99 @@ export const PreviewContentText = ({
     {text}
   </Typography>
 );
+
+export const TruncatedPreviewText = ({
+  text,
+  dataTestId,
+  maxLines = 2,
+  ...typographyProps
+}: TruncatedPreviewTextProps) => {
+  const [expanded, setExpanded] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const textRef = useRef<HTMLSpanElement>(null);
+  const testId = dataTestId
+    ? `${dataTestId}-preview-content`
+    : 'preview-content';
+
+  // Reset expanded state when text prop changes
+  useLayoutEffect(() => {
+    setExpanded(false);
+  }, [text]);
+
+  useLayoutEffect(() => {
+    const el = textRef.current;
+    if (!el) return;
+
+    const checkOverflow = () => {
+      // Compare scrollHeight to clientHeight to determine if text overflows
+      setIsOverflowing(el.scrollHeight > el.clientHeight);
+    };
+
+    // Initial check
+    checkOverflow();
+
+    // Re-check on dimension changes
+    let observer: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(checkOverflow);
+      observer.observe(el);
+    }
+
+    return () => {
+      if (observer) {
+        observer.disconnect();
+      }
+    };
+  }, [text, maxLines]);
+
+  return (
+    <Stack
+      spacing={0}
+      data-testid={
+        dataTestId
+          ? `${dataTestId}-truncated-wrapper`
+          : 'truncated-wrapper'
+      }
+    >
+      <Typography
+        ref={textRef}
+        variant="caption"
+        color="text.secondary"
+        data-testid={testId}
+        sx={{
+          ...(!expanded && {
+            display: '-webkit-box',
+            WebkitLineClamp: maxLines,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }),
+          wordBreak: 'break-word',
+          whiteSpace: 'pre-wrap',
+        }}
+        {...typographyProps}
+      >
+        {text}
+      </Typography>
+      {isOverflowing && (
+        <Link
+          component="button"
+          variant="caption"
+          onClick={() => setExpanded((prev) => !prev)}
+          aria-expanded={expanded}
+          data-testid={
+            dataTestId
+              ? `${dataTestId}-truncated-toggle`
+              : 'truncated-toggle'
+          }
+          sx={{
+            alignSelf: 'flex-start',
+            cursor: 'pointer',
+            mt: 0.25,
+          }}
+        >
+          {expanded ? Messages.showLess : Messages.showMore}
+        </Link>
+      )}
+    </Stack>
+  );
+};

--- a/ui/apps/everest/src/pages/database-form/database-preview/sections/advanced-configurations-section.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-preview/sections/advanced-configurations-section.tsx
@@ -1,4 +1,4 @@
-import { PreviewContentText } from '../preview-section';
+import { PreviewContentText, TruncatedPreviewText } from '../preview-section';
 import { AdvancedConfigurationType } from '../../database-form-schema.ts';
 import { ProxyExposeType } from 'shared-types/dbCluster.types';
 import { EMPTY_LOAD_BALANCER_CONFIGURATION } from 'consts.ts';
@@ -29,7 +29,10 @@ export const AdvancedConfigurationsPreviewSection = ({
         />
       )}
       {engineParametersEnabled && engineParameters && (
-        <PreviewContentText text="Database engine parameters set" />
+        <TruncatedPreviewText
+          text={`Engine parameters: ${engineParameters}`}
+          dataTestId="engine-parameters"
+        />
       )}
       {podSchedulingPolicyEnabled && podSchedulingPolicy && (
         <PreviewContentText


### PR DESCRIPTION
## Summary

This PR improves the Database Summary preview experience by adding safe truncation support for long preview values.

Previously, very long configuration values could overflow the preview layout and negatively impact readability. This change introduces a reusable truncation component with expandable preview behavior while preserving accessibility and responsive behavior.

## Changes

### Added `TruncatedPreviewText`
- Introduced a reusable `TruncatedPreviewText` component for handling long preview values
- Supports configurable line clamping
- Preserves formatting using `whiteSpace: 'pre-wrap'`
- Handles long unbroken strings safely with `wordBreak: 'break-word'`

### Expand / Collapse Behavior
- Added inline `Show more` / `Show less` toggle behavior
- Used accessible button semantics via MUI `Link component="button"`
- Added `aria-expanded` support for accessibility

### Responsive Overflow Detection
- Implemented dynamic overflow recalculation using `ResizeObserver`
- Correctly updates truncation state during:
  - window resizing
  - layout/container width changes
  - responsive UI shifts

### State Handling Improvements
- Reset expanded state whenever preview text changes
- Prevents stale expanded state when preview content updates dynamically

### Testing
Added unit tests covering:
- rendering behavior
- overflow detection
- expand/collapse interactions
- responsive recalculation behavior
- expanded state reset behavior
- custom/default test IDs

## Validation

```bash
pnpm test
pnpm --filter @percona/everest lint-check
```

## Closes
#2035 
