### PR TITLE
auth: implement everestctl auth logout

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -24,13 +24,13 @@ import (
 
 var authCmd = &cobra.Command{
 	Use:   "auth <command> [flags]",
-	Args:  cobra.ExactArgs(1),
 	Short: "Manage Everest authentication",
 	Long:  "Manage Everest authentication",
-	Run:   func(_ *cobra.Command, _ []string) {},
+	RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 }
 
 func init() {
 	rootCmd.AddCommand(authCmd)
 	authCmd.AddCommand(auth.GetLoginCmd())
+	authCmd.AddCommand(auth.GetLogoutCmd())
 }

--- a/commands/auth/logout.go
+++ b/commands/auth/logout.go
@@ -1,0 +1,65 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli"
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+	"github.com/openeverest/openeverest/v2/pkg/logger"
+	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+var (
+	logoutCmd = &cobra.Command{
+		Use:     "logout",
+		Args:    cobra.NoArgs,
+		Example: "everestctl auth logout",
+		Short:   "Log out of the current Everest server",
+		Long: `Revoke the current session on the Everest server and remove its credentials
+from the local config (~/.config/everest/config.yaml).`,
+		PreRun: logoutPreRun,
+		Run:    logoutRun,
+	}
+	logoutCfg = &authcli.Config{}
+)
+
+func logoutPreRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	logoutCfg.Pretty = !(cmd.Flag(cli.FlagVerbose).Changed || cmd.Flag(cli.FlagJSON).Changed)
+}
+
+func logoutRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		output.PrintError(err, logger.GetLogger(), logoutCfg.Pretty)
+		os.Exit(1)
+	}
+
+	lo := authcli.NewLogin(*logoutCfg, logger.GetLogger())
+	if err := lo.Logout(cmd.Context(), cfgPath); err != nil {
+		output.PrintError(err, logger.GetLogger(), logoutCfg.Pretty)
+		os.Exit(1)
+	}
+}
+
+// GetLogoutCmd returns the logout command.
+func GetLogoutCmd() *cobra.Command {
+	return logoutCmd
+}

