### PR TITLE
feat(ui): operator upgrade phase tracking and batch resolution

### DIFF
--- a/ui/apps/everest/src/hooks/api/db-engines/index.ts
+++ b/ui/apps/everest/src/hooks/api/db-engines/index.ts
@@ -1,1 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from './useDbEngines';
+export * from './useOperatorUpgradePhase';
+export * from './useBatchResolvePendingActions';

--- a/ui/apps/everest/src/hooks/api/db-engines/useBatchResolvePendingActions.ts
+++ b/ui/apps/everest/src/hooks/api/db-engines/useBatchResolvePendingActions.ts
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { enqueueSnackbar } from 'notistack';
+import semverCoerce from 'semver/functions/coerce';
+import { DbCluster } from 'shared-types/dbCluster.types';
+import { OperatorUpgradePendingAction } from 'shared-types/dbEngines.types';
+import { changeDbClusterEngine, setDbClusterRestart } from 'utils/db';
+import { updateDbCluster } from 'hooks/api/db-cluster/useUpdateDbCluster';
+import { DB_CLUSTERS_QUERY_KEY } from 'hooks/api/db-clusters/useDbClusters';
+
+const extractVersionFromMessage = (message: string): string | undefined => {
+  for (const part of message.split(' ')) {
+    if (semverCoerce(part, { includePrerelease: true })) return part;
+  }
+  return undefined;
+};
+
+export const useBatchResolvePendingActions = (
+  namespace: string,
+  dbClusters: DbCluster[],
+  actionable: OperatorUpgradePendingAction[]
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => {
+      const mutations = actionable
+        .map((action) => {
+          const cluster = dbClusters.find(
+            (c) => c.metadata.name === action.name
+          );
+          if (!cluster) return null;
+
+          if (action.pendingTask === 'restart') {
+            return updateDbCluster(setDbClusterRestart(cluster));
+          }
+
+          if (action.pendingTask === 'upgradeEngine') {
+            const version = extractVersionFromMessage(action.message);
+            if (!version) return null;
+            return updateDbCluster(changeDbClusterEngine(cluster, version));
+          }
+
+          return null;
+        })
+        .filter((p): p is Promise<DbCluster> => p !== null);
+
+      return Promise.allSettled(mutations);
+    },
+    onSuccess: (results) => {
+      const failed = results.filter((r) => r.status === 'rejected').length;
+      const succeeded = results.length - failed;
+
+      queryClient.invalidateQueries({
+        queryKey: [DB_CLUSTERS_QUERY_KEY, namespace],
+      });
+
+      if (failed > 0) {
+        enqueueSnackbar(
+          `${succeeded} cluster(s) updated. ${failed} could not be updated — retry individually.`,
+          { variant: 'warning' }
+        );
+      }
+    },
+    onError: () => {
+      enqueueSnackbar('Failed to apply pending actions.', { variant: 'error' });
+    },
+  });
+};

--- a/ui/apps/everest/src/hooks/api/db-engines/useOperatorUpgradePhase.ts
+++ b/ui/apps/everest/src/hooks/api/db-engines/useOperatorUpgradePhase.ts
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useMemo } from 'react';
+import {
+  DbEngine,
+  DbEngineStatus,
+  OperatorUpgradePendingAction,
+} from 'shared-types/dbEngines.types';
+import { UseOperatorsUpgradePlanType } from './useDbEngines';
+
+export type OperatorUpgradePhase =
+  | { phase: 'idle' }
+  | {
+      phase: 'operator-upgrading';
+      startedAt: string;
+      targetVersion: string;
+    }
+  | {
+      phase: 'actions-required';
+      actionable: OperatorUpgradePendingAction[];
+      resolvedCount: number;
+      totalCount: number;
+    }
+  | { phase: 'error'; stuckClusters: string[] };
+
+export const useOperatorUpgradePhase = (
+  dbEngines: DbEngine[],
+  operatorsUpgradePlan: UseOperatorsUpgradePlanType | undefined
+): OperatorUpgradePhase => {
+  return useMemo(() => {
+    const upgradingEngine = dbEngines.find(
+      (e) => e.status === DbEngineStatus.UPGRADING
+    );
+    if (upgradingEngine?.operatorUpgrade) {
+      return {
+        phase: 'operator-upgrading',
+        startedAt: upgradingEngine.operatorUpgrade.startedAt,
+        targetVersion: upgradingEngine.operatorUpgrade.targetVersion,
+      };
+    }
+
+    const pendingActions = operatorsUpgradePlan?.pendingActions ?? [];
+    const stuck = pendingActions.filter((a) => a.pendingTask === 'notReady');
+    if (stuck.length > 0) {
+      return { phase: 'error', stuckClusters: stuck.map((a) => a.name) };
+    }
+
+    const actionable = pendingActions.filter(
+      (a) => a.pendingTask === 'restart' || a.pendingTask === 'upgradeEngine'
+    );
+    if (actionable.length > 0) {
+      const totalCount = actionable.length;
+      const resolvedCount = pendingActions.filter(
+        (a) => a.pendingTask === 'ready'
+      ).length;
+      return {
+        phase: 'actions-required',
+        actionable,
+        resolvedCount,
+        totalCount,
+      };
+    }
+
+    return { phase: 'idle' };
+  }, [dbEngines, operatorsUpgradePlan]);
+};

