### PR TITLE
fix: add timeouts to HTTP clients and ensure local sign-out

### DIFF
--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -62,14 +63,19 @@ func (e *EverestServer) report(ctx context.Context, baseURL string, data Telemet
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		e.l.Error(errors.Join(err, errors.New("failed to send telemetry request")))
 		return err
 	}
 	defer resp.Body.Close() //nolint:errcheck
 	if resp.StatusCode != http.StatusOK {
-		e.l.Info("Telemetry service responded with http status ", resp.StatusCode)
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		e.l.Infof("Telemetry service responded with http status %d, body: %s", resp.StatusCode, string(bodyBytes))
 	}
 	return nil
 }

--- a/pkg/version_service/client.go
+++ b/pkg/version_service/client.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"time"
 
 	perconavs "github.com/Percona-Lab/percona-version-service/versionpb"
 	goversion "github.com/hashicorp/go-version"
@@ -58,13 +59,19 @@ type Interface interface {
 	GetEverestMetadata(ctx context.Context) (*perconavs.MetadataResponse, error)
 }
 
+const defaultHTTPTimeout = 30 * time.Second
+
 type versionServiceClient struct {
-	url string
+	url        string
+	httpClient *http.Client
 }
 
 // New returns a new version service client.
 func New(url string) Interface { //nolint:ireturn
-	return &versionServiceClient{url: url}
+	return &versionServiceClient{
+		url:        url,
+		httpClient: &http.Client{Timeout: defaultHTTPTimeout},
+	}
 }
 
 //nolint:gochecknoglobals
@@ -86,7 +93,7 @@ func (c *versionServiceClient) GetSupportedEngineVersions(ctx context.Context, o
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not create version service request"))
 	}
-	res, err := http.DefaultClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not retrieve version response"))
 	}
@@ -147,7 +154,7 @@ func (c *versionServiceClient) GetEverestMetadata(ctx context.Context) (*percona
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not create Everest metadata request"))
 	}
-	res, err := http.DefaultClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not retrieve Everest metadata"))
 	}

--- a/ui/apps/everest/src/contexts/auth/auth.provider.tsx
+++ b/ui/apps/everest/src/contexts/auth/auth.provider.tsx
@@ -98,7 +98,11 @@ const AuthProvider = ({ children, isSsoEnabled }: AuthProviderProps) => {
 
   const logout = async () => {
     const token = localStorage.getItem('everestToken');
-    await api.delete('/session', { headers: { token: token } });
+    try {
+      await api.delete('/session', { headers: { token: token } });
+    } catch (e) {
+      // Ignore error to ensure local sign-out completes
+    }
     if (isSsoEnabled) {
       await userManager.clearStaleState();
       await setLogoutStatus();


### PR DESCRIPTION
**Fixes #2247**: Replaced the default HTTP client in version_service/client.go with a dedicated *http.Client that has a strict 30-second timeout. This resolves the critical issue where everestctl would hang indefinitely during install/upgrade if the version server was unreachable.
**Fixes #2203**: Added the same 30-second timeout to the background telemetry HTTP client (internal/server/telemetry.go). Also added robust response body logging for non-200 responses to aid debugging.
**Fixes #2236**: Wrapped the DELETE /session call in auth.provider.tsx with a try/catch block. This ensures that even if the API throws an error (like 500 Internal Server Error), the local application state will still be successfully cleared and the user will be properly signed out.