### PR TITLE
Backup storage e2e tests

### DIFF
--- a/.github/workflows/dev-fe-e2e.yaml
+++ b/.github/workflows/dev-fe-e2e.yaml
@@ -138,40 +138,14 @@ jobs:
           --helm.set operator.image=ghcr.io/openeverest/openeverest-operator-dev \
           --helm.set olm.catalogSourceImage=ghcr.io/openeverest/openeverest-catalog-dev
 
-      - name: Add everest-ui namespace
+      - name: Add everest namespace
         shell: bash
         run: |
-          ./bin/everestctl namespaces add everest-ui -v \
+          ./bin/everestctl namespaces add everest -v \
           --operator.mongodb=true \
           --operator.postgresql=true \
           --operator.mysql=true \
-          --skip-wizard
-
-      - name: Adding psmdb namespace
-        shell: bash
-        run: |
-          ./bin/everestctl namespaces add psmdb-only -v \
-          --operator.mongodb=true \
-          --operator.postgresql=false \
-          --operator.mysql=false \
-          --skip-wizard
-
-      - name: Adding pxc namespace
-        shell: bash
-        run: |
-          ./bin/everestctl namespaces add pxc-only -v \
-          --operator.mongodb=false \
-          --operator.postgresql=false \
-          --operator.mysql=true \
-          --skip-wizard
-
-      - name: Adding pg namespace
-        shell: bash
-        run: |
-          ./bin/everestctl namespaces add pg-only -v \
-          --operator.mongodb=false \
-          --operator.postgresql=true \
-          --operator.mysql=false \
+          --take-ownership \
           --skip-wizard
 
       - name: Get Everest admin password
@@ -202,7 +176,7 @@ jobs:
         shell: bash
         env:
           EVEREST_URL: "http://localhost:3000"
-          EVEREST_BUCKETS_NAMESPACES_MAP: '[["bucket-1","everest-ui"],["bucket-2","psmdb-only"],["bucket-3","pxc-only"],["bucket-4","pg-only"],["bucket-5","everest-ui"]]'
+          EVEREST_BUCKETS_NAMESPACES_MAP: '[["bucket-1","everest"]]'
           EVEREST_LOCATION_ACCESS_KEY: "minioadmin"
           EVEREST_LOCATION_SECRET_KEY: "minioadmin"
           EVEREST_LOCATION_REGION: "us-east-1"
@@ -225,9 +199,9 @@ jobs:
           kubectl -n everest-system describe pods
           kubectl -n everest-monitoring describe pods
           kubectl -n everest-system logs deploy/everest-server
-          kubectl -n pxc-only describe pods
-          kubectl -n psmdb-only describe pods
-          kubectl -n pg-only describe pods
+          kubectl -n pxc-only describe pods || true
+          kubectl -n psmdb-only describe pods || true
+          kubectl -n pg-only describe pods || true
 
       - name: Archive report
         if: always()

--- a/.github/workflows/dev-fe-e2e.yaml
+++ b/.github/workflows/dev-fe-e2e.yaml
@@ -199,9 +199,6 @@ jobs:
           kubectl -n everest-system describe pods
           kubectl -n everest-monitoring describe pods
           kubectl -n everest-system logs deploy/everest-server
-          kubectl -n pxc-only describe pods || true
-          kubectl -n psmdb-only describe pods || true
-          kubectl -n pg-only describe pods || true
 
       - name: Archive report
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,7 @@ deploy:  ## Deploy Everest to K8S cluster using Everest CLI.
 	$(MAKE) expose
 
 DEPLOY_ALL_DEPS := build-ui build-debug docker-build k3d-upload-server-image
+DEPLOY_ALL_DEPS += build-cli-debug
 DEPLOY_ALL_DEPS += docker-build-operator k3d-upload-operator-image
 DEPLOY_ALL_DEPS += k3d-upload-server-image deploy
 .PHONY: deploy-all
@@ -360,32 +361,29 @@ undeploy: build-cli-debug ## Undeploy Everest from K8S cluster using Everest CLI
 	$(info Uninstalling Everest from K8S cluster using everestctl)
 	"$(LOCALBIN)/everestctl" uninstall -y -f -v
 
-.PHONY: add-pg-namespaces
-add-pg-namespaces: ## Add PostgreSQL namespace to Everest using Everest CLI(usage: DB_NAMESPACES=ns-1,ns-2 make add-pg-namespaces).
-	$(info Adding PostgreSQL namespaces=${DB_NAMESPACE} to Everest using everestctl)
-	$(LOCALBIN)/everestctl namespaces add $(DB_NAMESPACES) -v \
-	--operator.mongodb=false \
-	--operator.postgresql=true \
-	--operator.mysql=false \
-	--skip-wizard
-
-.PHONY: add-psmdb-namespaces
-add-psmdb-namespaces: ## Add PSMDB namespace to Everest using Everest CLI(usage: DB_NAMESPACES=ns-1,ns-2 make add-psmdb-namespaces).
-	$(info Adding PSMDB namespaces=${DB_NAMESPACE} to Everest using everestctl)
+.PHONY: add-shared-everest-namespace
+add-shared-everest-namespace: ## Add shared Everest namespace with all operators (usage: DB_NAMESPACES=everest make add-shared-everest-namespace).
+	$(info Adding shared namespaces=${DB_NAMESPACES} to Everest using everestctl)
 	$(LOCALBIN)/everestctl namespaces add $(DB_NAMESPACES) -v \
 	--operator.mongodb=true \
-	--operator.postgresql=false \
-	--operator.mysql=false \
+	--operator.postgresql=true \
+	--operator.mysql=true \
+	--take-ownership \
 	--skip-wizard
 
-.PHONY: add-pxc-namespaces
-add-pxc-namespaces: ## Add PXC namespace to Everest using Everest CLI(usage: DB_NAMESPACES=ns-1,ns-2 make add-pxc-namespaces).
-	$(info Adding PXC namespaces=${DB_NAMESPACE} to Everest using everestctl)
-	$(LOCALBIN)/everestctl namespaces add $(DB_NAMESPACES) -v \
-	--operator.mongodb=false \
-	--operator.postgresql=false \
-	--operator.mysql=true \
-	--skip-wizard
+.PHONY: cleanup-legacy-provider-namespaces
+cleanup-legacy-provider-namespaces: ## LEGACY manual one-time migration cleanup for upgraded environments.
+	# TODO(legacy-cleanup): Drop this target after confirming no upgraded environments need legacy namespace cleanup.
+	$(info Cleaning legacy provider namespaces from Everest management)
+	@{ \
+	if ! $(LOCALBIN)/everestctl namespaces remove psmdb-only,pxc-only,pg-only -v --keep-namespace ; then \
+		echo "Skipping cleanup: provider namespaces are absent, unmanaged, or in use"; \
+	fi; \
+	if ! $(LOCALBIN)/everestctl namespaces remove everest-ui -v --keep-namespace ; then \
+		echo "Skipping cleanup: everest-ui is absent, unmanaged, or in use"; \
+	fi; \
+	kubectl delete namespace everest-ui --ignore-not-found=true >/dev/null 2>&1 || true; \
+	}
 
 .PHONY: expose
 expose:

--- a/Makefile
+++ b/Makefile
@@ -370,20 +370,6 @@ add-shared-everest-namespace: ## Add shared Everest namespace with all operators
 	--take-ownership \
 	--skip-wizard
 
