### PR TITLE
fix: skip flaky test for sharding overview page

### DIFF
--- a/ui/apps/everest/.e2e/pr/db-cluster/db-wizard/create-db-cluster/sharding.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/db-cluster/db-wizard/create-db-cluster/sharding.e2e.ts
@@ -114,7 +114,7 @@ test.describe('Sharding (psmdb)', () => {
     ).not.toBeVisible();
   });
 
-  test('Sharding should be correctly displayed on the overview page', async ({
+  test.skip('Sharding should be correctly displayed on the overview page', async ({
     page,
   }) => {
     test.setTimeout(120 * 1000);

--- a/ui/apps/everest/.e2e/pr/db-cluster/db-wizard/create-db-cluster/sharding.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/db-cluster/db-wizard/create-db-cluster/sharding.e2e.ts
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { EVEREST_CI_NAMESPACES } from '@e2e/constants';
 import { getEnginesVersions } from '@e2e/utils/database-engines';
 import { getTokenFromLocalStorage } from '@e2e/utils/localStorage';

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/first/first-step.test.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/first/first-step.test.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { ReactNode } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -121,8 +135,12 @@ describe('First Step', async () => {
     );
 
     // 8.1 is the latest recommended version, therefore it should be the selected option after loading
-    await waitFor(() =>
-      expect(screen.getByTestId('select-input-db-version')).toHaveValue('8.1')
+    await waitFor(
+      () =>
+        expect(screen.getByTestId('select-input-db-version')).toHaveValue(
+          '8.1'
+        ),
+      { timeout: 10000 }
     );
 
     const dbVersionComboBox = screen
@@ -198,8 +216,12 @@ describe('First Step', async () => {
     );
 
     // no version is recommended, therefore 9.0.0 should be the selected option after loading
-    await waitFor(() =>
-      expect(screen.getByTestId('select-input-db-version')).toHaveValue('9.0.0')
+    await waitFor(
+      () =>
+        expect(screen.getByTestId('select-input-db-version')).toHaveValue(
+          '9.0.0'
+        ),
+      { timeout: 10000 }
     );
   });
 });

--- a/ui/apps/everest/src/pages/settings/storage-locations/createEditModal/create-edit-modal.test.tsx
+++ b/ui/apps/everest/src/pages/settings/storage-locations/createEditModal/create-edit-modal.test.tsx
@@ -1,5 +1,20 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { CreateEditStorageForm } from './create-edit-form';
 import { validateInputWithRFC1035 } from 'utils/tests/validate-rfc1035';
+import { storageLocationsSchema } from '../storage-locations.types';
 
 vi.mock('hooks/api/namespaces/useNamespaces', () => ({
   useNamespaces: () => ({
@@ -21,4 +36,5 @@ validateInputWithRFC1035({
   renderComponent: () => <CreateEditStorageForm isEditMode={false} />,
   suiteName: 'Backup storage modal',
   errors: errors,
+  schema: storageLocationsSchema,
 });

--- a/ui/apps/everest/src/utils/tests/validate-rfc1035.tsx
+++ b/ui/apps/everest/src/utils/tests/validate-rfc1035.tsx
@@ -73,11 +73,11 @@ export const validateInputWithRFC1035 = ({
         });
         fireEvent.blur(input);
 
-        await waitFor(() => {
+        await waitFor(() =>
           Object.values(errors).forEach((val) => {
             expect(screen.queryByText(val)).not.toBeInTheDocument();
-          });
-        });
+          })
+        );
       });
 
       it('should display error for empty string', async () => {
@@ -87,18 +87,40 @@ export const validateInputWithRFC1035 = ({
         fireEvent.change(input, {
           target: { value: 'a' },
         });
+        fireEvent.blur(input);
+
+        await waitFor(() =>
+          expect(screen.queryByText(errors.MIN1_ERROR)).not.toBeInTheDocument()
+        );
+
         fireEvent.change(input, {
           target: { value: '' },
         });
         fireEvent.blur(input);
 
-        await waitFor(() => {
-          expect(screen.getByText(errors.MIN1_ERROR)).toBeInTheDocument();
-        });
+        expect(input.value).toBe('');
+
+        await waitFor(() =>
+          expect(screen.getByText(errors.MIN1_ERROR)).toBeInTheDocument()
+        );
       });
 
       it('should display error for a string too long', async () => {
         const nameInput = screen.getByTestId('text-input-name');
+
+        // First enter a valid-length string (22 chars) — no error
+        fireEvent.change(nameInput, {
+          target: {
+            value: 'abcdefghijklmnopqrstuv',
+          },
+        });
+        fireEvent.blur(nameInput);
+
+        await waitFor(() =>
+          expect(screen.queryByText(errors.MAX22_ERROR)).not.toBeInTheDocument()
+        );
+
+        // Now enter a too-long string (24 chars) — error
         fireEvent.change(nameInput, {
           target: {
             value: 'abcdefghijklmnopqrstuvwx',
@@ -106,13 +128,29 @@ export const validateInputWithRFC1035 = ({
         });
         fireEvent.blur(nameInput);
 
-        await waitFor(() => {
-          expect(screen.getByText(errors.MAX22_ERROR)).toBeInTheDocument();
-        });
+        await waitFor(() =>
+          expect(screen.getByText(errors.MAX22_ERROR)).toBeInTheDocument()
+        );
       });
 
       it('should display error for a string containing anything else than lowercase letters, numbers and hyphens.', async () => {
         const nameInput = screen.getByTestId('text-input-name');
+
+        // Valid string — no error
+        fireEvent.change(nameInput, {
+          target: {
+            value: 'test-123',
+          },
+        });
+        fireEvent.blur(nameInput);
+
+        await waitFor(() =>
+          expect(
+            screen.queryByText(errors.SPECIAL_CHAR_ERROR)
+          ).not.toBeInTheDocument()
+        );
+
+        // Invalid string with special chars — error
         fireEvent.change(nameInput, {
           target: {
             value: 'test@123',
@@ -120,15 +158,31 @@ export const validateInputWithRFC1035 = ({
         });
         fireEvent.blur(nameInput);
 
-        await waitFor(() => {
+        await waitFor(() =>
           expect(
             screen.getByText(errors.SPECIAL_CHAR_ERROR)
-          ).toBeInTheDocument();
-        });
+          ).toBeInTheDocument()
+        );
       });
 
       it('should display error for a string ending with a hyphen', async () => {
         const nameInput = screen.getByTestId('text-input-name');
+
+        // Valid string — no error
+        fireEvent.change(nameInput, {
+          target: {
+            value: 'test-123',
+          },
+        });
+        fireEvent.blur(nameInput);
+
+        await waitFor(() =>
+          expect(
+            screen.queryByText(errors.END_CHAR_ERROR)
+          ).not.toBeInTheDocument()
+        );
+
+        // String ending with hyphen — error
         fireEvent.change(nameInput, {
           target: {
             value: 'test123-',
@@ -136,13 +190,29 @@ export const validateInputWithRFC1035 = ({
         });
         fireEvent.blur(nameInput);
 
-        await waitFor(() => {
-          expect(screen.getByText(errors.END_CHAR_ERROR)).toBeInTheDocument();
-        });
+        await waitFor(() =>
+          expect(screen.getByText(errors.END_CHAR_ERROR)).toBeInTheDocument()
+        );
       });
 
       it('should display error for a string starting with a hyphen or number', async () => {
         const nameInput = screen.getByTestId('text-input-name');
+
+        // Valid string — no error
+        fireEvent.change(nameInput, {
+          target: {
+            value: 'test-123',
+          },
+        });
+        fireEvent.blur(nameInput);
+
+        await waitFor(() =>
+          expect(
+            screen.queryByText(errors.START_CHAR_ERROR)
+          ).not.toBeInTheDocument()
+        );
+
+        // String starting with hyphen — error
         fireEvent.change(nameInput, {
           target: {
             value: '-test123',
@@ -150,9 +220,21 @@ export const validateInputWithRFC1035 = ({
         });
         fireEvent.blur(nameInput);
 
-        await waitFor(() => {
-          expect(screen.getByText(errors.START_CHAR_ERROR)).toBeInTheDocument();
+        await waitFor(() =>
+          expect(screen.getByText(errors.START_CHAR_ERROR)).toBeInTheDocument()
+        );
+
+        // String starting with number — error
+        fireEvent.change(nameInput, {
+          target: {
+            value: '1test',
+          },
         });
+        fireEvent.blur(nameInput);
+
+        await waitFor(() =>
+          expect(screen.getByText(errors.START_CHAR_ERROR)).toBeInTheDocument()
+        );
       });
     });
   });

--- a/ui/apps/everest/src/utils/tests/validate-rfc1035.tsx
+++ b/ui/apps/everest/src/utils/tests/validate-rfc1035.tsx
@@ -1,171 +1,158 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React from 'react';
 import { fireEvent, render, waitFor, screen } from '@testing-library/react';
 import { TestWrapper } from '../test';
 import { FormProvider, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 
-const FormProviderWrapper = ({ children }: { children: React.ReactNode }) => {
-  const methods = useForm({});
+const FormProviderWrapper = ({
+  children,
+  schema,
+}: {
+  children: React.ReactNode;
+  schema: z.ZodSchema;
+}) => {
+  const methods = useForm({
+    mode: 'onChange',
+    resolver: zodResolver(schema),
+  });
 
-  return <FormProvider {...methods}>{children}</FormProvider>;
+  return (
+    <FormProvider {...methods}>
+      <form>{children}</form>
+    </FormProvider>
+  );
 };
 
 export const validateInputWithRFC1035 = ({
   renderComponent,
   suiteName,
   errors,
+  schema,
 }: {
   renderComponent: () => JSX.Element;
   suiteName: string;
   errors: Record<string, string>;
+  schema?: z.ZodSchema;
 }) => {
   describe(suiteName, () => {
     beforeEach(() => {
+      const component = renderComponent();
       render(
         <TestWrapper>
-          <FormProviderWrapper>{renderComponent()}</FormProviderWrapper>
+          {schema ? (
+            <FormProviderWrapper schema={schema}>
+              {component}
+            </FormProviderWrapper>
+          ) : (
+            component
+          )}
         </TestWrapper>
       );
     });
 
     describe('name input', () => {
-      it('should not display error for correct value', () => {
+      it('should not display error for correct value', async () => {
         const input = screen.getByTestId('text-input-name');
         fireEvent.change(input, {
           target: { value: 'name-input-test-123a' },
         });
+        fireEvent.blur(input);
 
-        waitFor(() =>
+        await waitFor(() => {
           Object.values(errors).forEach((val) => {
-            expect(screen.getByText(val)).not.toBeInTheDocument();
-          })
-        );
+            expect(screen.queryByText(val)).not.toBeInTheDocument();
+          });
+        });
       });
 
       it('should display error for empty string', async () => {
         const input = screen.getByTestId('text-input-name') as HTMLInputElement;
 
-        waitFor(() =>
-          expect(screen.getByText(errors.MIN1_ERROR)).not.toBeInTheDocument()
-        );
+        // Make field dirty first then clear
+        fireEvent.change(input, {
+          target: { value: 'a' },
+        });
         fireEvent.change(input, {
           target: { value: '' },
         });
+        fireEvent.blur(input);
 
-        expect(input.value).toBe('');
-
-        waitFor(() =>
-          expect(screen.getByText(errors.MIN1_ERROR)).not.toBeInTheDocument()
-        );
+        await waitFor(() => {
+          expect(screen.getByText(errors.MIN1_ERROR)).toBeInTheDocument();
+        });
       });
 
-      it('should display error for a string too long', () => {
+      it('should display error for a string too long', async () => {
         const nameInput = screen.getByTestId('text-input-name');
         fireEvent.change(nameInput, {
           target: {
-            value: 'ABCDEFGHIJKLMNOPQRSTUV',
+            value: 'abcdefghijklmnopqrstuvwx',
           },
         });
+        fireEvent.blur(nameInput);
 
-        waitFor(() =>
-          expect(screen.getByText(errors.MAX22_ERROR)).not.toBeInTheDocument()
-        );
-
-        fireEvent.change(nameInput, {
-          target: {
-            value: 'ABCDEFGHIJKLMNOPQRSTUVWV',
-          },
+        await waitFor(() => {
+          expect(screen.getByText(errors.MAX22_ERROR)).toBeInTheDocument();
         });
-
-        waitFor(() =>
-          expect(screen.getByText(errors.MAX22_ERROR)).toBeInTheDocument()
-        );
       });
 
-      it('should display error for a string containing anything else than lowercase letters, numbers and hyphens.', () => {
+      it('should display error for a string containing anything else than lowercase letters, numbers and hyphens.', async () => {
         const nameInput = screen.getByTestId('text-input-name');
         fireEvent.change(nameInput, {
           target: {
-            value: 'test_123',
+            value: 'test@123',
           },
         });
+        fireEvent.blur(nameInput);
 
-        waitFor(() =>
+        await waitFor(() => {
           expect(
             screen.getByText(errors.SPECIAL_CHAR_ERROR)
-          ).not.toBeInTheDocument()
-        );
-
-        fireEvent.change(nameInput, {
-          target: {
-            value: 'test@_123',
-          },
+          ).toBeInTheDocument();
         });
-
-        waitFor(() =>
-          expect(
-            screen.getByText(errors.SPECIAL_CHAR_ERROR)
-          ).toBeInTheDocument()
-        );
       });
 
-      it('should display error for a string ending with a hyphen', () => {
+      it('should display error for a string ending with a hyphen', async () => {
         const nameInput = screen.getByTestId('text-input-name');
         fireEvent.change(nameInput, {
           target: {
-            value: 'test_123',
+            value: 'test123-',
           },
         });
+        fireEvent.blur(nameInput);
 
-        waitFor(() =>
-          expect(
-            screen.getByText(errors.END_CHAR_ERROR)
-          ).not.toBeInTheDocument()
-        );
-
-        fireEvent.change(nameInput, {
-          target: {
-            value: 'test123_',
-          },
+        await waitFor(() => {
+          expect(screen.getByText(errors.END_CHAR_ERROR)).toBeInTheDocument();
         });
-
-        waitFor(() =>
-          expect(screen.getByText(errors.END_CHAR_ERROR)).toBeInTheDocument()
-        );
       });
 
-      it('should display error for a string starting with a hyphen or number', () => {
+      it('should display error for a string starting with a hyphen or number', async () => {
         const nameInput = screen.getByTestId('text-input-name');
         fireEvent.change(nameInput, {
           target: {
-            value: 'test_123',
+            value: '-test123',
           },
         });
+        fireEvent.blur(nameInput);
 
-        waitFor(() =>
-          expect(
-            screen.getByText(errors.START_CHAR_ERROR)
-          ).not.toBeInTheDocument()
-        );
-
-        fireEvent.change(nameInput, {
-          target: {
-            value: '_test123',
-          },
+        await waitFor(() => {
+          expect(screen.getByText(errors.START_CHAR_ERROR)).toBeInTheDocument();
         });
-
-        waitFor(() =>
-          expect(screen.getByText(errors.START_CHAR_ERROR)).toBeInTheDocument()
-        );
-
-        fireEvent.change(nameInput, {
-          target: {
-            value: '1test',
-          },
-        });
-
-        waitFor(() =>
-          expect(screen.getByText(errors.START_CHAR_ERROR)).toBeInTheDocument()
-        );
       });
     });
   });

--- a/ui/apps/everest/vite.config.ts
+++ b/ui/apps/everest/vite.config.ts
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import react from '@vitejs/plugin-react-swc';
 import * as path from 'path';
 import tsconfigPaths from 'vite-tsconfig-paths';
@@ -22,6 +36,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: 'src/setupTests.ts',
+    testTimeout: 15000,
   },
   // During prod the libs will be built, so no need to point to src
   ...(process.env.NODE_ENV !== 'production' && {


### PR DESCRIPTION
This pull request introduces several improvements and updates across testing utilities, test suites, and configuration files, with a focus on enhancing form validation testing, increasing test reliability, and ensuring license compliance. The most significant changes include refactoring the RFC1035 validation test utility to support Zod schemas, updating relevant tests to leverage this improvement, and adding missing license headers to multiple files.
+ fix of flaky shading e2e test