--- a/ui/apps/everest/src/hooks/api/namespaces/useNamespaces.ts
+++ b/ui/apps/everest/src/hooks/api/namespaces/useNamespaces.ts
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,7 +48,9 @@ export const useDBEnginesForNamespaces = (
   const queries = namespaces.map<
     UseQueryOptions<DbEngine[], unknown, DbEngine[]>
   >((namespace) => ({
-    queryKey: ['dbEngines-multi', namespace],
+    queryKey: retrieveUpgradingEngines
+      ? ['dbEngines-multi', namespace, 'with-upgrading']
+      : ['dbEngines-multi', namespace],
     // We don't use "select" here so that our cache saves data already formatted
     // Otherwise, every render from components cause "select" to be called, which means new values on every render
     queryFn: async () => {

--- a/ui/apps/everest/src/pages/settings/namespaces/OperatorCell.tsx
+++ b/ui/apps/everest/src/pages/settings/namespaces/OperatorCell.tsx
@@ -12,7 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Button, CircularProgress, Stack, Tooltip, Typography } from '@mui/material';
+import {
+  Button,
+  CircularProgress,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import { useRBACPermissions } from 'hooks/rbac';
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -20,7 +26,13 @@ import { NamespaceInstance } from 'shared-types/namespaces.types';
 
 export const OperatorCell = ({
   description,
-  namespaceInstance: { name, operators, upgradeAvailable, isUpgrading, pendingActions },
+  namespaceInstance: {
+    name,
+    operators,
+    upgradeAvailable,
+    isUpgrading,
+    pendingActions,
+  },
 }: {
   description: string;
   namespaceInstance: NamespaceInstance;
@@ -36,14 +48,20 @@ export const OperatorCell = ({
       (a) => a.pendingTask === 'restart' || a.pendingTask === 'upgradeEngine'
     ).length > 0;
 
-  const showUpgradeButton = (upgradeAvailable || somePendingTask) && canRead && !isUpgrading;
+  const showUpgradeButton =
+    (upgradeAvailable || somePendingTask) && canRead && !isUpgrading;
 
   return (
     <Stack direction="row" alignItems="center" width="100%">
       <Typography variant="body1">{description}</Typography>
       {isUpgrading && canRead && (
         <Tooltip title="Operator upgrade in progress">
-          <Stack direction="row" alignItems="center" gap={1} sx={{ ml: 'auto' }}>
+          <Stack
+            direction="row"
+            alignItems="center"
+            gap={1}
+            sx={{ ml: 'auto' }}
+          >
             <CircularProgress size={16} />
             <Typography variant="body2" color="text.secondary">
               Upgrading

--- a/ui/apps/everest/src/pages/settings/namespaces/OperatorCell.tsx
+++ b/ui/apps/everest/src/pages/settings/namespaces/OperatorCell.tsx
@@ -1,4 +1,18 @@
-import { Button, Stack, Typography } from '@mui/material';
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Button, CircularProgress, Stack, Tooltip, Typography } from '@mui/material';
 import { useRBACPermissions } from 'hooks/rbac';
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -6,7 +20,7 @@ import { NamespaceInstance } from 'shared-types/namespaces.types';
 
 export const OperatorCell = ({
   description,
-  namespaceInstance: { name, operators, upgradeAvailable, pendingActions },
+  namespaceInstance: { name, operators, upgradeAvailable, isUpgrading, pendingActions },
 }: {
   description: string;
   namespaceInstance: NamespaceInstance;
@@ -22,10 +36,22 @@ export const OperatorCell = ({
       (a) => a.pendingTask === 'restart' || a.pendingTask === 'upgradeEngine'
     ).length > 0;
 
+  const showUpgradeButton = (upgradeAvailable || somePendingTask) && canRead && !isUpgrading;
+
   return (
     <Stack direction="row" alignItems="center" width="100%">
       <Typography variant="body1">{description}</Typography>
-      {(upgradeAvailable || somePendingTask) && canRead && (
+      {isUpgrading && canRead && (
+        <Tooltip title="Operator upgrade in progress">
+          <Stack direction="row" alignItems="center" gap={1} sx={{ ml: 'auto' }}>
+            <CircularProgress size={16} />
+            <Typography variant="body2" color="text.secondary">
+              Upgrading
+            </Typography>
+          </Stack>
+        </Tooltip>
+      )}
+      {showUpgradeButton && (
         <Button
           onClick={() => navigate(`/settings/namespaces/${name}`)}
           sx={{ ml: 'auto' }}

--- a/ui/apps/everest/src/pages/settings/namespaces/namespace-details/cluster-status-table.tsx
+++ b/ui/apps/everest/src/pages/settings/namespaces/namespace-details/cluster-status-table.tsx
@@ -1,6 +1,20 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { MRT_ColumnDef } from 'material-react-table';
-import { Button } from '@mui/material';
+import { Box, Button, Chip } from '@mui/material';
 import { Table } from '@percona/ui-lib';
 import { beautifyDbTypeName, dbEngineToDbType } from '@percona/utils';
 import semverCoerce from 'semver/functions/coerce';
@@ -11,6 +25,7 @@ import {
 import { DbCluster, DbClusterStatus, Spec } from 'shared-types/dbCluster.types';
 import { ClusterStatusTableProps } from './types';
 import { useDbClusters } from 'hooks/api/db-clusters/useDbClusters';
+import { useBatchResolvePendingActions } from 'hooks/api/db-engines/useBatchResolvePendingActions';
 import { DB_CLUSTER_STATUS_TO_BASE_STATUS } from 'pages/databases/DbClusterView.constants';
 import { beautifyDbClusterStatus } from 'pages/databases/DbClusterView.utils';
 import StatusField from 'components/status-field';
@@ -25,6 +40,7 @@ const ClusterStatusTable = ({
   namespace,
   pendingActions,
   dbEngines,
+  upgradePhase,
 }: ClusterStatusTableProps) => {
   const dbNames = pendingActions.map((db) => db.name);
   const { data: dbClusters = [] } = useDbClusters(namespace, {
@@ -34,6 +50,10 @@ const ClusterStatusTable = ({
       ),
     enabled: !!namespace && !!pendingActions.length,
   });
+  const actionable =
+    upgradePhase.phase === 'actions-required' ? upgradePhase.actionable : [];
+  const { mutate: resolveAll, isPending: resolvingAll } =
+    useBatchResolvePendingActions(namespace, dbClusters, actionable);
   const [openUpdateCrDialog, setOpenUpdateCrDialog] = useState(false);
   const [openUpdateEngineDialog, setOpenUpdateEngineDialog] = useState(false);
   const selectedDbCluster = useRef<DbCluster>();
@@ -171,6 +191,17 @@ const ClusterStatusTable = ({
           const task = row.original.pendingTask;
           const message = cell.getValue<string>();
 
+          if (task === 'notReady') {
+            return (
+              <Chip
+                label={message || 'Not ready'}
+                color="error"
+                size="small"
+                variant="outlined"
+              />
+            );
+          }
+
           if (task === 'restart' || task === 'upgradeEngine') {
             return (
               <Button
@@ -200,6 +231,22 @@ const ClusterStatusTable = ({
         noDataMessage="No pending actions"
         columns={columns}
         data={enhancedDbList}
+        renderTopToolbarCustomActions={() =>
+          actionable.length > 0 ? (
+            <Box display="flex" alignItems="center">
+              <Button
+                variant="contained"
+                size="small"
+                onClick={() => resolveAll()}
+                disabled={resolvingAll || dbClusters.length === 0}
+              >
+                {resolvingAll
+                  ? 'Resolving...'
+                  : `Resolve All (${actionable.length})`}
+              </Button>
+            </Box>
+          ) : undefined
+        }
       />
       {selectedDbCluster.current && openUpdateCrDialog && (
         <UpdateCrDialog

--- a/ui/apps/everest/src/pages/settings/namespaces/namespace-details/namespace-details.tsx
+++ b/ui/apps/everest/src/pages/settings/namespaces/namespace-details/namespace-details.tsx
@@ -65,11 +65,13 @@ const NamespaceDetails = () => {
       },
       enabled: !!namespace && dbEngines.length > 0,
       refetchInterval:
-        anyEngineUpgrading || hasPendingActionsRef.current ? 2 * 1000 : 5 * 1000,
+        anyEngineUpgrading || hasPendingActionsRef.current
+          ? 2 * 1000
+          : 5 * 1000,
     });
-  hasPendingActionsRef.current = (operatorsUpgradePlan?.pendingActions || []).some(
-    (a) => a.pendingTask !== 'ready'
-  );
+  hasPendingActionsRef.current = (
+    operatorsUpgradePlan?.pendingActions || []
+  ).some((a) => a.pendingTask !== 'ready');
   const phase = useOperatorUpgradePhase(dbEngines, operatorsUpgradePlan);
   const operatorNamesWithUpgrades = useMemo(
     () =>

--- a/ui/apps/everest/src/pages/settings/namespaces/namespace-details/namespace-details.tsx
+++ b/ui/apps/everest/src/pages/settings/namespaces/namespace-details/namespace-details.tsx
@@ -1,4 +1,18 @@
-import { useMemo, useState } from 'react';
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 import BackNavigationText from 'components/back-navigation-text';
@@ -8,6 +22,8 @@ import {
   useOperatorUpgrade,
   useOperatorsUpgradePlan,
 } from 'hooks/api/db-engines';
+import { useOperatorUpgradePhase } from 'hooks/api/db-engines/useOperatorUpgradePhase';
+import { DbEngineStatus } from 'shared-types/dbEngines.types';
 import { useRBACPermissions } from 'hooks/rbac';
 import { NoMatch } from 'pages/404/NoMatch';
 import UpgradeHeader from './upgrade-header';
@@ -34,6 +50,12 @@ const NamespaceDetails = () => {
     },
     true
   );
+  const anyEngineUpgrading = dbEngines.some(
+    (e) => e.status === DbEngineStatus.UPGRADING
+  );
+  // Track previous pending-actions state to set a faster refetch interval
+  // without creating a circular dependency on the query result itself.
+  const hasPendingActionsRef = useRef(false);
   const { data: operatorsUpgradePlan, isLoading: loadingOperatorsUpgradePlan } =
     useOperatorsUpgradePlan(namespaceName, dbEngines, {
       initialData: {
@@ -42,8 +64,13 @@ const NamespaceDetails = () => {
         upToDate: [],
       },
       enabled: !!namespace && dbEngines.length > 0,
-      refetchInterval: 5 * 1000,
+      refetchInterval:
+        anyEngineUpgrading || hasPendingActionsRef.current ? 2 * 1000 : 5 * 1000,
     });
+  hasPendingActionsRef.current = (operatorsUpgradePlan?.pendingActions || []).some(
+    (a) => a.pendingTask !== 'ready'
+  );
+  const phase = useOperatorUpgradePhase(dbEngines, operatorsUpgradePlan);
   const operatorNamesWithUpgrades = useMemo(
     () =>
       (operatorsUpgradePlan?.upgrades || []).map(
@@ -100,12 +127,14 @@ const NamespaceDetails = () => {
             (action) => action.pendingTask !== 'ready'
           )
         }
+        upgradePhase={phase}
         mt={3}
       />
       <ClusterStatusTable
         namespace={namespaceName}
         pendingActions={operatorsUpgradePlan?.pendingActions || []}
         dbEngines={dbEngines}
+        upgradePhase={phase}
       />
       <UpgradeModal
         namespace={namespace}

--- a/ui/apps/everest/src/pages/settings/namespaces/namespace-details/types.ts
+++ b/ui/apps/everest/src/pages/settings/namespaces/namespace-details/types.ts
@@ -1,4 +1,19 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { BoxProps } from '@mui/material';
+import { OperatorUpgradePhase } from 'hooks/api/db-engines/useOperatorUpgradePhase';
 import { UseOperatorsUpgradePlanType } from 'hooks/api/db-engines';
 import {
   DbEngine,
@@ -11,12 +26,14 @@ export type UpgradeHeaderProps = {
   pendingUpgradeTasks: boolean;
   upgradeAllowed: boolean;
   onUpgrade: () => void;
+  upgradePhase: OperatorUpgradePhase;
 } & BoxProps;
 
 export type ClusterStatusTableProps = {
   namespace: string;
   pendingActions: OperatorUpgradePendingAction[];
   dbEngines: DbEngine[];
+  upgradePhase: OperatorUpgradePhase;
 };
 
 export type UpgradeModalProps = {

--- a/ui/apps/everest/src/pages/settings/namespaces/namespace-details/upgrade-header.tsx
+++ b/ui/apps/everest/src/pages/settings/namespaces/namespace-details/upgrade-header.tsx
@@ -1,4 +1,26 @@
-import { Box, Button, Typography } from '@mui/material';
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  LinearProgress,
+  Typography,
+} from '@mui/material';
+import { formatDistanceToNow } from 'date-fns';
 import { UpgradeHeaderProps } from './types';
 import { Messages } from './messages';
 
@@ -7,8 +29,68 @@ const UpgradeHeader = ({
   pendingUpgradeTasks,
   upgradeAllowed,
   onUpgrade,
+  upgradePhase,
   ...boxProps
 }: UpgradeHeaderProps) => {
+  if (upgradePhase.phase === 'operator-upgrading') {
+    const elapsed = formatDistanceToNow(new Date(upgradePhase.startedAt), {
+      addSuffix: true,
+    });
+    return (
+      <Box display="flex" alignItems="center" gap={2} {...boxProps}>
+        <CircularProgress size={20} />
+        <Typography variant="body1">
+          Upgrading operator to v{upgradePhase.targetVersion}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Started {elapsed}
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (upgradePhase.phase === 'actions-required') {
+    const { resolvedCount, totalCount } = upgradePhase;
+    const progress =
+      resolvedCount + totalCount > 0
+        ? (resolvedCount / (resolvedCount + totalCount)) * 100
+        : 0;
+    return (
+      <Box {...boxProps}>
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          alignItems="center"
+          mb={1}
+        >
+          <Typography variant="body1">
+            Operator upgraded — {totalCount} cluster
+            {totalCount !== 1 ? 's' : ''} require attention.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {resolvedCount} of {resolvedCount + totalCount} resolved
+          </Typography>
+        </Box>
+        <LinearProgress variant="determinate" value={progress} />
+      </Box>
+    );
+  }
+
+  if (upgradePhase.phase === 'error') {
+    const { stuckClusters } = upgradePhase;
+    return (
+      <Box {...boxProps}>
+        <Alert severity="error">
+          Upgrade incomplete:{' '}
+          <strong>{stuckClusters.join(', ')}</strong>{' '}
+          {stuckClusters.length === 1 ? 'is' : 'are'} not ready. Check the
+          database{stuckClusters.length !== 1 ? 's' : ''} and retry
+          individually.
+        </Alert>
+      </Box>
+    );
+  }
+
   if (!upgradeAvailable) {
     return null;
   }
@@ -23,7 +105,7 @@ const UpgradeHeader = ({
       <Typography variant="body1">
         A new version of the operators is available.
         {pendingUpgradeTasks
-          ? 'Start upgrading by performing all the pending tasks in the Actions column.'
+          ? ' Start upgrading by performing all the pending tasks in the Actions column.'
           : ''}
       </Typography>
       <Button

--- a/ui/apps/everest/src/pages/settings/namespaces/namespace-details/upgrade-header.tsx
+++ b/ui/apps/everest/src/pages/settings/namespaces/namespace-details/upgrade-header.tsx
@@ -81,8 +81,7 @@ const UpgradeHeader = ({
     return (
       <Box {...boxProps}>
         <Alert severity="error">
-          Upgrade incomplete:{' '}
-          <strong>{stuckClusters.join(', ')}</strong>{' '}
+          Upgrade incomplete: <strong>{stuckClusters.join(', ')}</strong>{' '}
           {stuckClusters.length === 1 ? 'is' : 'are'} not ready. Check the
           database{stuckClusters.length !== 1 ? 's' : ''} and retry
           individually.

--- a/ui/apps/everest/src/pages/settings/namespaces/namespaces.tsx
+++ b/ui/apps/everest/src/pages/settings/namespaces/namespaces.tsx
@@ -1,8 +1,23 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useMemo } from 'react';
 import { Table } from '@percona/ui-lib';
 import { Typography } from '@mui/material';
 import { MRT_ColumnDef } from 'material-react-table';
 import { useQueries } from '@tanstack/react-query';
+import { DbEngineStatus } from 'shared-types/dbEngines.types';
 import { NamespaceInstance } from 'shared-types/namespaces.types';
 import { useDBEnginesForNamespaces } from 'hooks/api/namespaces/useNamespaces';
 import { operatorUpgradePlanQueryFn } from 'hooks/api/db-engines';
@@ -12,16 +27,20 @@ import { useNamespacePermissionsForResource } from 'hooks/rbac';
 import EmptyStateNamespaces from 'components/empty-state-namespaces';
 
 export const Namespaces = () => {
-  const { results: rawDbEngines } = useDBEnginesForNamespaces();
+  const { results: rawDbEngines } = useDBEnginesForNamespaces(true);
   const dbEngines = rawDbEngines?.filter(
     (item) => item.data && item.data.length
   );
   const { canRead } = useNamespacePermissionsForResource('database-clusters');
+  const anyUpgrading = dbEngines.some((item) =>
+    (item.data || []).some((e) => e.status === DbEngineStatus.UPGRADING)
+  );
   const operatorsUpgradePlan = useQueries({
     queries: dbEngines.map((item) => ({
       queryKey: ['operatorUpgradePlan', item.namespace],
       queryFn: () =>
         operatorUpgradePlanQueryFn(item.namespace, item.data || []),
+      refetchInterval: anyUpgrading ? 2 * 1000 : 5 * 1000,
       enabled:
         dbEngines.every((result) => result.isSuccess) &&
         canRead.includes(item.namespace),
@@ -33,6 +52,9 @@ export const Namespaces = () => {
     upgradeAvailable: operatorsUpgradePlan[idx].isSuccess
       ? operatorsUpgradePlan[idx].data.upgrades.length > 0
       : false,
+    isUpgrading: (item.data || []).some(
+      (e) => e.status === DbEngineStatus.UPGRADING
+    ),
     operators: item.data?.map((engine) => engine.name) || [],
     pendingActions: operatorsUpgradePlan[idx].isSuccess
       ? operatorsUpgradePlan[idx].data.pendingActions

--- a/ui/apps/everest/src/shared-types/namespaces.types.ts
+++ b/ui/apps/everest/src/shared-types/namespaces.types.ts
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +20,7 @@ import { OperatorUpgradePendingAction } from './dbEngines.types';
 export interface NamespaceInstance {
   name: string;
   upgradeAvailable: boolean;
+  isUpgrading: boolean;
   operators: string[];
   pendingActions: OperatorUpgradePendingAction[];
   operatorsDescription: string;


### PR DESCRIPTION
## SUMMARY

This PR improves the operator upgrade workflow in Everest by adding centralized upgrade phase tracking and better upgrade state handling across namespace and cluster views. It also adds support for resolving multiple pending upgrade actions at once and improves upgrade visibility during long-running operations.

## FIX

* Added centralized operator upgrade phase handling
* Added batch resolve support for pending restart and upgrade actions
* Added upgrade progress and active upgrade indicators
* Added blocked/stuck upgrade state handling
* Improved namespace and cluster upgrade UI states
* Improved polling behavior during active upgrades
* Added namespace-level upgrade tracking with `isUpgrading`
