### PR TITLE
fix: implement TTL annotation for backup storage secrets cleanup

### DIFF
--- a/internal/server/handlers/k8s/backup_storage.go
+++ b/internal/server/handlers/k8s/backup_storage.go
@@ -2,8 +2,8 @@ package k8s
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"time"
 
 	"github.com/AlekSi/pointer"
 	corev1 "k8s.io/api/core/v1"
@@ -15,6 +15,7 @@ import (
 
 	everestv1alpha1 "github.com/percona/everest-operator/api/everest/v1alpha1"
 	"github.com/percona/everest/api"
+	"github.com/percona/everest/pkg/common"
 )
 
 func (h *k8sHandler) ListBackupStorages(ctx context.Context, namespace string) (*everestv1alpha1.BackupStorageList, error) {
@@ -42,6 +43,9 @@ func (h *k8sHandler) CreateBackupStorage(ctx context.Context, namespace string, 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.Name,
 			Namespace: namespace,
+			Annotations: map[string]string{
+				common.CleanupAfterAnnotation: time.Now().Add(5 * time.Minute).Format(time.RFC3339),
+			},
 		},
 		Type:       corev1.SecretTypeOpaque,
 		StringData: backupSecretData(req.SecretKey, req.AccessKey),
@@ -77,17 +81,6 @@ func (h *k8sHandler) CreateBackupStorage(ctx context.Context, namespace string, 
 	}
 	created, err := h.kubeConnector.CreateBackupStorage(ctx, bs)
 	if err != nil {
-		// TODO: Move this logic to the operator
-		delObj := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      req.Name,
-				Namespace: namespace,
-			},
-		}
-		dErr := h.kubeConnector.DeleteSecret(ctx, delObj)
-		if dErr != nil {
-			return nil, errors.Join(err, dErr)
-		}
 		return nil, fmt.Errorf("failed to create backup storage: %w", err)
 	}
 

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -61,6 +61,9 @@ const (
 	// PerconaEverestCRDLabel is the label used to identify Everest CRDs.
 	PerconaEverestCRDLabel = "everest.percona.com/crd"
 
+	// CleanupAfterAnnotation is the annotation used to indicate that a resource should be cleaned up after a certain time.
+	CleanupAfterAnnotation = "everest.percona.com/cleanup-after"
+
 	// EverestOperatorName holds the name for Everest operator.
 	EverestOperatorName = "everest-operator"
 


### PR DESCRIPTION
If a BackupStorage Custom Resource fails to be created in the API server handlers, the Secret containing the storage credentials (which was created immediately prior) is left orphaned in the cluster. Kubernetes native garbage collection cannot clean this up because there is no OwnerReference linking it to the failed CR.

Related pull requests:

- openeverest/openeverest-operator/pull/958

Cause: We relied on a synchronous fallback block (DeleteSecret) inside the CreateBackupStorage API handler to clean up the Secret upon failure. This was inherently fragile and could quietly fail due to network drops or race conditions.

Solution: This PR implements the first half of a TTL-based asynchronous garbage collection pattern to elegantly solve this:

We now inject the everest.percona.com/cleanup-after annotation when creating the BackupStorage credential Secret. The TTL is set to 5 minutes.
We have completely removed the old, fragile synchronous DeleteSecret fallback logic, delegating cleanup responsibility to the operator.

closes: #2332 