### PR TITLE
Update backup storage API test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,9 +349,8 @@ deploy:  ## Deploy Everest to K8S cluster using Everest CLI.
 	--helm.set olm.catalogSourceImage=$(IMAGE_PREFIX)/$(EVEREST_CATALOG_DEV_IMAGE_NAME)
 	$(MAKE) expose
 
-DEPLOY_ALL_DEPS := build-ui build-debug docker-build k3d-upload-server-image
-DEPLOY_ALL_DEPS += docker-build-operator k3d-upload-operator-image
-DEPLOY_ALL_DEPS += k3d-upload-server-image deploy
+DEPLOY_ALL_DEPS := build-ui build-debug build-controller-debug docker-build
+DEPLOY_ALL_DEPS += k3d-upload-server-image k3d-upload-server-image deploy
 .PHONY: deploy-all
 deploy-all: $(DEPLOY_ALL_DEPS) ## Helper to build Everest and its dependencies and deploy to K3D test cluster.
 

--- a/api-tests/tests/backup-storage.spec.ts
+++ b/api-tests/tests/backup-storage.spec.ts
@@ -39,6 +39,8 @@ test.describe.parallel('Backup Storage V2 tests', () => {
         expect(backupStorage.spec.s3.bucket).toBe(payload.spec.s3.bucket)
         expect(backupStorage.spec.s3.region).toBe(payload.spec.s3.region)
         expect(backupStorage.spec.s3.endpointURL).toBe(payload.spec.s3.endpointURL)
+        expect(backupStorage.spec.s3.accessKeyId).toBeUndefined()
+        expect(backupStorage.spec.s3.secretAccessKey).toBeUndefined()
       });
 
       await test.step('get backup storage', async () => {
@@ -49,8 +51,8 @@ test.describe.parallel('Backup Storage V2 tests', () => {
         expect(backupStorage.spec.s3.region).toBe(payload.spec.s3.region)
         expect(backupStorage.spec.s3.endpointURL).toBe(payload.spec.s3.endpointURL)
         expect(backupStorage.spec.s3.credentialsSecretName).toBe(payload.spec.s3.credentialsSecretName)
-        expect(backupStorage.spec.s3.accessKeyId).toBe("")
-        expect(backupStorage.spec.s3.secretAccessKey).toBe("")
+        expect(backupStorage.spec.s3.accessKeyId).toBeUndefined()
+        expect(backupStorage.spec.s3.secretAccessKey).toBeUndefined()
         expect(backupStorage.spec.s3.forcePathStyle).toBe(payload.spec.s3.forcePathStyle)
         expect(backupStorage.spec.s3.verifyTLS).toBe(payload.spec.s3.verifyTLS)
       });
@@ -80,6 +82,30 @@ test.describe.parallel('Backup Storage V2 tests', () => {
           expect(backupStorage.spec.s3.bucket).toBe(updatePayload.spec.s3.bucket)
           expect(backupStorage.spec.s3.region).toBe(payload.spec.s3.region)
           expect(backupStorage.spec.type).toBe('s3')
+        }).toPass({
+          intervals: [1000],
+          timeout: 30 * 1000,
+        })
+      });
+
+      await test.step('patch backup storage', async () => {
+        const patchPayload = {
+          ...backupStorage,
+          spec: {
+            ...backupStorage.spec,
+            s3: {
+              ...backupStorage.spec.s3,
+              bucket: 'bucket-6',
+              accessKeyId: 'patchAccessKeyId',
+              secretAccessKey: 'patchSecretAccessKey',
+            },
+          },
+        }
+
+        await expect(async () => {
+          backupStorage = await th.patchBackupStorage(request, bsName, patchPayload)
+          expect(backupStorage.spec.s3.accessKeyId).toBeUndefined()
+          expect(backupStorage.spec.s3.secretAccessKey).toBeUndefined()
         }).toPass({
           intervals: [1000],
           timeout: 30 * 1000,

--- a/api-tests/tests/backup-storage.spec.ts
+++ b/api-tests/tests/backup-storage.spec.ts
@@ -46,6 +46,13 @@ test.describe.parallel('Backup Storage V2 tests', () => {
         expect(backupStorage.metadata.name).toBe(bsName)
         expect(backupStorage.spec.type).toBe('s3')
         expect(backupStorage.spec.s3.bucket).toBe(payload.spec.s3.bucket)
+        expect(backupStorage.spec.s3.region).toBe(payload.spec.s3.region)
+        expect(backupStorage.spec.s3.endpointURL).toBe(payload.spec.s3.endpointURL)
+        expect(backupStorage.spec.s3.credentialsSecretName).toBe(payload.spec.s3.credentialsSecretName)
+        expect(backupStorage.spec.s3.accessKeyId).toBe("")
+        expect(backupStorage.spec.s3.secretAccessKey).toBe("")
+        expect(backupStorage.spec.s3.forcePathStyle).toBe(payload.spec.s3.forcePathStyle)
+        expect(backupStorage.spec.s3.verifyTLS).toBe(payload.spec.s3.verifyTLS)
       });
 
       await test.step('list backup storages', async () => {

--- a/api-tests/tests/utils/api.ts
+++ b/api-tests/tests/utils/api.ts
@@ -295,6 +295,16 @@ export const updateBackupStorageRaw = async (request, name, data) => {
   return await request.put(`/v1/clusters/${CLUSTER_NAME}/namespaces/${EVEREST_CI_NAMESPACE}/backup-storages/${name}`, {data: data})
 }
 
+export const patchBackupStorage = async (request, name, data) => {
+  const response = await patchBackupStorageRaw(request, name, data)
+  await checkError(response)
+  return (await response.json())
+}
+
+export const patchBackupStorageRaw = async (request, name, data) => {
+  return await request.patch(`/v1/clusters/${CLUSTER_NAME}/namespaces/${EVEREST_CI_NAMESPACE}/backup-storages/${name}`, {data: data})
+}
+
 export const deleteBackupStorage = async (request, name) => {
   // Wait for deletion mark.
   await expect(async () => {


### PR DESCRIPTION
In https://github.com/openeverest/openeverest/pull/2320, PATCH was added to backup storage API. This PR adds API tests for it.

It also checks the fields used for secret creation are not returned from API.