### PR TITLE
chore(ui): add unit tests for orderComponents and generateFieldId

### DIFF
--- a/ui/apps/everest/src/components/ui-generator/utils/component-renderer/generate-field-id.test.ts
+++ b/ui/apps/everest/src/components/ui-generator/utils/component-renderer/generate-field-id.test.ts
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+import { generateFieldId } from './generate-field-id';
+import { FieldType } from '../../ui-generator.types';
+import type { Component, ComponentGroup } from '../../ui-generator.types';
+
+describe('generateFieldId', () => {
+  it('returns the component path when path is a plain string', () => {
+    const item: Component = {
+      uiType: FieldType.Text,
+      path: 'spec.proxy.replicas',
+      fieldParams: { label: 'Replicas' },
+    };
+    expect(generateFieldId(item, 'myField')).toBe('spec.proxy.replicas');
+  });
+
+  it('returns g-{name} fallback for a group (no path)', () => {
+    const item: ComponentGroup = {
+      uiType: 'group',
+      components: {},
+    };
+    expect(generateFieldId(item, 'resources')).toBe('g-resources');
+  });
+
+  it('returns g-{name} fallback for a hidden field (no path resolution)', () => {
+    const item: Component = {
+      uiType: 'hidden',
+      path: 'spec.hidden',
+      fieldParams: {},
+    } as unknown as Component;
+    expect(generateFieldId(item, 'hiddenField')).toBe('g-hiddenField');
+  });
+
+  it('returns g-{name} when component has no path', () => {
+    const item = {
+      uiType: FieldType.Text,
+      fieldParams: { label: 'No path' },
+    } as unknown as Component;
+    expect(generateFieldId(item, 'noPath')).toBe('g-noPath');
+  });
+});

--- a/ui/apps/everest/src/components/ui-generator/utils/component-renderer/generate-field-id.test.ts
+++ b/ui/apps/everest/src/components/ui-generator/utils/component-renderer/generate-field-id.test.ts
@@ -35,20 +35,20 @@ describe('generateFieldId', () => {
     expect(generateFieldId(item, 'resources')).toBe('g-resources');
   });
 
-  it('returns g-{name} fallback for a hidden field (no path resolution)', () => {
-    const item: Component = {
+  it('returns g-{name} fallback for a hidden group (no path resolution)', () => {
+    const item: ComponentGroup = {
       uiType: 'hidden',
-      path: 'spec.hidden',
-      fieldParams: {},
-    } as unknown as Component;
+      components: {},
+    };
     expect(generateFieldId(item, 'hiddenField')).toBe('g-hiddenField');
   });
 
-  it('returns g-{name} when component has no path', () => {
-    const item = {
+  it('returns g-{name} when component path is undefined', () => {
+    const item: Component = {
       uiType: FieldType.Text,
+      path: undefined as unknown as string,
       fieldParams: { label: 'No path' },
-    } as unknown as Component;
+    };
     expect(generateFieldId(item, 'noPath')).toBe('g-noPath');
   });
 });

--- a/ui/apps/everest/src/components/ui-generator/utils/component-renderer/order-components.test.ts
+++ b/ui/apps/everest/src/components/ui-generator/utils/component-renderer/order-components.test.ts
@@ -23,39 +23,40 @@ const makeField = (path: string): Component => ({
   fieldParams: { label: path },
 });
 
-const components = {
+const makeComponents = () => ({
   a: makeField('spec.a'),
   b: makeField('spec.b'),
   c: makeField('spec.c'),
-};
+});
 
 describe('orderComponents', () => {
   it('returns original order when no componentsOrder is given', () => {
-    const result = orderComponents(components);
+    const result = orderComponents(makeComponents());
     expect(result.map(([k]) => k)).toEqual(['a', 'b', 'c']);
   });
 
   it('returns original order when componentsOrder is an empty array', () => {
-    const result = orderComponents(components, []);
+    const result = orderComponents(makeComponents(), []);
     expect(result.map(([k]) => k)).toEqual(['a', 'b', 'c']);
   });
 
   it('reorders components according to componentsOrder', () => {
-    const result = orderComponents(components, ['c', 'a', 'b']);
+    const result = orderComponents(makeComponents(), ['c', 'a', 'b']);
     expect(result.map(([k]) => k)).toEqual(['c', 'a', 'b']);
   });
 
   it('appends unordered components after ordered ones', () => {
-    const result = orderComponents(components, ['c']);
+    const result = orderComponents(makeComponents(), ['c']);
     expect(result.map(([k]) => k)).toEqual(['c', 'a', 'b']);
   });
 
   it('silently skips keys in componentsOrder that do not exist', () => {
-    const result = orderComponents(components, ['z', 'b', 'a']);
+    const result = orderComponents(makeComponents(), ['z', 'b', 'a']);
     expect(result.map(([k]) => k)).toEqual(['b', 'a', 'c']);
   });
 
   it('preserves the component value at each key', () => {
+    const components = makeComponents();
     const result = orderComponents(components, ['b']);
     const bEntry = result.find(([k]) => k === 'b');
     expect(bEntry?.[1]).toBe(components.b);

--- a/ui/apps/everest/src/components/ui-generator/utils/component-renderer/order-components.test.ts
+++ b/ui/apps/everest/src/components/ui-generator/utils/component-renderer/order-components.test.ts
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+import { orderComponents } from './order-components';
+import { FieldType } from '../../ui-generator.types';
+import type { Component } from '../../ui-generator.types';
+
+const makeField = (path: string): Component => ({
+  uiType: FieldType.Text,
+  path,
+  fieldParams: { label: path },
+});
+
+const components = {
+  a: makeField('spec.a'),
+  b: makeField('spec.b'),
+  c: makeField('spec.c'),
+};
+
+describe('orderComponents', () => {
+  it('returns original order when no componentsOrder is given', () => {
+    const result = orderComponents(components);
+    expect(result.map(([k]) => k)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns original order when componentsOrder is an empty array', () => {
+    const result = orderComponents(components, []);
+    expect(result.map(([k]) => k)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('reorders components according to componentsOrder', () => {
+    const result = orderComponents(components, ['c', 'a', 'b']);
+    expect(result.map(([k]) => k)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('appends unordered components after ordered ones', () => {
+    const result = orderComponents(components, ['c']);
+    expect(result.map(([k]) => k)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('silently skips keys in componentsOrder that do not exist', () => {
+    const result = orderComponents(components, ['z', 'b', 'a']);
+    expect(result.map(([k]) => k)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('preserves the component value at each key', () => {
+    const result = orderComponents(components, ['b']);
+    const bEntry = result.find(([k]) => k === 'b');
+    expect(bEntry?.[1]).toBe(components.b);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `order-components.test.ts` — 6 tests covering: no order given, empty order array, full reorder, append unordered remainder, skip unknown keys, preserve component values
- Add `generate-field-id.test.ts` — 4 tests covering: plain string path, group fallback to `g-{name}`, hidden field fallback, component with no path

Both utils had no test file. Neighbouring utils (`object-path`, `schema-walker`, `build-section-field-map`) all have tests — this fills the gap.

`generateFieldId`'s `g-${name}` fallback is the exact naming path where the double-dot RHF bug class (#2232) originates, so having it tested prevents regressions of the same kind.

Closes #2350

## Test plan

- `pnpm --filter "@percona/everest" exec vitest run` — 10/10 tests pass
- No runtime behaviour change — test files only