### PR TITLE
fix(cli): bind --helm.reuse-values to ReuseValues (fixes #2199)

### DIFF
--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -61,7 +61,7 @@ func init() {
 	upgradeCmd.Flags().StringVar(&upgradeCfg.RepoURL, helm.FlagRepository, helm.DefaultHelmRepoURL, "Helm chart repository to download the Everest charts from")
 	upgradeCmd.Flags().StringSliceVar(&upgradeCfg.Values.Values, helm.FlagHelmSet, []string{}, "Set helm values on the command line (can specify multiple values with commas: key1=val1,key2=val2)")
 	upgradeCmd.Flags().StringSliceVarP(&upgradeCfg.Values.ValueFiles, helm.FlagHelmValues, "f", []string{}, "Specify values in a YAML file or a URL (can specify multiple)")
-	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmReuseValues, false, "Reuse the last release's values and merge in any overrides from the command line via --helm.set and -f")
+	upgradeCmd.Flags().BoolVar(&upgradeCfg.ReuseValues, helm.FlagHelmReuseValues, false, "Reuse the last release's values and merge in any overrides from the command line via --helm.set and -f")
 	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetValues, helm.FlagHelmResetValues, false, "Reset the values to the ones built into the chart")
 	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmResetThenReuseValues, false, "Reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f.")
 }

--- a/commands/upgrade_test.go
+++ b/commands/upgrade_test.go
@@ -1,0 +1,62 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/percona/everest/pkg/cli/upgrade"
+)
+
+// TestUpgradeCmd_HelmValueFlagBindings guards the binding of the --helm.reuse-values
+// and --helm.reset-then-reuse-values flags to the Helm CLIOptions fields.
+// Regression test for #2199 where --helm.reuse-values was incorrectly bound to
+// ResetThenReuseValues, silently changing Helm upgrade precedence semantics.
+func TestUpgradeCmd_HelmValueFlagBindings(t *testing.T) {
+	tests := []struct {
+		name                     string
+		args                     []string
+		wantReuseValues          bool
+		wantResetThenReuseValues bool
+	}{
+		{
+			name:                     "--helm.reuse-values sets only ReuseValues",
+			args:                     []string{"--helm.reuse-values"},
+			wantReuseValues:          true,
+			wantResetThenReuseValues: false,
+		},
+		{
+			name:                     "--helm.reset-then-reuse-values sets only ResetThenReuseValues",
+			args:                     []string{"--helm.reset-then-reuse-values"},
+			wantReuseValues:          false,
+			wantResetThenReuseValues: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			*upgradeCfg = upgrade.Config{}
+
+			require.NoError(t, upgradeCmd.ParseFlags(tt.args))
+
+			assert.Equal(t, tt.wantReuseValues, upgradeCfg.ReuseValues, "ReuseValues")
+			assert.Equal(t, tt.wantResetThenReuseValues, upgradeCfg.ResetThenReuseValues, "ResetThenReuseValues")
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #2199: `--helm.reuse-values` was bound to `ResetThenReuseValues`, so users running `everestctl upgrade --helm.reuse-values` got `--reset-then-reuse-values` semantics instead — new chart defaults flowed in even though the user asked to pin the last release's values.
- One-line binding fix in `commands/upgrade.go`.
- Adds `commands/upgrade_test.go` regression guard that parses the flag and asserts only the intended `upgrade.Config` field is set. Mirror case for `--helm.reset-then-reuse-values` included.

## Why it matters
`ReuseValues` and `ResetThenReuseValues` have different precedence: the former ignores new chart defaults entirely, the latter pulls them in before overlaying the last release's values. The bug made `--helm.reuse-values` silently behave like its sibling, which matters on any upgrade where chart defaults change.

## Test plan
- [x] `go test ./commands/ -run TestUpgradeCmd_HelmValueFlagBindings` (verified via CI; local run blocked by disk space on my machine)
- [ ] CI green