### PR TITLE
chore(ui): break checkbox circular dependency in ui-lib

### DIFF
--- a/ui/packages/ui-lib/.eslintrc.cjs
+++ b/ui/packages/ui-lib/.eslintrc.cjs
@@ -9,7 +9,7 @@ module.exports = {
       {
         patterns: [
           {
-            group: ['../../..', '../../../index', '../../../*'],
+            group: ['../../..', '../../../index'],
             message:
               "Do not import from the ui-lib package root barrel inside src/. Use a direct relative path (e.g. '../../../labeled-content') instead.",
           },

--- a/ui/packages/ui-lib/.eslintrc.cjs
+++ b/ui/packages/ui-lib/.eslintrc.cjs
@@ -1,4 +1,20 @@
 module.exports = {
   root: true,
   extends: ['@percona/eslint-config-react', 'plugin:storybook/recommended'],
+  rules: {
+    // Prevent internal ui-lib components from importing through the package root barrel.
+    // Use direct relative paths (e.g. '../../../labeled-content') instead.
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['../../..', '../../../index', '../../../*'],
+            message:
+              "Do not import from the ui-lib package root barrel inside src/. Use a direct relative path (e.g. '../../../labeled-content') instead.",
+          },
+        ],
+      },
+    ],
+  },
 };

--- a/ui/packages/ui-lib/src/form/inputs/checkbox/checkbox.tsx
+++ b/ui/packages/ui-lib/src/form/inputs/checkbox/checkbox.tsx
@@ -1,8 +1,22 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Controller, useFormContext } from 'react-hook-form';
 import { Checkbox as MUICheckbox } from '@mui/material';
 import { CheckboxProps } from './checkbox.types';
 import { kebabize } from '@percona/utils';
-import { LabeledContent } from '../../..';
+import LabeledContent from '../../../labeled-content';
 
 const Checkbox = ({
   name,

--- a/ui/packages/ui-lib/src/form/inputs/checkbox/checkbox.types.ts
+++ b/ui/packages/ui-lib/src/form/inputs/checkbox/checkbox.types.ts
@@ -1,6 +1,20 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Control, UseControllerProps } from 'react-hook-form';
 import { CheckboxProps as MUICheckboxProps } from '@mui/material';
-import { LabeledContentProps } from '../../..';
+import { type LabeledContentProps } from '../../../labeled-content';
 
 export type CheckboxProps = {
   name: string;


### PR DESCRIPTION
## Summary

- \`checkbox.tsx\` imported \`LabeledContent\` through the package root barrel (\`../../..\`), creating a cycle: \`checkbox.tsx\` → \`checkbox/index.ts\` → \`ui-lib/src/index.ts\` → \`checkbox/index.ts\`.
- Fixed by replacing the barrel import with a direct relative import (\`../../../labeled-content\`), matching the pattern already used by \`radio-group\` and \`toggle-button-group\`.
- Same fix applied to \`checkbox.types.ts\` which had the same barrel import for \`LabeledContentProps\`.
- Added \`no-restricted-imports\` ESLint rule to \`ui-lib/.eslintrc.cjs\` to prevent this pattern from coming back.

Closes #2334

## Test plan

- Verify \`Checkbox\` renders correctly without a label (bare checkbox).
- Verify \`Checkbox\` renders correctly with a label (wrapped in \`LabeledContent\`).
- Run \`make copyright-check\` — passes.
- Run ESLint on \`ui-lib\` — no violations.
- No visible UI changes.