### PR TITLE
fix: replace TEST_ROOT with REPO_ROOT in build-ui and deploy-all also make them quoted.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REPO_ROOT=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+REPO_ROOT=$(shell dirname "$(realpath $(firstword $(MAKEFILE_LIST)))")
 RELEASE_VERSION ?= v0.0.0-$(shell git rev-parse --short HEAD)
 RELEASE_FULLCOMMIT ?= $(shell git rev-parse HEAD)
 IMAGE_PREFIX ?= ghcr.io/openeverest
@@ -170,8 +170,8 @@ release-cli: ## Build Everest CLI release versions for different OS and ARCH. (U
 .PHONY: build-ui
 build-ui:
 	$(info Building Everest UI)
-	$(MAKE) -C ${TEST_ROOT}/ui init
-	$(MAKE) -C ${TEST_ROOT}/ui build EVEREST_OUT_DIR=${TEST_ROOT}/public/dist
+	$(MAKE) -C "$(REPO_ROOT)/ui" init
+	$(MAKE) -C "$(REPO_ROOT)/ui" build EVEREST_OUT_DIR="$(REPO_ROOT)/public/dist"
 
 .PHONY: docker-build
 docker-build: ## Build docker image with Everest API server.


### PR DESCRIPTION
## Summary

This PR fixes `make build-ui` and `make deploy-all` failing during local development.

The `build-ui` target previously used `TEST_ROOT`, which is not defined anywhere in the Makefile. As a result, Make expanded `${TEST_ROOT}/ui` to `/ui`, causing both `make build-ui` and `make deploy-all` (which depends on `build-ui`) to fail.

This PR replaces `TEST_ROOT` with the existing `REPO_ROOT` variable and quotes `REPO_ROOT` so paths resolve correctly when the repository is in a directory with spaces.

Closes: #2261 

## Problem
 TEST_ROOT is undefined, so Make treats it as empty and resolves the UI path to /ui instead of <repo-root>/ui.

On paths with spaces, REPO_ROOT itself could also be computed incorrectly because dirname and realpath were not quoted

## Changes

- Replace TEST_ROOT with REPO_ROOT in the build-ui target.
- Quote REPO_ROOT computation so dirname receives the full Makefile path as a single argument.
- Quote (REPO_ROOT)/ui and (REPO_ROOT)/public/dist in nested make -C invocations.

## Screenshots

### Before:

<img width="1496" height="899" alt="Screenshot 2026-05-18 at 6 29 14 PM" src="https://github.com/user-attachments/assets/a8ed4d6c-a8fe-4b4e-b149-2316568a5507" />

### After:

1. Running `make deploy-all`
<img width="1496" height="899" alt="Screenshot 2026-05-18 at 9 13 07 PM" src="https://github.com/user-attachments/assets/918e4fc4-bc68-422c-bd2a-c8e0366ff1f2" />

2. Running `make build-ui`
<img width="1496" height="899" alt="Screenshot 2026-05-18 at 8 51 10 PM" src="https://github.com/user-attachments/assets/bcb3c317-b721-4363-bbe8-970ea37c5d6c" />


