### PR TITLE
fix(namespaces): use %w instead of %s in NewErrNamespaceAlreadyManagedByEverest to fix errors.Is check

### DIFF
--- a/pkg/cli/namespaces/errors.go
+++ b/pkg/cli/namespaces/errors.go
@@ -51,7 +51,7 @@ var (
 
 	// ErrNamespaceAlreadyManagedByEverest appears when the namespace is already owned by Everest.
 	NewErrNamespaceAlreadyManagedByEverest = func(namespace string) error {
-		return fmt.Errorf("'%s': %s", namespace, ErrNamespaceAlreadyManagedByEverest)
+		return fmt.Errorf("'%s': %w", namespace, ErrNamespaceAlreadyManagedByEverest)
 	}
 
 	// ErrNamespaceListEmpty appears when the provided list of the namespaces is considered empty.

--- a/pkg/cli/namespaces/errors_test.go
+++ b/pkg/cli/namespaces/errors_test.go
@@ -1,0 +1,30 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespaces
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewErrNamespaceAlreadyManagedByEverest_ErrorsIs(t *testing.T) {
+	t.Parallel()
+	err := NewErrNamespaceAlreadyManagedByEverest("my-ns")
+	assert.True(t, errors.Is(err, ErrNamespaceAlreadyManagedByEverest),
+		"errors.Is should match sentinel after wrapping with %%w")
+}


### PR DESCRIPTION
Fixes #2355

## What

Single-character fix: `%s` → `%w` in `NewErrNamespaceAlreadyManagedByEverest` so the sentinel error is properly wrapped and `errors.Is` can unwrap it.

## Why

`pkg/cli/namespaces/errors.go` has 4 error constructors. Three wrap with `%w`, one uses `%s` by mistake:

```go
NewErrNamespaceNotExist                → fmt.Errorf("'%s': %w", ...)  ✓
NewErrNamespaceAlreadyExists           → fmt.Errorf("'%s': %w", ...)  ✓
NewErrNamespaceNotManagedByEverest     → fmt.Errorf("'%s': %w", ...)  ✓
NewErrNamespaceAlreadyManagedByEverest → fmt.Errorf("'%s': %s", ...)  ← bug
```

Because `%s` doesn't wrap, this block in `commands/namespaces/add.go` is dead code — `updateHintMessage` never reaches the user:

```go
if errors.Is(err, namespaces.ErrNamespaceAlreadyManagedByEverest) {
    err = fmt.Errorf("%w. %s", err, updateHintMessage) // never executes
}
```

## Changes

- `pkg/cli/namespaces/errors.go` — `%s` → `%w` (line 54)
- `pkg/cli/namespaces/errors_test.go` — new unit test verifying
  `errors.Is` matches sentinel correctly after fix

## Checklist
- [x] `make test` passes
- [x] `make copyright-check` passes
- [x] Commit signed off (`git commit -s`)
- [x] Scoped to single bug, no unrelated changes