### PR TITLE
fix: remove leftover debug output from DB engine upgrade validation

### DIFF
--- a/internal/server/handlers/validation/database_cluster.go
+++ b/internal/server/handlers/validation/database_cluster.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package validation
 
 import (
@@ -638,7 +652,6 @@ func validateDBEngineVersionUpgrade(engineType everestv1alpha1.EngineType, newVe
 	oldMajorInt, _ := strconv.Atoi(semver.Major(oldVersion)[1:])
 	// We will not allow major upgrades if the versions are not sequential.
 	if newMajorInt-oldMajorInt > 1 {
-		fmt.Println("errDBEngineMajorUpgradeNotSeq")
 		return errDBEngineMajorUpgradeNotSeq
 	}
 	return nil


### PR DESCRIPTION
### SUMMARY

This PR removes a leftover debug statement from the database engine upgrade validation flow. The change is limited to `internal/server/handlers/validation/database_cluster.go` and keeps the existing validation behavior unchanged while preventing unnecessary stdout output in production.

### FIX

```go
//Before
if newMajorInt-oldMajorInt > 1 {
    fmt.Println("errDBEngineMajorUpgradeNotSeq")
    return errDBEngineMajorUpgradeNotSeq
}

//After
if newMajorInt-oldMajorInt > 1 {
    return errDBEngineMajorUpgradeNotSeq
}
```
