### PR TITLE
feat(auth): synchronize logout state across browser tabs

### DIFF
--- a/ui/apps/everest/src/contexts/auth/auth.provider.tsx
+++ b/ui/apps/everest/src/contexts/auth/auth.provider.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   AuthProvider as OidcAuthProvider,
@@ -14,6 +28,7 @@ import {
   removeApiAuthInterceptor,
 } from 'api/api';
 import { enqueueSnackbar } from 'notistack';
+import { useQueryClient } from '@tanstack/react-query';
 import AuthContext from './auth.context';
 import { EVEREST_JWT_ISSUER } from 'consts';
 import {
@@ -27,6 +42,7 @@ import {
   initializeAuthorizerFetchLoop,
   stopAuthorizerFetchLoop,
 } from 'utils/rbac';
+import { useCrossTabAuth } from 'hooks/utils';
 
 const Provider = ({
   oidcConfig,
@@ -51,6 +67,7 @@ const Provider = ({
 const AuthProvider = ({ children, isSsoEnabled }: AuthProviderProps) => {
   const [authStatus, setAuthStatus] = useState<UserAuthStatus>('unknown');
   const [redirect, setRedirect] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
   const { signIn, userManager } = useOidcAuth();
   const checkAuth = useCallback(async (token: string) => {
@@ -96,20 +113,32 @@ const AuthProvider = ({ children, isSsoEnabled }: AuthProviderProps) => {
     }
   };
 
-  const logout = async () => {
-    const token = localStorage.getItem('everestToken');
-    await api.delete('/session', { headers: { token: token } });
-    if (isSsoEnabled) {
-      await userManager.clearStaleState();
-      await setLogoutStatus();
-    }
-
+  const runLogoutCleanup = useCallback(async () => {
     setAuthStatus('loggedOut');
     localStorage.removeItem('everestToken');
     sessionStorage.clear();
     setRedirect(null);
+    stopAuthorizerFetchLoop();
+    queryClient.clear();
     removeApiErrorInterceptor();
     removeApiAuthInterceptor();
+    if (isSsoEnabled) {
+      await userManager.clearStaleState();
+      await userManager.removeUser();
+    }
+  }, [isSsoEnabled, queryClient, userManager]);
+
+  const { broadcastLogout } = useCrossTabAuth(runLogoutCleanup);
+
+  const logout = async () => {
+    const token = localStorage.getItem('everestToken');
+    try {
+      await api.delete('/session', { headers: { token: token } });
+    } catch {
+      // proceed with cleanup even if the session delete request fails
+    }
+    broadcastLogout();
+    await runLogoutCleanup();
   };
 
   const setRedirectRoute = (route: string) => {
@@ -126,12 +155,13 @@ const AuthProvider = ({ children, isSsoEnabled }: AuthProviderProps) => {
   const setLogoutStatus = useCallback(async () => {
     setAuthStatus('loggedOut');
     localStorage.removeItem('everestToken');
+    queryClient.clear();
     if (isSsoEnabled) {
       await userManager.clearStaleState();
       await userManager.removeUser();
     }
     stopAuthorizerFetchLoop();
-  }, [userManager]);
+  }, [isSsoEnabled, queryClient, userManager]);
 
   const silentlyRenewToken = useCallback(async () => {
     try {

--- a/ui/apps/everest/src/hooks/utils/index.ts
+++ b/ui/apps/everest/src/hooks/utils/index.ts
@@ -1,4 +1,19 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from './useActiveBreakpoint';
+export * from './useCrossTabAuth';
 export * from './useDeleteModal';
 export * from './useLocalStorage';
 export * from './useUpdateEntityWithConflictRetry';

--- a/ui/apps/everest/src/hooks/utils/useCrossTabAuth.test.ts
+++ b/ui/apps/everest/src/hooks/utils/useCrossTabAuth.test.ts
@@ -1,0 +1,104 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCrossTabAuth } from './useCrossTabAuth';
+
+type MockChannel = {
+  postMessage: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  onmessage: ((event: MessageEvent) => void) | null;
+};
+
+describe('useCrossTabAuth', () => {
+  let mockChannel: MockChannel;
+
+  beforeEach(() => {
+    mockChannel = { postMessage: vi.fn(), close: vi.fn(), onmessage: null };
+    vi.stubGlobal('BroadcastChannel', vi.fn(() => mockChannel));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('opens a BroadcastChannel on mount and closes it on unmount', () => {
+    const { unmount } = renderHook(() => useCrossTabAuth(vi.fn()));
+    expect(BroadcastChannel).toHaveBeenCalledWith('everest-auth');
+    unmount();
+    expect(mockChannel.close).toHaveBeenCalledOnce();
+  });
+
+  it('broadcastLogout posts a LOGOUT message to the channel', () => {
+    const { result } = renderHook(() => useCrossTabAuth(vi.fn()));
+    act(() => {
+      result.current.broadcastLogout();
+    });
+    expect(mockChannel.postMessage).toHaveBeenCalledWith({ type: 'LOGOUT' });
+  });
+
+  it('calls onRemoteLogout when a LOGOUT message arrives from another tab', () => {
+    const onRemoteLogout = vi.fn();
+    renderHook(() => useCrossTabAuth(onRemoteLogout));
+
+    act(() => {
+      mockChannel.onmessage?.({ data: { type: 'LOGOUT' } } as MessageEvent);
+    });
+
+    expect(onRemoteLogout).toHaveBeenCalledOnce();
+  });
+
+  it('ignores messages with unknown types', () => {
+    const onRemoteLogout = vi.fn();
+    renderHook(() => useCrossTabAuth(onRemoteLogout));
+
+    act(() => {
+      mockChannel.onmessage?.({ data: { type: 'OTHER' } } as MessageEvent);
+    });
+
+    expect(onRemoteLogout).not.toHaveBeenCalled();
+  });
+
+  it('uses the latest callback without recreating the channel on rerender', () => {
+    const firstCallback = vi.fn();
+    const secondCallback = vi.fn();
+
+    const { rerender } = renderHook(({ cb }) => useCrossTabAuth(cb), {
+      initialProps: { cb: firstCallback },
+    });
+
+    expect(BroadcastChannel).toHaveBeenCalledTimes(1);
+
+    rerender({ cb: secondCallback });
+
+    expect(BroadcastChannel).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      mockChannel.onmessage?.({ data: { type: 'LOGOUT' } } as MessageEvent);
+    });
+
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(secondCallback).toHaveBeenCalledOnce();
+  });
+
+  it('does not call broadcastLogout after unmount', () => {
+    const { result, unmount } = renderHook(() => useCrossTabAuth(vi.fn()));
+    unmount();
+    act(() => {
+      result.current.broadcastLogout();
+    });
+    expect(mockChannel.postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/ui/apps/everest/src/hooks/utils/useCrossTabAuth.test.ts
+++ b/ui/apps/everest/src/hooks/utils/useCrossTabAuth.test.ts
@@ -27,7 +27,10 @@ describe('useCrossTabAuth', () => {
 
   beforeEach(() => {
     mockChannel = { postMessage: vi.fn(), close: vi.fn(), onmessage: null };
-    vi.stubGlobal('BroadcastChannel', vi.fn(() => mockChannel));
+    vi.stubGlobal(
+      'BroadcastChannel',
+      vi.fn(() => mockChannel)
+    );
   });
 
   afterEach(() => {

--- a/ui/apps/everest/src/hooks/utils/useCrossTabAuth.ts
+++ b/ui/apps/everest/src/hooks/utils/useCrossTabAuth.ts
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useCallback, useEffect, useRef } from 'react';
+
+const CHANNEL_NAME = 'everest-auth';
+
+type AuthMessage = { type: 'LOGOUT' };
+
+export const useCrossTabAuth = (onRemoteLogout: () => void) => {
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  const callbackRef = useRef(onRemoteLogout);
+
+  useEffect(() => {
+    callbackRef.current = onRemoteLogout;
+  });
+
+  useEffect(() => {
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+    channelRef.current = channel;
+
+    channel.onmessage = ({ data }: MessageEvent<AuthMessage>) => {
+      if (data.type === 'LOGOUT') {
+        callbackRef.current();
+      }
+    };
+
+    return () => {
+      channel.close();
+      channelRef.current = null;
+    };
+  }, []);
+
+  const broadcastLogout = useCallback(() => {
+    channelRef.current?.postMessage({ type: 'LOGOUT' } satisfies AuthMessage);
+  }, []);
+
+  return { broadcastLogout };
+};


### PR DESCRIPTION
## SUMMARY

Many OpenEverest users work across multiple tabs at the same time. Previously, logging out from one tab only cleaned up that tab, leaving other tabs with stale authenticated state.

This PR adds cross-tab logout synchronization and centralizes logout cleanup, ensuring all open tabs clear cached data, stop background activity, and stay in sync when a user signs out.

---

## FIX

### Before

```ts
const logout = async () => {
  await api.delete('/session');
  await setLogoutStatus();
};
```

### After

```ts
const logout = async () => {
  try {
    await api.delete('/session');
  } catch {}

  broadcastLogout();
  await runLogoutCleanup();
};
```


