### PR TITLE
rbac: replace panic with structured error logging on policy reload

### DIFF
--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -119,15 +119,32 @@ func refreshEnforcerInBackground(
 		if !ok || cm.GetName() != common.EverestRBACConfigMapName {
 			return
 		}
+
+		// Validate the incoming policy with a temporary enforcer before modifying the live
+		// enforcer state. This ensures a bad or partial ConfigMap update (syntax error,
+		// unknown resource, interrupted rollout) is rejected without disrupting the
+		// currently-serving policy.
+		tmpAdapter := configmapadapter.New(l, kubeConnector, types.NamespacedName{
+			Namespace: common.SystemNamespace,
+			Name:      common.EverestRBACConfigMapName,
+		})
+		if _, err := newEnforcer(tmpAdapter, false); err != nil {
+			l.Errorw("RBAC ConfigMap update rejected: invalid policy detected; keeping current enforcement state",
+				zap.Error(err))
+			return
+		}
+
+		// Policy is valid. Reload the live enforcer.
 		if err := enforcer.LoadPolicy(); err != nil {
-			panic("invalid policy detected - " + err.Error())
+			l.Errorw("Failed to reload RBAC policy from ConfigMap update",
+				zap.Error(err))
+			return
 		}
-		if err := validatePolicy(enforcer); err != nil {
-			panic("invalid policy detected - " + err.Error())
-		}
-		// Calling LoadPolicy() re-writes the entire model, so we need to add back the admin role.
+		// LoadPolicy() re-writes the entire model, so we need to add back the admin role.
 		if err := loadAdminPolicy(enforcer); err != nil {
-			panic("failed to load admin policy - " + err.Error())
+			l.Errorw("Failed to restore admin policy after RBAC reload; enforcement state may be degraded",
+				zap.Error(err))
+			return
 		}
 		enforcer.EnableEnforce(IsEnabled(cm))
 	})


### PR DESCRIPTION
When the everest-rbac ConfigMap is updated, refreshEnforcerInBackground previously called panic() if LoadPolicy(), validatePolicy(), or loadAdminPolicy() failed. This caused the everest-server pod to crash and enter a CrashLoopBackOff instead of keeping the last known-good enforcement state.

Fix the crash by:

1. Pre-validating the incoming policy with a temporary enforcer before touching the live enforcer state. If the new policy is invalid (syntax error, unknown resource, interrupted rollout), the error is logged and the live enforcer is left unchanged.

2. Replacing all three panic() calls with structured l.Errorw() calls so transient failures (e.g. a flaky K8s API call on LoadPolicy) are surfaced in logs without taking down the server.

The live enforcer is now only updated after the full validation + loadAdminPolicy sequence succeeds, preserving the last-good-policy invariant on any failure.

Fixes #2258