### PR TITLE
Set the version tag back to 0.0.0-ref

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REPO_ROOT=$(shell dirname "$(realpath $(firstword $(MAKEFILE_LIST)))")
-RELEASE_VERSION ?= v2.0.0-dev.1
+RELEASE_VERSION ?= v0.0.0-$(shell git rev-parse --short HEAD)
 RELEASE_FULLCOMMIT ?= $(shell git rev-parse HEAD)
 IMAGE_PREFIX ?= ghcr.io/openeverest
 EVEREST_SERVER_DEV_IMAGE_NAME ?= openeverest-dev


### PR DESCRIPTION
Release of v2 updated `RELEASE_VERSION` on `release-2.0` branch. For v2 development we continue using `release-2.0` branch, and this PR updates `RELEASE_VERSION` back to previous 0.0.0-{ref} version so API integration tests and CLI integration tests pass.
https://github.com/openeverest/openeverest/actions/runs/26740703924/job/78803796930?pr=2234
https://github.com/openeverest/openeverest/actions/runs/26740703924/job/78803796949?pr=2234