--- a/pkg/cli/auth/logout.go
+++ b/pkg/cli/auth/logout.go
@@ -1,0 +1,118 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+)
+
+// Logout revokes the current session on the server and removes its context, user,
+// and (if unreferenced) server entry from the local config.
+func (lo *Login) Logout(ctx context.Context, cfgPath string) error {
+	// If the access token is expired, refresh it so the revoke endpoint accepts it.
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		return err
+	}
+
+	currentCtx, ok := cfg.GetCurrentContext()
+	if !ok {
+		return fmt.Errorf("no active context %q found in config", cfg.CurrentContext)
+	}
+
+	usr, ok := cfg.GetUser(currentCtx.User)
+	if !ok {
+		return fmt.Errorf("user %q not found in config", currentCtx.User)
+	}
+
+	if time.Now().After(usr.ExpiresAt) {
+		if err := lo.Refresh(ctx, cfgPath); err != nil {
+			return fmt.Errorf("access token expired and refresh failed: %w", err)
+		}
+		// Reload config so we use the refreshed access token.
+		cfg, err = config.Load(cfgPath)
+		if err != nil {
+			return err
+		}
+		currentCtx, ok = cfg.GetCurrentContext()
+		if !ok {
+			return fmt.Errorf("context %q disappeared after token refresh", cfg.CurrentContext)
+		}
+		usr, ok = cfg.GetUser(currentCtx.User)
+		if !ok {
+			return fmt.Errorf("user %q disappeared after token refresh", currentCtx.User)
+		}
+	}
+
+	srv, ok := cfg.GetServer(currentCtx.Server)
+	if !ok {
+		return fmt.Errorf("server %q not found in config", currentCtx.Server)
+	}
+
+	if err := validateServerURL(srv.URL); err != nil {
+		return fmt.Errorf("invalid server URL in config: %w", err)
+	}
+
+	c, err := client.NewClient(normalizeServerURL(srv.URL))
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := c.RevokeAuthToken(ctx, client.RevokeAuthTokenJSONRequestBody{
+		Token: &usr.RefreshToken,
+	}, bearerToken(usr.AccessToken))
+	if err != nil {
+		return fmt.Errorf("revoke request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("logout failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	contextName := cfg.CurrentContext
+	srvName := currentCtx.Server
+	userName := currentCtx.User
+
+	cfg.RemoveContext(contextName)
+	cfg.CurrentContext = ""
+
+	if !cfg.IsUserReferenced(userName) {
+		cfg.RemoveUser(userName)
+	}
+	if !cfg.IsServerReferenced(srvName) {
+		cfg.RemoveServer(srvName)
+	}
+
+	return cfg.Save(cfgPath)
+}
+
+// bearerToken returns a request editor that sets the Authorization header.
+func bearerToken(token string) client.RequestEditorFn {
+	return func(_ context.Context, req *http.Request) error {
+		req.Header.Set("Authorization", "Bearer "+token)
+		return nil
+	}
+}

--- a/pkg/cli/auth/logout.go
+++ b/pkg/cli/auth/logout.go
@@ -29,8 +29,13 @@ import (
 
 // Logout revokes the current session on the server and removes its context, user,
 // and (if unreferenced) server entry from the local config.
+//
+// The /auth/revoke endpoint is unauthenticated per RFC 7009: the refresh token in
+// the request body is sufficient proof of session ownership. If the access token is
+// still valid it is included opportunistically so the server can blocklist it;
+// if expired it is omitted and the server skips blocklisting (acceptable given the
+// 15-minute TTL). Local credentials are always cleared regardless of server response.
 func (lo *Login) Logout(ctx context.Context, cfgPath string) error {
-	// If the access token is expired, refresh it so the revoke endpoint accepts it.
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		return err
@@ -44,25 +49,6 @@ func (lo *Login) Logout(ctx context.Context, cfgPath string) error {
 	usr, ok := cfg.GetUser(currentCtx.User)
 	if !ok {
 		return fmt.Errorf("user %q not found in config", currentCtx.User)
-	}
-
-	if time.Now().After(usr.ExpiresAt) {
-		if err := lo.Refresh(ctx, cfgPath); err != nil {
-			return fmt.Errorf("access token expired and refresh failed: %w", err)
-		}
-		// Reload config so we use the refreshed access token.
-		cfg, err = config.Load(cfgPath)
-		if err != nil {
-			return err
-		}
-		currentCtx, ok = cfg.GetCurrentContext()
-		if !ok {
-			return fmt.Errorf("context %q disappeared after token refresh", cfg.CurrentContext)
-		}
-		usr, ok = cfg.GetUser(currentCtx.User)
-		if !ok {
-			return fmt.Errorf("user %q disappeared after token refresh", currentCtx.User)
-		}
 	}
 
 	srv, ok := cfg.GetServer(currentCtx.Server)
@@ -79,19 +65,28 @@ func (lo *Login) Logout(ctx context.Context, cfgPath string) error {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
+	// Include the access token only if it is still valid so the server can
+	// blocklist it. If expired, omit it — the refresh token alone is enough.
+	var reqEditors []client.RequestEditorFn
+	if time.Now().Before(usr.ExpiresAt) {
+		reqEditors = append(reqEditors, bearerToken(usr.AccessToken))
+	}
+
 	resp, err := c.RevokeAuthToken(ctx, client.RevokeAuthTokenJSONRequestBody{
 		Token: &usr.RefreshToken,
-	}, bearerToken(usr.AccessToken))
+	}, reqEditors...)
 	if err != nil {
-		return fmt.Errorf("revoke request failed: %w", err)
+		lo.l.Warnf("revoke request failed: %v — clearing local credentials anyway", err)
+	} else {
+		defer resp.Body.Close() //nolint:errcheck
+		if resp.StatusCode != http.StatusNoContent {
+			body, _ := io.ReadAll(resp.Body)
+			lo.l.Warnf("server returned %d during logout: %s — clearing local credentials anyway",
+				resp.StatusCode, strings.TrimSpace(string(body)))
+		}
 	}
-	defer resp.Body.Close() //nolint:errcheck
 
-	if resp.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("logout failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
+	// Always clear local credentials regardless of server response.
 	contextName := cfg.CurrentContext
 	srvName := currentCtx.Server
 	userName := currentCtx.User

--- a/pkg/cli/auth/logout_test.go
+++ b/pkg/cli/auth/logout_test.go
@@ -16,11 +16,9 @@
 package auth
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -28,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	"github.com/openeverest/openeverest/v2/client"
 	"github.com/openeverest/openeverest/v2/pkg/cli/config"
 )
 
@@ -78,7 +75,7 @@ func TestLogout_Success(t *testing.T) {
 	assert.Empty(t, updated.Servers)
 }
 
-func TestLogout_ServerError(t *testing.T) {
+func TestLogout_ServerError_ClearsLocalConfig(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -90,15 +87,15 @@ func TestLogout_ServerError(t *testing.T) {
 	require.NoError(t, newLogoutConfig(srv.URL).Save(cfgPath))
 
 	lo := NewLogin(Config{}, zap.NewNop().Sugar())
-	err := lo.Logout(t.Context(), cfgPath)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "500")
+	// server error must not block logout — local credentials are always cleared
+	require.NoError(t, lo.Logout(t.Context(), cfgPath))
 
-	// config must be unchanged
-	loaded, err := config.Load(cfgPath)
+	updated, err := config.Load(cfgPath)
 	require.NoError(t, err)
-	assert.Len(t, loaded.Contexts, 1)
-	assert.Len(t, loaded.Users, 1)
+	assert.Empty(t, updated.CurrentContext)
+	assert.Empty(t, updated.Contexts)
+	assert.Empty(t, updated.Users)
+	assert.Empty(t, updated.Servers)
 }
 
 func TestLogout_NoActiveContext(t *testing.T) {
@@ -118,42 +115,29 @@ func TestLogout_NoActiveContext(t *testing.T) {
 	assert.Contains(t, err.Error(), "missing")
 }
 
-func TestLogout_ExpiredToken_RefreshesBeforeRevoke(t *testing.T) {
+func TestLogout_ExpiredToken_NoBearerHeader(t *testing.T) {
 	t.Parallel()
 
-	var refreshCalled bool
+	var authHeader string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/auth/token") {
-			refreshCalled = true
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(client.AuthTokenResponse{
-				AccessToken:  "new-access-jwt",
-				RefreshToken: "everest_rt_new",
-				ExpiresIn:    900,
-				TokenType:    client.AuthTokenResponseTokenTypeBearer,
-			})
-			return
-		}
+		authHeader = r.Header.Get("Authorization")
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
 
 	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
 	cfg := newLogoutConfig(srv.URL)
-	cfg.Users[0].User.ExpiresAt = time.Now().Add(-time.Minute)
+	cfg.Users[0].User.ExpiresAt = time.Now().Add(-time.Minute) // expired
 	require.NoError(t, cfg.Save(cfgPath))
 
 	lo := NewLogin(Config{}, zap.NewNop().Sugar())
 	require.NoError(t, lo.Logout(t.Context(), cfgPath))
 
-	assert.True(t, refreshCalled, "expected refresh endpoint to be called for expired token")
+	assert.Empty(t, authHeader, "expired access token must not be sent as Bearer header")
 
 	updated, err := config.Load(cfgPath)
 	require.NoError(t, err)
-	assert.Empty(t, updated.CurrentContext)
 	assert.Empty(t, updated.Contexts)
-	assert.Empty(t, updated.Users)
-	assert.Empty(t, updated.Servers)
 }
 
 func TestLogout_MultiContext_PreservesSharedServer(t *testing.T) {
@@ -195,7 +179,7 @@ func TestLogout_MultiContext_PreservesSharedServer(t *testing.T) {
 	assert.Empty(t, updated.CurrentContext)
 	assert.Len(t, updated.Contexts, 1, "ctx-b should remain")
 	assert.Equal(t, "ctx-b", updated.Contexts[0].Name)
-	assert.Len(t, updated.Servers, 1, "shared server should not be removed")
+	assert.Len(t, updated.Servers, 1, "shared server must not be removed")
 	assert.Len(t, updated.Users, 1, "user-b should remain")
 	assert.Equal(t, userB, updated.Users[0].Name)
 }

--- a/pkg/cli/auth/logout_test.go
+++ b/pkg/cli/auth/logout_test.go
@@ -1,0 +1,201 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+)
+
+// newLogoutConfig builds a minimal config with a fresh (non-expired) access token.
+func newLogoutConfig(serverURL string) *config.Config {
+	srvName := serverName(serverURL)
+	userName := "admin@" + srvName
+	return &config.Config{
+		APIVersion:     "config.openeverest.io/v1alpha1",
+		Kind:           "ClientConfig",
+		CurrentContext: userName,
+		Contexts: []config.NamedContext{
+			{Name: userName, Context: config.Context{Server: srvName, User: userName}},
+		},
+		Servers: []config.NamedServer{
+			{Name: srvName, Server: config.Server{URL: serverURL}},
+		},
+		Users: []config.NamedUser{
+			{Name: userName, User: config.User{
+				AccessToken:  "access-jwt",
+				RefreshToken: "everest_rt_old",
+				ExpiresAt:    time.Now().Add(time.Minute),
+			}},
+		},
+	}
+}
+
+func TestLogout_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newLogoutConfig(srv.URL).Save(cfgPath))
+
+	lo := NewLogin(Config{}, zap.NewNop().Sugar())
+	require.NoError(t, lo.Logout(t.Context(), cfgPath))
+
+	updated, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	assert.Empty(t, updated.CurrentContext)
+	assert.Empty(t, updated.Contexts)
+	assert.Empty(t, updated.Users)
+	assert.Empty(t, updated.Servers)
+}
+
+func TestLogout_ServerError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newLogoutConfig(srv.URL).Save(cfgPath))
+
+	lo := NewLogin(Config{}, zap.NewNop().Sugar())
+	err := lo.Logout(t.Context(), cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+
+	// config must be unchanged
+	loaded, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	assert.Len(t, loaded.Contexts, 1)
+	assert.Len(t, loaded.Users, 1)
+}
+
+func TestLogout_NoActiveContext(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	cfg := &config.Config{
+		APIVersion:     "config.openeverest.io/v1alpha1",
+		Kind:           "ClientConfig",
+		CurrentContext: "missing",
+	}
+	require.NoError(t, cfg.Save(cfgPath))
+
+	lo := NewLogin(Config{}, zap.NewNop().Sugar())
+	err := lo.Logout(t.Context(), cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing")
+}
+
+func TestLogout_ExpiredToken_RefreshesBeforeRevoke(t *testing.T) {
+	t.Parallel()
+
+	var refreshCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/auth/token") {
+			refreshCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(client.AuthTokenResponse{
+				AccessToken:  "new-access-jwt",
+				RefreshToken: "everest_rt_new",
+				ExpiresIn:    900,
+				TokenType:    client.AuthTokenResponseTokenTypeBearer,
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	cfg := newLogoutConfig(srv.URL)
+	cfg.Users[0].User.ExpiresAt = time.Now().Add(-time.Minute)
+	require.NoError(t, cfg.Save(cfgPath))
+
+	lo := NewLogin(Config{}, zap.NewNop().Sugar())
+	require.NoError(t, lo.Logout(t.Context(), cfgPath))
+
+	assert.True(t, refreshCalled, "expected refresh endpoint to be called for expired token")
+
+	updated, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	assert.Empty(t, updated.CurrentContext)
+	assert.Empty(t, updated.Contexts)
+	assert.Empty(t, updated.Users)
+	assert.Empty(t, updated.Servers)
+}
+
+func TestLogout_MultiContext_PreservesSharedServer(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	srvName := serverName(srv.URL)
+	userA := "user-a@" + srvName
+	userB := "user-b@" + srvName
+	cfg := &config.Config{
+		APIVersion:     "config.openeverest.io/v1alpha1",
+		Kind:           "ClientConfig",
+		CurrentContext: "ctx-a",
+		Contexts: []config.NamedContext{
+			{Name: "ctx-a", Context: config.Context{Server: srvName, User: userA}},
+			{Name: "ctx-b", Context: config.Context{Server: srvName, User: userB}},
+		},
+		Servers: []config.NamedServer{
+			{Name: srvName, Server: config.Server{URL: srv.URL}},
+		},
+		Users: []config.NamedUser{
+			{Name: userA, User: config.User{AccessToken: "access-a", RefreshToken: "rt-a", ExpiresAt: time.Now().Add(time.Minute)}},
+			{Name: userB, User: config.User{AccessToken: "access-b", RefreshToken: "rt-b", ExpiresAt: time.Now().Add(time.Minute)}},
+		},
+	}
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	lo := NewLogin(Config{}, zap.NewNop().Sugar())
+	require.NoError(t, lo.Logout(t.Context(), cfgPath))
+
+	updated, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	assert.Empty(t, updated.CurrentContext)
+	assert.Len(t, updated.Contexts, 1, "ctx-b should remain")
+	assert.Equal(t, "ctx-b", updated.Contexts[0].Name)
+	assert.Len(t, updated.Servers, 1, "shared server should not be removed")
+	assert.Len(t, updated.Users, 1, "user-b should remain")
+	assert.Equal(t, userB, updated.Users[0].Name)
+}

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -170,3 +170,56 @@ func (c *Config) GetUser(name string) (User, bool) {
 	}
 	return User{}, false
 }
+
+// RemoveContext removes the named context from the config.
+func (c *Config) RemoveContext(name string) {
+	out := c.Contexts[:0]
+	for _, nc := range c.Contexts {
+		if nc.Name != name {
+			out = append(out, nc)
+		}
+	}
+	c.Contexts = out
+}
+
+// RemoveServer removes the named server from the config.
+func (c *Config) RemoveServer(name string) {
+	out := c.Servers[:0]
+	for _, ns := range c.Servers {
+		if ns.Name != name {
+			out = append(out, ns)
+		}
+	}
+	c.Servers = out
+}
+
+// RemoveUser removes the named user from the config.
+func (c *Config) RemoveUser(name string) {
+	out := c.Users[:0]
+	for _, nu := range c.Users {
+		if nu.Name != name {
+			out = append(out, nu)
+		}
+	}
+	c.Users = out
+}
+
+// IsServerReferenced reports whether any context references the named server.
+func (c *Config) IsServerReferenced(name string) bool {
+	for _, nc := range c.Contexts {
+		if nc.Context.Server == name {
+			return true
+		}
+	}
+	return false
+}
+
+// IsUserReferenced reports whether any context references the named user.
+func (c *Config) IsUserReferenced(name string) bool {
+	for _, nc := range c.Contexts {
+		if nc.Context.User == name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Revokes the current session on the Everest server (POST /v1/auth/revoke) and removes the context, user, and orphaned server entries from the local config file.

Key details:
- Sends the stored refresh token in the request body and the access token as a Bearer header (required by the JWT middleware on /v1/auth/revoke)
- Automatically refreshes the access token if it has expired before attempting revocation (don't know if this is the correct approach, since, we are gonna logout, why should we make a new access token for this to be valid for 15 mins. One alternative is that we could revoke using the refresh token instead)
- (And what of the case when, network call fails or something, what should be the backup ?)
- ( one idea is that :- if the access token is expired and refresh fails, just wipe the local config without calling the server. The refresh token will eventually expire server-side anyway. is doing this a good practice?)
- Cleans up server entry only when no other context still references it, preserving multi-server configs
- Adds RemoveContext/Server/User and IsServerReferenced/IsUserReferenced helpers to config.Config following the same pattern as the existing Upsert/Get helpers