-.PHONY: cleanup-legacy-provider-namespaces
-cleanup-legacy-provider-namespaces: ## LEGACY manual one-time migration cleanup for upgraded environments.
-	# TODO(legacy-cleanup): Drop this target after confirming no upgraded environments need legacy namespace cleanup.
-	$(info Cleaning legacy provider namespaces from Everest management)
-	@{ \
-	if ! $(LOCALBIN)/everestctl namespaces remove psmdb-only,pxc-only,pg-only -v --keep-namespace ; then \
-		echo "Skipping cleanup: provider namespaces are absent, unmanaged, or in use"; \
-	fi; \
-	if ! $(LOCALBIN)/everestctl namespaces remove everest-ui -v --keep-namespace ; then \
-		echo "Skipping cleanup: everest-ui is absent, unmanaged, or in use"; \
-	fi; \
-	kubectl delete namespace everest-ui --ignore-not-found=true >/dev/null 2>&1 || true; \
-	}
-
 .PHONY: expose
 expose:
 	kubectl patch svc -n everest-system everest --type=merge \

--- a/ui/apps/everest/.e2e/Makefile
+++ b/ui/apps/everest/.e2e/Makefile
@@ -19,7 +19,6 @@ init:     ## Install tests dependencies.
 	npx playwright install --with-deps chromium
 
 CI_INIT_DEPS := init deploy-minio create-db-namespaces deploy-monitoring
-CI_INIT_DEPS += k3d-upload-images
 .PHONY: ci-init
 ci-init: $(CI_INIT_DEPS) 	## Prepare environment for running tests.
 
@@ -45,9 +44,7 @@ deploy-monitoring:     ## Deploy monitoring instances to K3D test cluster.
 .PHONY: create-db-namespaces
 create-db-namespaces:
 	$(info Creating DB namespaces in Everest)
-	$(MAKE) -f $(REPO_ROOT_MAKEFILE) add-psmdb-namespaces DB_NAMESPACES=psmdb-only
-	$(MAKE) -f $(REPO_ROOT_MAKEFILE) add-pxc-namespaces DB_NAMESPACES=pxc-only
-	$(MAKE) -f $(REPO_ROOT_MAKEFILE) add-pg-namespaces DB_NAMESPACES=pg-only
+	$(MAKE) -f $(REPO_ROOT_MAKEFILE) add-shared-everest-namespace DB_NAMESPACES=everest
 
 #EVERESTCTL=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/../bin/everestctl
 #.PHONY: create-test-users
@@ -57,57 +54,6 @@ create-db-namespaces:
 #	$(EVERESTCTL) accounts create -u everest_ci -p password
 #	kubectl patch configmap everest-rbac -n everest-system --patch "$$(kubectl get configmap everest-rbac -n everest-system -o json | jq '.data["policy.csv"] += "\ng, everest_ci, role:admin"' | jq '{data: { "policy.csv": .data["policy.csv"] } }')"
 #	kubectl get configmap everest-rbac -n everest-system -ojsonpath='{.data.policy\.csv}'
-
-.PHONY: k3d-upload-pg-images
-k3d-upload-pg-images: ## Pre-upload Postgresql images to K3D test  cluster to speedup tests execution.
-	$(info Uploading PG images to K3D test cluster)
-	@{ \
-	pg_engine_image=$$(kubectl -n pg-only get dbengine/percona-postgresql-operator -ojson | jq -r '[.status.availableVersions.engine[] | select(.status == "recommended").imagePath][-1] ') ;\
-	pg_proxy_image=$$(kubectl -n pg-only get dbengine/percona-postgresql-operator -ojson | jq -r '[.status.availableVersions.proxy.pgbouncer[] | select(.status == "recommended").imagePath][-1] ') ;\
-	pg_backup_image=$$(kubectl -n pg-only get dbengine/percona-postgresql-operator -ojson | jq -r '[.status.availableVersions.backup[] | select(.status == "recommended").imagePath][-1] ') ;\
-	pg_operator_image=$$(kubectl -n pg-only get deploy/percona-postgresql-operator -o json | jq -r '.spec.template.spec.containers[] | select (.name == "operator").image') ;\
-	for node in $(k3d node list | grep everest-server-test | grep -v registry | awk '{print $1}'); do \
-		docker exec $node ctr image pull docker.io/$${pg_engine_image} ;\
-		docker exec $node ctr image pull docker.io/$${pg_proxy_image} ;\
-		docker exec $node ctr image pull docker.io/$${pg_backup_image}  ;\
-		docker exec $node ctr image pull docker.io/$${pg_operator_image}  ;\
-	done ;\
-	}
-
-.PHONY: k3d-upload-psmdb-images
-k3d-upload-psmdb-images: ## Pre-upload PSMDB images to K3D test  cluster to speedup tests execution.
-	$(info Uploading PSMDB images to K3D test cluster)
-	@{ \
-	psmdb_engine_image=$$(kubectl -n psmdb-only get dbengine/percona-server-mongodb-operator -ojson | jq -r '[.status.availableVersions.engine[] | select(.status == "recommended").imagePath][-1] ') ;\
-	psmdb_backup_image=$$(kubectl -n psmdb-only get dbengine/percona-server-mongodb-operator -ojson | jq -r '[.status.availableVersions.backup[] | select(.status == "recommended").imagePath][-1] ') ;\
-	psmdb_operator_image=$$(kubectl -n psmdb-only get deploy/percona-server-mongodb-operator -o json | jq -r '.spec.template.spec.containers[] | select (.name == "percona-server-mongodb-operator").image') ;\
-	for node in $(k3d node list | grep everest-server-test | grep -v registry | awk '{print $1}'); do \
-		docker exec $node ctr image pull docker.io/$${psmdb_engine_image} ;\
-		docker exec $node ctr image pull docker.io/$${psmdb_backup_image}  ;\
-		docker exec $node ctr image pull docker.io/$${psmdb_operator_image}  ;\
-	done ;\
-	}
-
-.PHONY: k3d-upload-pxc-images
-k3d-upload-pxc-images: ## Pre-upload PXC images to K3D test cluster to speedup tests execution.
-	$(info Uploading PXC images to K3D test cluster)
-	@{ \
-	pxc_engine_image=$$(kubectl -n pxc-only get dbengine/percona-xtradb-cluster-operator -ojson | jq -r '[.status.availableVersions.engine[] | select(.status == "recommended").imagePath][-1] ') ;\
-	pxc_proxy_image=$$(kubectl -n pxc-only get dbengine/percona-xtradb-cluster-operator -ojson | jq -r '[.status.availableVersions.proxy.haproxy[] | select(.status == "recommended").imagePath][-1] ') ;\
-	pxc_backup_image=$$(kubectl -n pxc-only get dbengine/percona-xtradb-cluster-operator -ojson | jq -r '[.status.availableVersions.backup[] | select(.status == "recommended").imagePath][-1] ') ;\
-	pxc_operator_image=$$(kubectl -n pxc-only get deploy/percona-xtradb-cluster-operator -o json | jq -r '.spec.template.spec.containers[] | select (.name == "percona-xtradb-cluster-operator").image') ;\
-	pmm_client_image=percona/pmm-client:2 ;\
-	for node in $(k3d node list | grep everest-server-test | grep -v registry | awk '{print $1}'); do \
-		docker exec $node ctr image pull docker.io/$${pxc_engine_image} ;\
-		docker exec $node ctr image pull docker.io/$${pxc_proxy_image}  ;\
-		docker exec $node ctr image pull docker.io/$${pxc_backup_image}  ;\
-		docker exec $node ctr image pull docker.io/$${pxc_operator_image}  ;\
-		docker exec $node ctr image pull docker.io/$${pmm_client_image}  ;\
-	done ;\
-	}
-
-.PHONY: k3d-upload-images
-k3d-upload-images: k3d-upload-pg-images k3d-upload-psmdb-images k3d-upload-pxc-images 	## Pre-upload PG,PSMDB,PXC images to K3D test cluster to speedup tests execution.
 
 ##@ Test
 
