### PR TITLE
Update namespace filter

### DIFF
--- a/pkg/cli/namespaces/list.go
+++ b/pkg/cli/namespaces/list.go
@@ -39,24 +39,7 @@ import (
 // getSkipNamespaces returns a list of namespaces that cannot be added to Everest management.
 // It contains Kubernetes system, reserved by Everest core and cloud providers specific namespaces.
 func getSkipNamespaces(systemNamespace string) []string {
-	return []string{
-		// Kubernetes native system namespaces.
-		"kube-system",
-		"kube-public",
-		"kube-node-lease",
-
-		// Everest core namespaces.
-		systemNamespace,
-		common.MonitoringNamespace,
-		kubernetes.OLMNamespace,
-
-		// GKE namespaces.
-		"gke-managed-cim",
-		"gke-managed-system",
-		"gke-managed-volumepopulator",
-		"gmp-public",
-		"gmp-system",
-	}
+	return kubernetes.GetSystemNamespaces(systemNamespace)
 }
 
 type (

--- a/pkg/kubernetes/kubernetes_interface.gen.go
+++ b/pkg/kubernetes/kubernetes_interface.gen.go
@@ -235,6 +235,7 @@ type KubernetesConnector interface {
 	// GetNamespace returns a namespace that matches the criteria.
 	GetNamespace(ctx context.Context, key ctrlclient.ObjectKey) (*corev1.Namespace, error)
 	// GetDBNamespaces returns namespaces that can be used to manage databases.
+	// Filters out Kubernetes system namespaces, Everest core namespaces, and cloud provider-specific namespaces.
 	GetDBNamespaces(ctx context.Context, opts ...ctrlclient.ListOption) (*corev1.NamespaceList, error)
 	// DeleteNamespace deletes a namespace that matches the criteria.
 	DeleteNamespace(ctx context.Context, obj *corev1.Namespace) error

--- a/pkg/kubernetes/kubernetes_interface.gen.go
+++ b/pkg/kubernetes/kubernetes_interface.gen.go
@@ -234,7 +234,7 @@ type KubernetesConnector interface {
 	CreateNamespace(ctx context.Context, namespace *corev1.Namespace) (*corev1.Namespace, error)
 	// GetNamespace returns a namespace that matches the criteria.
 	GetNamespace(ctx context.Context, key ctrlclient.ObjectKey) (*corev1.Namespace, error)
-	// GetDBNamespaces returns a list of DB namespaces that managed by the Everest and match the criteria.
+	// GetDBNamespaces returns namespaces that can be used to manage databases.
 	GetDBNamespaces(ctx context.Context, opts ...ctrlclient.ListOption) (*corev1.NamespaceList, error)
 	// DeleteNamespace deletes a namespace that matches the criteria.
 	DeleteNamespace(ctx context.Context, obj *corev1.Namespace) error

--- a/pkg/kubernetes/namespace.go
+++ b/pkg/kubernetes/namespace.go
@@ -44,12 +44,11 @@ func (k *Kubernetes) GetNamespace(ctx context.Context, key ctrlclient.ObjectKey)
 	return result, nil
 }
 
-// GetDBNamespaces returns a list of DB namespaces that managed by the Everest and match the criteria.
+// GetDBNamespaces returns namespaces that can be used to manage databases.
 func (k *Kubernetes) GetDBNamespaces(ctx context.Context, opts ...ctrlclient.ListOption) (*corev1.NamespaceList, error) {
-	opts = append(opts, ctrlclient.MatchingLabels{common.KubernetesManagedByLabel: common.Everest})
 	result, err := k.ListNamespaces(ctx, opts...)
 	if err != nil {
-		return nil, errors.Join(err, errors.New("failed to get managed namespaces"))
+		return nil, errors.Join(err, errors.New("failed to get namespaces"))
 	}
 
 	internalNs := []string{k.Namespace(), common.MonitoringNamespace}

--- a/pkg/kubernetes/namespace.go
+++ b/pkg/kubernetes/namespace.go
@@ -27,6 +27,29 @@ import (
 	"github.com/openeverest/openeverest/v2/pkg/common"
 )
 
+// GetSystemNamespaces returns a list of namespaces that should be excluded from database operations.
+// It includes Kubernetes system namespaces, Everest core namespaces, and cloud provider-specific namespaces.
+func GetSystemNamespaces(systemNamespace string) []string {
+	return []string{
+		// Kubernetes native system namespaces.
+		"kube-system",
+		"kube-public",
+		"kube-node-lease",
+
+		// Everest core namespaces.
+		systemNamespace,
+		common.MonitoringNamespace,
+		OLMNamespace,
+
+		// GKE namespaces.
+		"gke-managed-cim",
+		"gke-managed-system",
+		"gke-managed-volumepopulator",
+		"gmp-public",
+		"gmp-system",
+	}
+}
+
 // CreateNamespace creates the given namespace.
 func (k *Kubernetes) CreateNamespace(ctx context.Context, namespace *corev1.Namespace) (*corev1.Namespace, error) {
 	if err := k.k8sClient.Create(ctx, namespace); err != nil {
@@ -45,16 +68,17 @@ func (k *Kubernetes) GetNamespace(ctx context.Context, key ctrlclient.ObjectKey)
 }
 
 // GetDBNamespaces returns namespaces that can be used to manage databases.
+// Filters out Kubernetes system namespaces, Everest core namespaces, and cloud provider-specific namespaces.
 func (k *Kubernetes) GetDBNamespaces(ctx context.Context, opts ...ctrlclient.ListOption) (*corev1.NamespaceList, error) {
 	result, err := k.ListNamespaces(ctx, opts...)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("failed to get namespaces"))
 	}
 
-	internalNs := []string{k.Namespace(), common.MonitoringNamespace}
-	// filter out Everest system and monitoring namespaces.
+	systemNamespaces := GetSystemNamespaces(k.Namespace())
+	// Filter out all system namespaces to prevent database operations in reserved namespaces.
 	result.Items = slices.DeleteFunc(result.Items, func(ns corev1.Namespace) bool {
-		return slices.Contains(internalNs, ns.Name)
+		return slices.Contains(systemNamespaces, ns.Name)
 	})
 	return result, nil
 }


### PR DESCRIPTION
This PR removes filter by everest managed label which was previously created by `everestctl`.

Namespaces API lists namespaces excluding kubernetes, cloud and everest system namespaces. 