@@ -131,7 +77,7 @@ test:
   	export RBAC_PASSWORD="rbac-e2e-test" ;\
     export SESSION_USER="session" ;\
     export SESSION_PASS="session1234" ;\
-	export EVEREST_BUCKETS_NAMESPACES_MAP='[["bucket-1","everest"],["bucket-2","psmdb-only"],["bucket-3","pxc-only"],["bucket-4","pg-only"],["bucket-5","everest"]]' ;\
+	export EVEREST_BUCKETS_NAMESPACES_MAP='[["bucket-1","everest"]]' ;\
   	export EVEREST_LOCATION_ACCESS_KEY="minioadmin" ;\
 	export EVEREST_LOCATION_SECRET_KEY="minioadmin" ;\
 	export EVEREST_LOCATION_REGION="us-east-1" ;\

--- a/ui/apps/everest/.e2e/constants.ts
+++ b/ui/apps/everest/.e2e/constants.ts
@@ -38,7 +38,7 @@ export const SESSION_USER_STORAGE_STATE_FILE = path.join(
 export const EVEREST_CI_CLUSTER = 'main';
 
 export enum EVEREST_CI_NAMESPACES {
-  EVEREST_UI = 'everest-ui',
+  EVEREST_UI = 'everest',
   PSMDB_ONLY = 'psmdb-only',
   PXC_ONLY = 'pxc-only',
   PG_ONLY = 'pg-only',

--- a/ui/apps/everest/.e2e/pr/settings/backup-storage.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/settings/backup-storage.e2e.ts
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +17,11 @@
 import { test, expect } from '@playwright/test';
 import { findRowAndClickActions, waitForDelete } from '@e2e/utils/table';
 import { goToUrl, limitedSuffixedName } from '@e2e/utils/generic';
-import { EVEREST_CI_NAMESPACES, TIMEOUTS } from '@e2e/constants';
+import {
+  EVEREST_CI_NAMESPACES,
+  EVEREST_CI_CLUSTER,
+  TIMEOUTS,
+} from '@e2e/constants';
 import { getCITokenFromLocalStorage } from '@e2e/utils/localStorage';
 import {
   deleteBackupStorage,
@@ -60,10 +65,9 @@ test.describe.serial('Backup storage', () => {
     await test.step(`Create Backup Storage`, async () => {
       await page.getByTestId('add-backup-storage').click();
       await page.getByTestId('text-input-name').fill(backupStorageName);
-      await page.getByTestId('text-input-description').fill('test-description');
 
       await page.getByTestId('text-input-namespace').click();
-      await page.getByRole('option', { name: namespace }).click();
+      await page.getByRole('option', { name: namespace, exact: true }).click();
       await expect(page.getByTestId('select-input-type')).toHaveValue('s3');
       await page.getByTestId('text-input-bucket-name').fill(bucketName);
       await page.getByTestId('text-input-region').fill(EVEREST_LOCATION_REGION);
@@ -106,18 +110,24 @@ test.describe.serial('Backup storage', () => {
   });
 
   test('Edit Backup Storage', async ({ page }) => {
-    const newDescription = 'new-test-description';
+    const newUrl = 'https://minio-updated.minio.svc.cluster.local';
 
-    await test.step('Update Backup Storage description', async () => {
+    await test.step('Update Backup Storage URL', async () => {
       await findRowAndClickActions(page, backupStorageName, 'Edit');
-      await page.getByTestId('text-input-description').fill(newDescription);
+      await page.getByTestId('text-input-url').fill(newUrl);
+      await page
+        .getByTestId('text-input-access-key')
+        .fill(EVEREST_LOCATION_ACCESS_KEY);
+      await page
+        .getByTestId('text-input-secret-key')
+        .fill(EVEREST_LOCATION_SECRET_KEY);
       const updResponse = page.waitForResponse(
         (resp) =>
           resp.request().method() === 'PATCH' &&
           resp
             .url()
             .includes(
-              `/v1/namespaces/${namespace}/backup-storages/${backupStorageName}`
+              `/v1/clusters/${EVEREST_CI_CLUSTER}/namespaces/${namespace}/backup-storages/${backupStorageName}`
             ) &&
           resp.status() === 200
       );
@@ -125,12 +135,10 @@ test.describe.serial('Backup storage', () => {
       await updResponse;
     });
 
-    await test.step('Check updated Backup Storage description', async () => {
+    await test.step('Check updated Backup Storage URL', async () => {
       await goToUrl(page, '/settings/storage-locations');
       await findRowAndClickActions(page, backupStorageName, 'Edit');
-      await expect(page.getByTestId('text-input-description')).toHaveValue(
-        newDescription
-      );
+      await expect(page.getByTestId('text-input-url')).toHaveValue(newUrl);
       await page.getByTestId('form-dialog-cancel').click();
     });
   });
@@ -143,7 +151,7 @@ test.describe.serial('Backup storage', () => {
         resp
           .url()
           .includes(
-            `/v1/namespaces/${namespace}/backup-storages/${backupStorageName}`
+            `/v1/clusters/${EVEREST_CI_CLUSTER}/namespaces/${namespace}/backup-storages/${backupStorageName}`
           ) &&
         resp.status() === 204
     );

--- a/ui/apps/everest/.e2e/pr/settings/monitoring-config.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/settings/monitoring-config.e2e.ts
@@ -288,7 +288,9 @@ test.describe.serial('Monitoring Configs', () => {
 
       const selectInput = page.getByRole('combobox').first();
       await expect(selectInput).toBeVisible({ timeout: TIMEOUTS.TenSeconds });
-      await expect(selectInput).toContainText(fallbackConfigName);
+      await expect(selectInput).toContainText(fallbackConfigName, {
+        timeout: TIMEOUTS.TenSeconds,
+      });
     });
   });
 });

--- a/ui/apps/everest/.e2e/pr/settings/monitoring-config.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/settings/monitoring-config.e2e.ts
@@ -105,7 +105,7 @@ test.describe.serial('Monitoring Configs', () => {
       // filling out the form
       await page.getByTestId('text-input-name').fill(monitoringConfigName);
       await page.getByTestId('text-input-namespace').click();
-      await page.getByRole('option', { name: namespace }).click();
+      await page.getByRole('option', { name: namespace, exact: true }).click();
       await page.getByTestId('text-input-url').fill(MONITORING_URL!);
       await page.getByTestId('text-input-user').fill(MONITORING_USER!);
       await page.getByTestId('text-input-password').fill(MONITORING_PASSWORD!);

--- a/ui/apps/everest/.e2e/pr/settings/project.config.ts
+++ b/ui/apps/everest/.e2e/pr/settings/project.config.ts
@@ -21,21 +21,21 @@ export const settingsProject: PlaywrightTestProject[] = [
     testMatch: /.^/,
     dependencies: [
       'pr:settings:monitoring-config',
-      // 'pr:settings:backup-storage',
+      'pr:settings:backup-storage',
       // 'pr:settings:namespace',
       // 'pr:settings:psp',
       // 'pr:settings:operator-upgrade',
     ],
   },
-  // {
-  //   name: 'pr:settings:backup-storage',
-  //   testDir: './pr/settings',
-  //   testMatch: /backup-storage\.e2e\.ts/,
-  //   dependencies: ['global:auth:ci:setup'],
-  //   use: {
-  //     storageState: CI_USER_STORAGE_STATE_FILE,
-  //   },
-  // },
+  {
+    name: 'pr:settings:backup-storage',
+    testDir: './pr/settings',
+    testMatch: /backup-storage\.e2e\.ts/,
+    dependencies: ['global:auth:ci:setup'],
+    use: {
+      storageState: CI_USER_STORAGE_STATE_FILE,
+    },
+  },
   {
     name: 'pr:settings:monitoring-config',
     testDir: './pr/settings',

--- a/ui/apps/everest/.e2e/utils/backup-storage.ts
+++ b/ui/apps/everest/.e2e/utils/backup-storage.ts
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +15,7 @@
 // limitations under the License.
 
 import { APIRequestContext, expect } from '@playwright/test';
+import { EVEREST_CI_CLUSTER } from '@e2e/constants';
 
 export const getBackupStorage = async (
   request: APIRequestContext,
@@ -22,7 +24,7 @@ export const getBackupStorage = async (
   token: string
 ) => {
   const response = await request.get(
-    `/v1/namespaces/${namespace}/backup-storages/${name}`,
+    `/v1/clusters/${EVEREST_CI_CLUSTER}/namespaces/${namespace}/backup-storages/${name}`,
     {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -40,7 +42,7 @@ export const deleteBackupStorage = async (
   token: string
 ) => {
   const response = await request.delete(
-      `/v1/namespaces/${namespace}/backup-storages/${name}`,
+      `/v1/clusters/${EVEREST_CI_CLUSTER}/namespaces/${namespace}/backup-storages/${name}`,
       {
         headers: {
           'Content-Type': 'application/json',

--- a/ui/apps/everest/src/api/backupStorage.ts
+++ b/ui/apps/everest/src/api/backupStorage.ts
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 import {
   BackupStorageFormValues,
   BackupStorageCRD,

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.test.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.test.tsx
@@ -35,7 +35,7 @@ vi.mock('../../ui-generator-context', () => ({
   useUiGeneratorContext: () => ({ namespace: 'ns' }),
 }));
 
-vi.mock('hooks/useClusterName', () => ({
+vi.mock('hooks/api/useClusterName', () => ({
   useClusterName: () => 'main',
 }));
 

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.test.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.test.tsx
@@ -248,7 +248,7 @@ describe('DataSourceField', () => {
       render(<Harness />);
 
       expect(screen.getByTestId('fallback')).toBeInTheDocument();
-      expect(screen.queryByTestId('child')).not.toBeInTheDocument();
+      expect(screen.getByTestId('child')).not.toBeVisible();
     });
 
     it('does not render fallback when emptyStateFallback is null', () => {

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
@@ -12,32 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import type { Component } from '../../ui-generator.types';
 import { providerRegistry, useProviderOptions } from '../registry';
 import { useUiGeneratorContext } from '../../ui-generator-context';
 import { useClusterName } from 'hooks/api/useClusterName';
 import type { DataSourceFieldProps } from './data-source-field.types';
-
-const resolveFieldValue = (
-  current: unknown,
-  options: { value: string }[]
-): string | null => {
-  const validValues = options.map((o) => o.value);
-  const currentStr = typeof current === 'string' ? current : '';
-
-  if (currentStr && !validValues.includes(currentStr)) {
-    return options.length > 0 ? options[0].value : '';
-  }
-  if (
-    (currentStr === '' || current === undefined || current === null) &&
-    options.length > 0
-  ) {
-    return options[0].value;
-  }
-  return null;
-};
+import { getReconciledDataSourceValue } from './data-source-field.utils';
 
 export const DataSourceField: React.FC<DataSourceFieldProps> = ({
   item,
@@ -60,38 +42,13 @@ export const DataSourceField: React.FC<DataSourceFieldProps> = ({
     { enabled: hasValidContext }
   );
 
-  // Synchronous value sync: ensures the form value is correct BEFORE the
-  // child Controller renders. This eliminates the timing gap where the
-  // Controller would mount with a stale/empty value and then re-render
-  // one tick later after the useEffect fires.
-  const lastSyncedRef = useRef<{ options: typeof options; name: string }>();
-
-  if (
-    !isLoading &&
-    name &&
-    options.length > 0 &&
-    (lastSyncedRef.current?.options !== options ||
-      lastSyncedRef.current?.name !== name)
-  ) {
-    const current = getValues(name);
-    const corrected = resolveFieldValue(current, options);
-    if (corrected !== null) {
-      setValue(name, corrected);
-    }
-    lastSyncedRef.current = { options, name };
-  }
-
-  // Async fallback: handles value invalidation when options change after
-  // the component is already mounted (e.g. namespace switch, config deletion).
   useEffect(() => {
     if (isLoading || !name) return;
 
-    const current = getValues(name);
-    const corrected = resolveFieldValue(current, options);
-    if (corrected !== null) {
-      setValue(name, corrected, {
-        shouldValidate: true,
-      });
+    const nextValue = getReconciledDataSourceValue(getValues(name), options);
+
+    if (nextValue !== null) {
+      setValue(name, nextValue, { shouldValidate: true });
     }
   }, [isLoading, options, name, getValues, setValue]);
 
@@ -122,14 +79,12 @@ export const DataSourceField: React.FC<DataSourceFieldProps> = ({
     } as Component;
   }, [baseComponent, options, isLoading, error, isEmpty]);
 
-  const fallback = useMemo(() => {
+  const FallbackComponent = useMemo(() => {
     const entry = providerRegistry.get(dataSource.provider);
-    return entry?.emptyStateFallback ?? null;
+    return entry?.emptyStateFallback?.component ?? null;
   }, [dataSource.provider]);
 
-  if (isEmpty && !isLoading && fallback && namespace) {
-    const { component: FallbackComponent } = fallback;
-
+  if (isEmpty && !isLoading && FallbackComponent && namespace) {
     return <FallbackComponent namespace={namespace} cluster={cluster} />;
   }
 

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
@@ -97,7 +97,11 @@ export const DataSourceField: React.FC<DataSourceFieldProps> = ({
       {showFallback && (
         <FallbackComponent namespace={namespace!} cluster={cluster} />
       )}
-      <div style={showFallback ? { display: 'none' } : undefined}>
+      <div
+        style={{
+          display: showFallback ? 'none' : 'contents',
+        }}
+      >
         {children(patchedItem)}
       </div>
     </>

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
@@ -84,7 +84,8 @@ export const DataSourceField: React.FC<DataSourceFieldProps> = ({
     return entry?.emptyStateFallback?.component ?? null;
   }, [dataSource.provider]);
 
-  const showFallback = isEmpty && !isLoading && !!FallbackComponent && !!namespace;
+  const showFallback =
+    isEmpty && !isLoading && !!FallbackComponent && !!namespace;
 
   // We always render the children (Select/Controller) and hide them with
   // display:none instead of conditionally unmounting. This keeps the RHF

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.tsx
@@ -84,9 +84,22 @@ export const DataSourceField: React.FC<DataSourceFieldProps> = ({
     return entry?.emptyStateFallback?.component ?? null;
   }, [dataSource.provider]);
 
-  if (isEmpty && !isLoading && FallbackComponent && namespace) {
-    return <FallbackComponent namespace={namespace} cluster={cluster} />;
-  }
+  const showFallback = isEmpty && !isLoading && !!FallbackComponent && !!namespace;
 
-  return <>{children(patchedItem)}</>;
+  // We always render the children (Select/Controller) and hide them with
+  // display:none instead of conditionally unmounting. This keeps the RHF
+  // Controller mounted so the field stays registered in the form. Without this,
+  // when options arrive after inline creation via the FallbackComponent, the
+  // Controller would remount and setValue() would fire before the field is
+  // re-registered — making it a no-op and leaving the Select empty.
+  return (
+    <>
+      {showFallback && (
+        <FallbackComponent namespace={namespace!} cluster={cluster} />
+      )}
+      <div style={showFallback ? { display: 'none' } : undefined}>
+        {children(patchedItem)}
+      </div>
+    </>
+  );
 };

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.utils.test.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.utils.test.ts
@@ -1,0 +1,55 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+import { getReconciledDataSourceValue } from './data-source-field.utils';
+
+describe('getReconciledDataSourceValue', () => {
+  const options = [
+    { label: 'first', value: 'first' },
+    { label: 'second', value: 'second' },
+  ];
+
+  it('returns first option when value is empty and options are available', () => {
+    expect(getReconciledDataSourceValue('', options)).toBe('first');
+  });
+
+  it('returns first option when value is undefined and options are available', () => {
+    expect(getReconciledDataSourceValue(undefined, options)).toBe('first');
+  });
+
+  it('returns first option when value is null and options are available', () => {
+    expect(getReconciledDataSourceValue(null, options)).toBe('first');
+  });
+
+  it('returns null when current value is valid', () => {
+    expect(getReconciledDataSourceValue('second', options)).toBeNull();
+  });
+
+  it('returns first option when current value is invalid', () => {
+    expect(getReconciledDataSourceValue('stale', options)).toBe('first');
+  });
+
+  it('returns empty string when value is invalid and options are empty', () => {
+    expect(getReconciledDataSourceValue('stale', [])).toBe('');
+  });
+
+  it('returns null when value is empty and options are empty', () => {
+    expect(getReconciledDataSourceValue('', [])).toBeNull();
+  });
+
+  it('returns first option when current value is non-string and options are available', () => {
+    expect(getReconciledDataSourceValue(123, options)).toBe('first');
+  });
+});

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.utils.ts
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-field/data-source-field.utils.ts
@@ -15,6 +15,29 @@
 import type { Component } from '../../ui-generator.types';
 import type { ComponentWithDataSource } from './data-source-field.types';
 
+type OptionValue = { value: string };
+
+export const getReconciledDataSourceValue = (
+  current: unknown,
+  options: OptionValue[]
+): string | null => {
+  const validValues = options.map((o) => o.value);
+  const currentStr = typeof current === 'string' ? current : '';
+
+  if (currentStr && !validValues.includes(currentStr)) {
+    return options.length > 0 ? options[0].value : '';
+  }
+
+  if (
+    (currentStr === '' || current === undefined || current === null) &&
+    options.length > 0
+  ) {
+    return options[0].value;
+  }
+
+  return null;
+};
+
 export const hasDataSource = (
   item: Component
 ): item is ComponentWithDataSource => {

--- a/ui/apps/everest/src/components/ui-generator/api-providers/data-source-prefetcher.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/data-source-prefetcher.tsx
@@ -20,6 +20,7 @@ import { useProviderOptions } from './registry';
 import { ComponentErrorBoundary } from '../component-error-boundary';
 import { getComponentSourcePath } from '../utils/preprocess/normalized-component';
 import { useClusterName } from 'hooks/api/useClusterName';
+import { getReconciledDataSourceValue } from './data-source-field/data-source-field.utils';
 
 type DataSourceDeclaration = {
   provider: string;
@@ -83,21 +84,11 @@ const PrefetchItem = ({
   useEffect(() => {
     if (isLoading) return;
 
-    const validValues = options.map((o) => o.value);
-
     for (const path of fieldPaths) {
-      const current = getValues(path);
+      const nextValue = getReconciledDataSourceValue(getValues(path), options);
 
-      // this block checks if the current form value is not in the valid options list (can happen during namespace change)
-      if (current && !validValues.includes(current as string)) {
-        setValue(path, options.length > 0 ? options[0].value : '', {
-          shouldValidate: true,
-        });
-      } else if (
-        (current === '' || current === undefined || current === null) &&
-        options.length > 0
-      ) {
-        setValue(path, options[0].value, { shouldValidate: true });
+      if (nextValue !== null) {
+        setValue(path, nextValue, { shouldValidate: true });
       }
     }
   }, [isLoading, options, fieldPaths, getValues, setValue]);

--- a/ui/apps/everest/src/hooks/api/backup-storages/useBackupStorages.ts
+++ b/ui/apps/everest/src/hooks/api/backup-storages/useBackupStorages.ts
@@ -35,6 +35,11 @@ import { useClusterName } from '../useClusterName';
 
 export const BACKUP_STORAGES_QUERY_KEY = 'backupStorages';
 
+export const getBackupStoragesQueryKey = (
+  cluster: string,
+  namespace: string
+) => [BACKUP_STORAGES_QUERY_KEY, cluster, namespace] as const;
+
 export const useBackupStorages = () => {
   const cluster = useClusterName();
   const { data: namespaces = [] } = useNamespaces({
@@ -42,7 +47,7 @@ export const useBackupStorages = () => {
   });
   const queries = namespaces.map((namespace) => {
     return {
-      queryKey: [BACKUP_STORAGES_QUERY_KEY, cluster, namespace],
+      queryKey: getBackupStoragesQueryKey(cluster, namespace),
       queryFn: () => getBackupStoragesFn(cluster, namespace),
       refetchInterval: 5 * 1000,
     };
@@ -61,7 +66,7 @@ export const useBackupStoragesByNamespace = (
 ) => {
   const cluster = useClusterName();
   return useQuery<BackupStorageCRD[], unknown, BackupStorageCRD[]>({
-    queryKey: [BACKUP_STORAGES_QUERY_KEY, cluster, namespace],
+    queryKey: getBackupStoragesQueryKey(cluster, namespace),
     queryFn: () => getBackupStoragesFn(cluster, namespace),
     ...options,
   });

--- a/ui/apps/everest/src/hooks/api/backup-storages/useBackupStorages.ts
+++ b/ui/apps/everest/src/hooks/api/backup-storages/useBackupStorages.ts
@@ -35,10 +35,8 @@ import { useClusterName } from '../useClusterName';
 
 export const BACKUP_STORAGES_QUERY_KEY = 'backupStorages';
 
-export const getBackupStoragesQueryKey = (
-  cluster: string,
-  namespace: string
-) => [BACKUP_STORAGES_QUERY_KEY, cluster, namespace] as const;
+export const getBackupStoragesQueryKey = (cluster: string, namespace: string) =>
+  [BACKUP_STORAGES_QUERY_KEY, cluster, namespace] as const;
 
 export const useBackupStorages = () => {
   const cluster = useClusterName();

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps-old/monitoring/monitoring.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps-old/monitoring/monitoring.tsx
@@ -26,7 +26,7 @@ import { CreateEditEndpointModal } from 'pages/settings/monitoring-endpoints/cre
 import { EndpointFormType } from 'pages/settings/monitoring-endpoints/createEditModal/create-edit-modal.types.ts';
 import { useFormContext } from 'react-hook-form';
 import { useQueryClient } from '@tanstack/react-query';
-import { updateDataAfterCreate } from 'utils/generalOptimisticDataUpdate.ts';
+import { optimisticCreateBy } from 'utils/generalOptimisticDataUpdate.ts';
 import { DbWizardFormFields } from 'consts.ts';
 import { useDatabasePageMode } from '../../../hooks/use-database-page-mode.js';
 import { StepHeader } from '../step-header/step-header.js';
@@ -35,6 +35,7 @@ import ActionableAlert from 'components/actionable-alert';
 import { convertMonitoringInstancesPayloadToTableFormat } from 'pages/settings/monitoring-endpoints/monitoring-endpoints.utils.ts';
 import { useRBACPermissions } from 'hooks/rbac';
 import { WizardMode } from 'shared-types/wizard.types.ts';
+import { MonitoringConfig } from 'shared-types/api.types';
 
 export const Monitoring = () => {
   const [openCreateEditModal, setOpenCreateEditModal] = useState(false);
@@ -107,10 +108,14 @@ export const Monitoring = () => {
       },
       {
         onSuccess: (newInstance) => {
-          updateDataAfterCreate(queryClient, [
-            MONITORING_INSTANCES_QUERY_KEY,
-            newInstance.namespace,
-          ])(newInstance);
+          optimisticCreateBy<MonitoringConfig>(
+            queryClient,
+            [MONITORING_INSTANCES_QUERY_KEY, newInstance.namespace],
+            newInstance,
+            (item) =>
+              item.metadata?.name === newInstance.metadata?.name &&
+              item.metadata?.namespace === newInstance.metadata?.namespace
+          );
           handleCloseModal();
         },
       }

--- a/ui/apps/everest/src/pages/settings/monitoring-endpoints/monitoring-endpoints.tsx
+++ b/ui/apps/everest/src/pages/settings/monitoring-endpoints/monitoring-endpoints.tsx
@@ -53,8 +53,7 @@ export const MonitoringEndpoints = () => {
 
   const monitoringConfigsLoading =
     isNamespacesLoading ||
-    (monitoringConfigs.length > 0 &&
-      !monitoringConfigs.some((result) => result.queryResult.isSuccess));
+    monitoringConfigs.some((result) => result.queryResult.isLoading);
 
   const { mutate: createMonitoringConfig, isPending: creatingConfig } =
     useCreateMonitoringConfig();

--- a/ui/apps/everest/src/pages/settings/storage-locations/createEditModal/create-edit-modal.tsx
+++ b/ui/apps/everest/src/pages/settings/storage-locations/createEditModal/create-edit-modal.tsx
@@ -22,6 +22,7 @@ import {
   StorageLocationsFields,
   storageLocationDefaultValues,
   storageLocationEditValues,
+  storageLocationsEditSchema,
   storageLocationsSchema,
 } from '../storage-locations.types';
 import { CreateEditStorageForm } from './create-edit-form';
@@ -37,13 +38,7 @@ export const CreateEditModalStorage = ({
 }: CreateEditModalStorageProps) => {
   const isEditMode = !!selectedStorageLocation;
   const schema = useMemo(
-    () =>
-      isEditMode
-        ? storageLocationsSchema.partial({
-            [StorageLocationsFields.accessKey]: true,
-            [StorageLocationsFields.secretKey]: true,
-          })
-        : storageLocationsSchema,
+    () => (isEditMode ? storageLocationsEditSchema : storageLocationsSchema),
     [isEditMode]
   );
 

--- a/ui/apps/everest/src/pages/settings/storage-locations/storage-locations.tsx
+++ b/ui/apps/everest/src/pages/settings/storage-locations/storage-locations.tsx
@@ -47,9 +47,9 @@ import { useClusterName } from 'hooks/api/useClusterName';
 import TableActionsMenu from '../../../components/table-actions-menu';
 import { StorageLocationsActionButtons } from './storage-locations-menu-actions';
 import {
-  updateDataAfterCreate,
-  updateDataAfterDelete,
-  updateDataAfterEdit,
+  optimisticCreateBy,
+  optimisticDeleteBy,
+  optimisticEditBy,
 } from 'utils/generalOptimisticDataUpdate';
 
 export const StorageLocations = () => {
@@ -129,11 +129,15 @@ export const StorageLocations = () => {
     const queryKey = getBackupStoragesQueryKey(clusterName, data.namespace);
     editBackupStorage(data, {
       onSuccess: (updatedLocation) => {
-        updateDataAfterEdit(
+        const updatedStorage = updatedLocation as BackupStorageCRD;
+        optimisticEditBy<BackupStorageCRD>(
           queryClient,
           queryKey,
-          StorageLocationsFields.name
-        )(updatedLocation as BackupStorageCRD);
+          updatedStorage,
+          (item) =>
+            item.metadata?.name === updatedStorage.metadata?.name &&
+            item.metadata?.namespace === updatedStorage.metadata?.namespace
+        );
         handleCloseModal();
       },
     });
@@ -143,10 +147,15 @@ export const StorageLocations = () => {
     const queryKey = getBackupStoragesQueryKey(clusterName, data.namespace);
     createBackupStorage(data, {
       onSuccess: (newLocation) => {
-        updateDataAfterCreate(
+        const createdStorage = newLocation as BackupStorageCRD;
+        optimisticCreateBy<BackupStorageCRD>(
           queryClient,
-          queryKey
-        )(newLocation as BackupStorageCRD);
+          queryKey,
+          createdStorage,
+          (item) =>
+            item.metadata?.name === createdStorage.metadata?.name &&
+            item.metadata?.namespace === createdStorage.metadata?.namespace
+        );
         handleCloseModal();
       },
     });
@@ -182,11 +191,13 @@ export const StorageLocations = () => {
       },
       {
         onSuccess: () => {
-          updateDataAfterDelete(
+          optimisticDeleteBy<BackupStorageCRD>(
             queryClient,
             queryKey,
-            StorageLocationsFields.name
-          )({} as BackupStorageCRD, backupStorageName);
+            (item) =>
+              item.metadata?.name === backupStorageName &&
+              item.metadata?.namespace === namespace
+          );
           handleCloseDeleteDialog();
         },
       }

--- a/ui/apps/everest/src/pages/settings/storage-locations/storage-locations.tsx
+++ b/ui/apps/everest/src/pages/settings/storage-locations/storage-locations.tsx
@@ -18,7 +18,7 @@ import { Table } from '@percona/ui-lib';
 import { useQueryClient } from '@tanstack/react-query';
 import { ConfirmDialog } from 'components/confirm-dialog/confirm-dialog';
 import {
-  BACKUP_STORAGES_QUERY_KEY,
+  getBackupStoragesQueryKey,
   useBackupStorages,
   useCreateBackupStorage,
   useDeleteBackupStorage,
@@ -46,6 +46,11 @@ import { useNamespacePermissionsForResource } from 'hooks/rbac';
 import { useClusterName } from 'hooks/api/useClusterName';
 import TableActionsMenu from '../../../components/table-actions-menu';
 import { StorageLocationsActionButtons } from './storage-locations-menu-actions';
+import {
+  updateDataAfterCreate,
+  updateDataAfterDelete,
+  updateDataAfterEdit,
+} from 'utils/generalOptimisticDataUpdate';
 
 export const StorageLocations = () => {
   const queryClient = useQueryClient();
@@ -120,23 +125,25 @@ export const StorageLocations = () => {
     setOpenCreateEditModal(false);
   };
 
-  const handleEditBackup = (data: BackupStorageFormValues) => {
+  const handleEditBackupStorage = (data: BackupStorageFormValues) => {
+    const queryKey = getBackupStoragesQueryKey(clusterName, data.namespace);
     editBackupStorage(data, {
-      onSuccess: () => {
-        queryClient.invalidateQueries({
-          queryKey: [BACKUP_STORAGES_QUERY_KEY, clusterName, data.namespace],
-        });
+      onSuccess: (updatedLocation) => {
+        updateDataAfterEdit(queryClient, queryKey, StorageLocationsFields.name)(
+          updatedLocation as BackupStorageCRD
+        );
         handleCloseModal();
       },
     });
   };
 
   const handleCreateBackup = (data: BackupStorageFormValues) => {
+    const queryKey = getBackupStoragesQueryKey(clusterName, data.namespace);
     createBackupStorage(data, {
-      onSuccess: () => {
-        queryClient.invalidateQueries({
-          queryKey: [BACKUP_STORAGES_QUERY_KEY, clusterName, data.namespace],
-        });
+      onSuccess: (newLocation) => {
+        updateDataAfterCreate(queryClient, queryKey)(
+          newLocation as BackupStorageCRD
+        );
         handleCloseModal();
       },
     });
@@ -144,7 +151,7 @@ export const StorageLocations = () => {
 
   const handleSubmit = (isEdit: boolean, data: BackupStorageFormValues) => {
     if (isEdit) {
-      handleEditBackup(data);
+      handleEditBackupStorage(data);
     } else {
       handleCreateBackup(data);
     }
@@ -164,18 +171,24 @@ export const StorageLocations = () => {
     backupStorageName: string,
     namespace: string
   ) => {
+    const queryKey = getBackupStoragesQueryKey(clusterName, namespace);
     deleteBackupStorage(
-      { backupStorageId: backupStorageName, namespace: namespace },
+      {
+        backupStorageId: backupStorageName,
+        namespace,
+      },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: [BACKUP_STORAGES_QUERY_KEY, clusterName, namespace],
-          });
+          updateDataAfterDelete(queryClient, queryKey, StorageLocationsFields.name)(
+            {} as BackupStorageCRD,
+            backupStorageName
+          );
           handleCloseDeleteDialog();
         },
       }
     );
   };
+
   return (
     <>
       <Table

--- a/ui/apps/everest/src/pages/settings/storage-locations/storage-locations.tsx
+++ b/ui/apps/everest/src/pages/settings/storage-locations/storage-locations.tsx
@@ -129,9 +129,11 @@ export const StorageLocations = () => {
     const queryKey = getBackupStoragesQueryKey(clusterName, data.namespace);
     editBackupStorage(data, {
       onSuccess: (updatedLocation) => {
-        updateDataAfterEdit(queryClient, queryKey, StorageLocationsFields.name)(
-          updatedLocation as BackupStorageCRD
-        );
+        updateDataAfterEdit(
+          queryClient,
+          queryKey,
+          StorageLocationsFields.name
+        )(updatedLocation as BackupStorageCRD);
         handleCloseModal();
       },
     });
@@ -141,9 +143,10 @@ export const StorageLocations = () => {
     const queryKey = getBackupStoragesQueryKey(clusterName, data.namespace);
     createBackupStorage(data, {
       onSuccess: (newLocation) => {
-        updateDataAfterCreate(queryClient, queryKey)(
-          newLocation as BackupStorageCRD
-        );
+        updateDataAfterCreate(
+          queryClient,
+          queryKey
+        )(newLocation as BackupStorageCRD);
         handleCloseModal();
       },
     });
@@ -179,10 +182,11 @@ export const StorageLocations = () => {
       },
       {
         onSuccess: () => {
-          updateDataAfterDelete(queryClient, queryKey, StorageLocationsFields.name)(
-            {} as BackupStorageCRD,
-            backupStorageName
-          );
+          updateDataAfterDelete(
+            queryClient,
+            queryKey,
+            StorageLocationsFields.name
+          )({} as BackupStorageCRD, backupStorageName);
           handleCloseDeleteDialog();
         },
       }

--- a/ui/apps/everest/src/pages/settings/storage-locations/storage-locations.types.ts
+++ b/ui/apps/everest/src/pages/settings/storage-locations/storage-locations.types.ts
@@ -86,6 +86,11 @@ export const storageLocationsSchema = z.object({
   [StorageLocationsFields.forcePathStyle]: z.boolean(),
 });
 
+export const storageLocationsEditSchema = storageLocationsSchema.extend({
+  [StorageLocationsFields.accessKey]: z.string(),
+  [StorageLocationsFields.secretKey]: z.string(),
+});
+
 export type BackupStorageType = z.infer<typeof storageLocationsSchema>;
 
 export interface BackupStorageTableElement {

--- a/ui/apps/everest/src/pages/settings/storage-locations/storage-locations.types.ts
+++ b/ui/apps/everest/src/pages/settings/storage-locations/storage-locations.types.ts
@@ -19,6 +19,16 @@ import {
 } from 'shared-types/backupStorages.types';
 import { rfc_123_schema } from 'utils/common-validation';
 
+export type BackupStoragesMutationContext = {
+  queryKey: readonly [string, string, string];
+  previousStorages?: BackupStorageCRD[];
+};
+
+export type DeleteBackupStorageArgs = {
+  backupStorageId: string;
+  namespace: string;
+};
+
 export enum StorageLocationsFields {
   name = 'name',
   type = 'type',
@@ -27,7 +37,6 @@ export enum StorageLocationsFields {
   url = 'url',
   accessKey = 'accessKey',
   secretKey = 'secretKey',
-  namespaces = 'allowedNamespaces',
   namespace = 'namespace',
   verifyTLS = 'verifyTLS',
   forcePathStyle = 'forcePathStyle',

--- a/ui/apps/everest/src/pages/settings/storage-locations/storage-locations.utils.ts
+++ b/ui/apps/everest/src/pages/settings/storage-locations/storage-locations.utils.ts
@@ -23,16 +23,13 @@ import { BackupStorageTableElement } from './storage-locations.types';
 export const convertStoragesType = (value: StorageType) =>
   ({
     [StorageType.S3]: Messages.s3,
-    [StorageType.GCS]: Messages.gcs,
-    [StorageType.AZURE]: Messages.azure,
-  })[value];
+  })[value] ?? value;
 
 export const convertBackupStoragesPayloadToTableFormat = (
   data: UseQueryResult<BackupStorageCRD[], Error>[]
 ): BackupStorageTableElement[] => {
-  const result: BackupStorageTableElement[] = [];
-  data.forEach((item) => {
-    const tableDataForNamespace: BackupStorageTableElement[] = item.isSuccess
+  return data.flatMap((item) =>
+    item.isSuccess
       ? item.data.map((storage) => ({
           namespace: storage.metadata?.namespace ?? '',
           name: storage.metadata?.name ?? '',
@@ -41,8 +38,6 @@ export const convertBackupStoragesPayloadToTableFormat = (
           url: storage.spec?.s3?.endpointURL ?? '',
           raw: storage,
         }))
-      : [];
-    result.push(...tableDataForNamespace);
-  });
-  return result;
+      : []
+  );
 };

--- a/ui/apps/everest/src/shared-types/backupStorages.types.ts
+++ b/ui/apps/everest/src/shared-types/backupStorages.types.ts
@@ -39,6 +39,6 @@ export interface BackupStorageFormValues {
 
 export enum StorageType {
   S3 = 's3',
-  AZURE = 'azure',
-  GCS = 'gcs',
+  // AZURE = 'azure',
+  // GCS = 'gcs',
 }

--- a/ui/apps/everest/src/utils/generalOptimisticDataUpdate.ts
+++ b/ui/apps/everest/src/utils/generalOptimisticDataUpdate.ts
@@ -68,39 +68,3 @@ export const optimisticDeleteBy = <T>(
     oldData.filter((item) => !shouldDelete(item))
   );
 };
-
-export const updateDataAfterEdit =
-  (
-    queryClient: QueryClient,
-    queryKey: readonly unknown[],
-    identifier: string | undefined = 'id'
-  ) =>
-  <T extends object>(updatedObject: T) => {
-    queryClient.setQueryData(queryKey, (oldData?: T[]) => {
-      return (oldData || []).map((value) =>
-        // @ts-ignore
-        value[identifier] === updatedObject[identifier] ? updatedObject : value
-      );
-    });
-  };
-
-export const updateDataAfterCreate =
-  (queryClient: QueryClient, queryKey: readonly unknown[]) =>
-  <T extends object>(createdObject: T) => {
-    queryClient.setQueryData(queryKey, (oldData?: T[]) => {
-      return [createdObject, ...(oldData || [])];
-    });
-  };
-
-export const updateDataAfterDelete =
-  (
-    queryClient: QueryClient,
-    queryKey: readonly unknown[],
-    identifier: string | undefined = 'id'
-  ) =>
-  <T extends object>(_: T, objectId: string) => {
-    queryClient.setQueryData(queryKey, (oldData?: T[]) => {
-      // @ts-ignore
-      return (oldData || []).filter((value) => value[identifier] !== objectId);
-    });
-  };

--- a/ui/apps/everest/src/utils/generalOptimisticDataUpdate.ts
+++ b/ui/apps/everest/src/utils/generalOptimisticDataUpdate.ts
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { QueryClient } from '@tanstack/react-query';
 
 export type OptimisticQueryContext<T> = {

--- a/ui/apps/everest/src/utils/generalOptimisticDataUpdate.ts
+++ b/ui/apps/everest/src/utils/generalOptimisticDataUpdate.ts
@@ -1,13 +1,68 @@
 import { QueryClient } from '@tanstack/react-query';
 
+export type OptimisticQueryContext<T> = {
+  queryKey: readonly unknown[];
+  previousData?: T[];
+};
+
+export const snapshotQueryData = <T>(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[]
+): OptimisticQueryContext<T> => ({
+  queryKey,
+  previousData: queryClient.getQueryData<T[]>(queryKey),
+});
+
+export const rollbackQueryData = <T>(
+  queryClient: QueryClient,
+  context?: OptimisticQueryContext<T>
+) => {
+  if (context) {
+    queryClient.setQueryData(context.queryKey, context.previousData);
+  }
+};
+
+export const optimisticCreateBy = <T>(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[],
+  createdObject: T,
+  isSame: (item: T) => boolean
+) => {
+  queryClient.setQueryData<T[]>(queryKey, (oldData = []) => [
+    createdObject,
+    ...oldData.filter((item) => !isSame(item)),
+  ]);
+};
+
+export const optimisticEditBy = <T>(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[],
+  updatedObject: T,
+  isSame: (item: T) => boolean
+) => {
+  queryClient.setQueryData<T[]>(queryKey, (oldData = []) =>
+    oldData.map((item) => (isSame(item) ? updatedObject : item))
+  );
+};
+
+export const optimisticDeleteBy = <T>(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[],
+  shouldDelete: (item: T) => boolean
+) => {
+  queryClient.setQueryData<T[]>(queryKey, (oldData = []) =>
+    oldData.filter((item) => !shouldDelete(item))
+  );
+};
+
 export const updateDataAfterEdit =
   (
     queryClient: QueryClient,
-    queryKey: string[],
+    queryKey: readonly unknown[],
     identifier: string | undefined = 'id'
   ) =>
   <T extends object>(updatedObject: T) => {
-    queryClient.setQueryData([queryKey], (oldData?: T[]) => {
+    queryClient.setQueryData(queryKey, (oldData?: T[]) => {
       return (oldData || []).map((value) =>
         // @ts-ignore
         value[identifier] === updatedObject[identifier] ? updatedObject : value
@@ -16,7 +71,7 @@ export const updateDataAfterEdit =
   };
 
 export const updateDataAfterCreate =
-  (queryClient: QueryClient, queryKey: string[]) =>
+  (queryClient: QueryClient, queryKey: readonly unknown[]) =>
   <T extends object>(createdObject: T) => {
     queryClient.setQueryData(queryKey, (oldData?: T[]) => {
       return [createdObject, ...(oldData || [])];
@@ -26,11 +81,11 @@ export const updateDataAfterCreate =
 export const updateDataAfterDelete =
   (
     queryClient: QueryClient,
-    queryKey: string[],
+    queryKey: readonly unknown[],
     identifier: string | undefined = 'id'
   ) =>
   <T extends object>(_: T, objectId: string) => {
-    queryClient.setQueryData([queryKey], (oldData?: T[]) => {
+    queryClient.setQueryData(queryKey, (oldData?: T[]) => {
       // @ts-ignore
       return (oldData || []).filter((value) => value[identifier] !== objectId);
     });


### PR DESCRIPTION
Backup Storage E2E Tests
This PR adds and improves end-to-end tests for backup storage features

Main changes:
Uses one shared namespace (everest)  instead of separate namespaces for each provider type
Enabled backup storage tests: Uncommented and activated backup storage tests in the CI pipeline.
Better backup storage API: Updated API paths to include cluster information for consistency.


Refactored data source logic: Moved field value reconciliation into a separate utility with dedicated tests for better code organization
Optimistic UI updates: Added smart data synchronization so UI updates immediately without waiting for server response, then rolls back if something fails.