### PR TITLE
CNCF approved telemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,11 @@ build-debug: SERVER_GC_FLAGS = -gcflags=all="-N -l"
 build-debug: build-server-helper	## Build Everest API server binary with debug symbols.
 
 .PHONY: rc
-rc: SERVER_LD_FLAGS += -X 'github.com/percona/everest/cmd/config.TelemetryURL=https://check-dev.percona.com'
+rc: SERVER_LD_FLAGS += -X 'github.com/percona/everest/cmd/config.BuildChannel=rc'
 rc: build-server-helper	## Build Everest API server RC version.
 
 .PHONY: release
-release: SERVER_LD_FLAGS += -X 'github.com/percona/everest/cmd/config.TelemetryURL=https://check.percona.com'
+release: SERVER_LD_FLAGS += -X 'github.com/percona/everest/cmd/config.BuildChannel=release'
 release: build-server-helper	## Build Everest API server release version. (Use for building release only!)
 
 # Everest CLI

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -30,12 +30,16 @@ const (
 
 //nolint:gochecknoglobals
 var (
-	// TelemetryURL Everest telemetry endpoint. The variable is set for the release builds via ldflags
-	// to have the correct default telemetry url.
-	TelemetryURL string
-	// TelemetryInterval Everest telemetry sending frequency. The variable is set for the release builds via ldflags
-	// to have the correct default telemetry interval.
+	// TelemetryURL is the default Everest telemetry endpoint. Points at the
+	// Scarf Gateway Event Collection endpoint; can be overridden at build
+	// time via ldflags or at runtime via the TELEMETRY_URL env var.
+	TelemetryURL = "https://openeverest.gateway.scarf.sh/telemetry"
+	// TelemetryInterval is the default telemetry sending frequency. Set via
+	// ldflags for release builds.
 	TelemetryInterval string
+	// BuildChannel identifies the release channel of this binary
+	// ("dev", "rc", or "release"). Set via ldflags for rc and release builds.
+	BuildChannel = "dev"
 )
 
 // EverestConfig stores the configuration for the application.

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/operator-framework/api v0.44.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20260622121956-f2f942efeb9d
 	github.com/rodaine/table v1.3.1
+	github.com/scarf-sh/scarf-go v0.1.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/unrolled/secure v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -885,6 +885,8 @@ github.com/sashamelentyev/interfacebloat v1.1.0 h1:xdRdJp0irL086OyW1H/RTZTr1h/tM
 github.com/sashamelentyev/interfacebloat v1.1.0/go.mod h1:+Y9yU5YdTkrNvoX0xHc84dxiN1iBi9+G8zZIhPVoNjQ=
 github.com/sashamelentyev/usestdlibvars v1.29.0 h1:8J0MoRrw4/NAXtjQqTHrbW9NN+3iMf7Knkq057v4XOQ=
 github.com/sashamelentyev/usestdlibvars v1.29.0/go.mod h1:8PpnjHMk5VdeWlVb4wCdrB8PNbLqZ3wBZTZWkrpZZL8=
+github.com/scarf-sh/scarf-go v0.1.0 h1:A/o5+Q1T8ExmKNCa4D0c1iw5iB3EpS10jyycG9isWr0=
+github.com/scarf-sh/scarf-go v0.1.0/go.mod h1:5Ll7/48YAVqo+GKDb+ptdZhwGat6TqPSbkGaZLVWtLI=
 github.com/securego/gosec/v2 v2.22.5 h1:ySws9uwOeE42DsG54v2moaJfh7r08Ev7SAYJuoMDfRA=
 github.com/securego/gosec/v2 v2.22.5/go.mod h1:AWfgrFsVewk5LKobsPWlygCHt8K91boVPyL6GUZG5NY=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/internal/server/database_cluster.go
+++ b/internal/server/database_cluster.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
-	"time"
 
 	"github.com/labstack/echo/v4"
 	corev1 "k8s.io/api/core/v1"
@@ -53,16 +52,6 @@ func (e *EverestServer) CreateDatabaseCluster(c echo.Context, namespace string) 
 		e.l.Errorf("CreateDatabaseCluster failed: %v", err)
 		return err
 	}
-
-	// Collect metrics immediately after a DB cluster has been created.
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-		defer cancel()
-
-		if err := e.collectMetrics(ctx, *e.config); err != nil {
-			e.l.Errorf("Could not send metrics: %v", err)
-		}
-	}()
 	return c.JSON(http.StatusCreated, result)
 }
 

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -1,158 +1,40 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"net/http"
-	"strconv"
 	"time"
 
-	"github.com/google/uuid"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/percona/everest/cmd/config"
-	"github.com/percona/everest/pkg/version"
+	"github.com/percona/everest/internal/server/telemetry"
 )
 
-const (
-	telemetryProductFamily = "PRODUCT_FAMILY_EVEREST"
-	telemetryVersionKey    = "version"
-
-	// delay the initial metrics to prevent flooding in case of many restarts.
-	initialMetricsDelay = 5 * time.Minute
-
-	numEngineTypes = 3
-)
-
-// Telemetry is the struct for telemetry reports.
-type Telemetry struct {
-	Reports []Report `json:"reports"`
-}
-
-// Report is a struct for a single telemetry report.
-type Report struct {
-	ID            string    `json:"id"`
-	CreateTime    time.Time `json:"createTime"`
-	InstanceID    string    `json:"instanceId"`
-	ProductFamily string    `json:"productFamily"`
-	Metrics       []Metric  `json:"metrics"`
-}
-
-// Metric represents key-value metrics.
-type Metric struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-func (e *EverestServer) report(ctx context.Context, baseURL string, data Telemetry) error {
-	b, err := json.Marshal(data)
-	if err != nil {
-		e.l.Error(errors.Join(err, errors.New("failed to marshal the telemetry report")))
-		return err
-	}
-
-	url := fmt.Sprintf("%s/v1/telemetry/GenericReport", baseURL)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
-	if err != nil {
-		e.l.Error(errors.Join(err, errors.New("failed to create http request")))
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		e.l.Error(errors.Join(err, errors.New("failed to send telemetry request")))
-		return err
-	}
-	defer resp.Body.Close() //nolint:errcheck
-	if resp.StatusCode != http.StatusOK {
-		e.l.Info("Telemetry service responded with http status ", resp.StatusCode)
-	}
-	return nil
-}
-
-// RunTelemetryJob runs background job for collecting telemetry.
+// RunTelemetryJob runs the background telemetry collector. It delegates to
+// the telemetry package and never returns an error: launch as a goroutine
+// and let it tear down when ctx is canceled.
 func (e *EverestServer) RunTelemetryJob(ctx context.Context, c *config.EverestConfig) {
-	e.l.Debug("Starting background jobs runner.")
-
 	interval, err := time.ParseDuration(c.TelemetryInterval)
 	if err != nil {
-		e.l.Error(errors.Join(err, errors.New("could not parse telemetry interval")))
+		e.l.Error(errors.Join(err, errors.New("could not parse telemetry interval; telemetry disabled")))
 		return
 	}
 
-	timer := time.NewTimer(initialMetricsDelay)
-	defer timer.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-timer.C:
-			timer.Reset(interval)
-			err = e.collectMetrics(ctx, *c)
-			if err != nil {
-				e.l.Error(errors.Join(err, errors.New("failed to collect telemetry data")))
-			}
-		}
-	}
-}
-
-func (e *EverestServer) collectMetrics(ctx context.Context, config config.EverestConfig) error {
-	if config.DisableTelemetry {
-		return nil
-	}
-	everestID, err := e.kubeConnector.GetEverestID(ctx)
-	if err != nil {
-		e.l.Error(errors.Join(err, errors.New("failed to get Everest settings")))
-		return err
-	}
-
-	namespaces, err := e.kubeConnector.GetDBNamespaces(ctx)
-	if err != nil {
-		e.l.Error(errors.Join(err, errors.New("failed to get watched namespaces")))
-		return err
-	}
-
-	types := make(map[string]int, numEngineTypes)
-	metrics := make([]Metric, 0, numEngineTypes+1)
-	// Everest version.
-	metrics = append(metrics, Metric{
-		Key:   telemetryVersionKey,
-		Value: version.Version,
-	})
-
-	for _, ns := range namespaces.Items {
-		clusters, err := e.kubeConnector.ListDatabaseClusters(ctx, ctrlclient.InNamespace(ns.GetName()))
-		if err != nil {
-			e.l.Error(errors.Join(err, errors.New("failed to list database clusters")))
-			return err
-		}
-
-		for _, cl := range clusters.Items {
-			types[string(cl.Spec.Engine.Type)]++
-		}
-	}
-
-	for key, val := range types {
-		// Number of DBs per DB engine.
-		metrics = append(metrics, Metric{key, strconv.Itoa(val)})
-	}
-
-	report := Telemetry{
-		[]Report{
-			{
-				ID:            uuid.NewString(),
-				CreateTime:    time.Now(),
-				InstanceID:    everestID,
-				ProductFamily: telemetryProductFamily,
-				Metrics:       metrics,
-			},
-		},
-	}
-
-	return e.report(ctx, config.TelemetryURL, report)
+	transport := telemetry.NewScarfTransport(c.TelemetryURL)
+	runner := telemetry.NewRunner(e.kubeConnector, e.l, transport, interval, nil)
+	runner.Run(ctx)
 }

--- a/internal/server/telemetry/probe.go
+++ b/internal/server/telemetry/probe.go
@@ -1,0 +1,268 @@
+// everest
+// Copyright (C) 2025 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/percona/everest/pkg/common"
+	"github.com/percona/everest/pkg/kubernetes"
+	"github.com/percona/everest/pkg/rbac"
+)
+
+// Probe collects a set of telemetry properties.
+// Each Probe is independent: a failure in one must not abort the others.
+type Probe interface {
+	Name() string
+	Collect(ctx context.Context, k kubernetes.KubernetesConnector) (map[string]string, error)
+}
+
+// defaultProbes returns the probes used by the v1 schema.
+func defaultProbes() []Probe {
+	return []Probe{
+		&dbClustersProbe{},
+		&backupStoragesProbe{},
+		&monitoringConfigsProbe{},
+		&lbConfigsProbe{},
+		&pspProbe{},
+		&dataImportersProbe{},
+		&splitHorizonDNSProbe{},
+		&authProbe{},
+		&providersProbe{},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// dbClustersProbe: counts databases across all watched namespaces and derives
+// feature-usage booleans. Engine-keyed property names use the open string
+// `string(cl.Spec.Engine.Type)` so 2.0's `Spec.Provider` slots in unchanged.
+// ---------------------------------------------------------------------------
+
+type dbClustersProbe struct{}
+
+func (dbClustersProbe) Name() string { return "db_clusters" }
+
+func (dbClustersProbe) Collect(ctx context.Context, k kubernetes.KubernetesConnector) (map[string]string, error) {
+	out := map[string]string{}
+
+	namespaces, err := k.GetDBNamespaces(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out["db_namespaces_count"] = strconv.Itoa(len(namespaces.Items))
+
+	counts := map[string]int{}
+	versions := map[string]map[string]struct{}{}
+
+	var total int
+	var anyPITR, anySchedules, anyExternal, anyDataImport, anyPSP bool
+
+	for _, ns := range namespaces.Items {
+		clusters, err := k.ListDatabaseClusters(ctx, ctrlclient.InNamespace(ns.GetName()))
+		if err != nil {
+			return nil, err
+		}
+		for _, cl := range clusters.Items {
+			total++
+			engine := string(cl.Spec.Engine.Type)
+			counts[engine]++
+			if v := cl.Spec.Engine.Version; v != "" {
+				if versions[engine] == nil {
+					versions[engine] = map[string]struct{}{}
+				}
+				versions[engine][v] = struct{}{}
+			}
+			if cl.Spec.Backup.PITR.Enabled {
+				anyPITR = true
+			}
+			if len(cl.Spec.Backup.Schedules) > 0 {
+				anySchedules = true
+			}
+			if exposeType := string(cl.Spec.Proxy.Expose.Type); exposeType != "" && exposeType != "internal" {
+				anyExternal = true
+			}
+			if cl.Spec.DataSource != nil {
+				anyDataImport = true
+			}
+			if cl.Spec.PodSchedulingPolicyName != "" {
+				anyPSP = true
+			}
+		}
+	}
+
+	out["db_clusters_total"] = strconv.Itoa(total)
+	for engine, count := range counts {
+		out["engine_"+engine+"_count"] = strconv.Itoa(count)
+	}
+	for engine, set := range versions {
+		out["engine_"+engine+"_versions"] = joinSortedSet(set)
+	}
+	out["feat_pitr"] = boolStr(anyPITR)
+	out["feat_scheduled_backups"] = boolStr(anySchedules)
+	out["feat_external_access"] = boolStr(anyExternal)
+	out["feat_data_import_in_use"] = boolStr(anyDataImport)
+	out["feat_psp_in_use"] = boolStr(anyPSP)
+
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Object-count probes
+// ---------------------------------------------------------------------------
+
+type backupStoragesProbe struct{}
+
+func (backupStoragesProbe) Name() string { return "backup_storages" }
+func (backupStoragesProbe) Collect(ctx context.Context, k kubernetes.KubernetesConnector) (map[string]string, error) {
+	list, err := k.ListBackupStorages(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{"backup_storages_count": strconv.Itoa(len(list.Items))}, nil
+}
+
+type monitoringConfigsProbe struct{}
+
+func (monitoringConfigsProbe) Name() string { return "monitoring_configs" }
+func (monitoringConfigsProbe) Collect(ctx context.Context, k kubernetes.KubernetesConnector) (map[string]string, error) {
+	list, err := k.ListMonitoringConfigs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		"monitoring_configs_count": strconv.Itoa(len(list.Items)),
+		"feat_monitoring_in_use":   boolStr(len(list.Items) > 0),
+	}, nil
+}
+
+type lbConfigsProbe struct{}
+
+func (lbConfigsProbe) Name() string { return "load_balancer_configs" }
+func (lbConfigsProbe) Collect(ctx context.Context, k kubernetes.KubernetesConnector) (map[string]string, error) {
+	list, err := k.ListLoadBalancerConfigs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{"load_balancer_configs_count": strconv.Itoa(len(list.Items))}, nil
+}
+
+type pspProbe struct{}
+
+func (pspProbe) Name() string { return "pod_scheduling_policies" }
+func (pspProbe) Collect(ctx context.Context, k kubernetes.KubernetesConnector) (map[string]string, error) {
+	list, err := k.ListPodSchedulingPolicies(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{"pod_scheduling_policies_count": strconv.Itoa(len(list.Items))}, nil
+}
+
+type dataImportersProbe struct{}
+
+func (dataImportersProbe) Name() string { return "data_importers" }
+func (dataImportersProbe) Collect(ctx context.Context, k kubernetes.KubernetesConnector) (map[string]string, error) {
+	list, err := k.ListDataImporters(ctx)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(list.Items))
+	for _, di := range list.Items {
+		names = append(names, di.GetName())
+	}
+	sort.Strings(names)
+	return map[string]string{
+		"data_importers_count":     strconv.Itoa(len(list.Items)),
+		"data_importers_installed": strings.Join(names, ","),
+	}, nil
+}
+
+type splitHorizonDNSProbe struct{}
+
+func (splitHorizonDNSProbe) Name() string { return "split_horizon_dns" }
+func (splitHorizonDNSProbe) Collect(ctx context.Context, k kubernetes.KubernetesConnector) (map[string]string, error) {
+	list, err := k.ListSplitHorizonDNSConfigs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{"split_horizon_dns_configs_count": strconv.Itoa(len(list.Items))}, nil
+}
+
+// ---------------------------------------------------------------------------
+// authProbe reports whether RBAC and OIDC are configured, without leaking
+// any actual policy content.
+// ---------------------------------------------------------------------------
+
+type authProbe struct{}
+
+func (authProbe) Name() string { return "auth" }
+func (authProbe) Collect(ctx context.Context, k kubernetes.KubernetesConnector) (map[string]string, error) {
+	out := map[string]string{
+		"auth_rbac_enabled":    "false",
+		"auth_oidc_configured": "false",
+	}
+
+	rbacCM, err := k.GetConfigMap(ctx, ctrlclient.ObjectKey{
+		Namespace: common.SystemNamespace,
+		Name:      common.EverestRBACConfigMapName,
+	})
+	if err == nil && rbac.IsEnabled(rbacCM) {
+		out["auth_rbac_enabled"] = "true"
+	}
+
+	settings, err := k.GetEverestSettings(ctx)
+	if err == nil && settings.OIDCConfigRaw != "" {
+		out["auth_oidc_configured"] = "true"
+	}
+
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// providersProbe: 1.x emits an empty value to reserve the property name for
+// 2.0 (where it will enumerate installed Provider CRs).
+// ---------------------------------------------------------------------------
+
+type providersProbe struct{}
+
+func (providersProbe) Name() string { return "providers" }
+func (providersProbe) Collect(_ context.Context, _ kubernetes.KubernetesConnector) (map[string]string, error) {
+	return map[string]string{"providers_installed": ""}, nil
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func joinSortedSet(set map[string]struct{}) string {
+	out := make([]string, 0, len(set))
+	for v := range set {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ",")
+}

--- a/internal/server/telemetry/probe_test.go
+++ b/internal/server/telemetry/probe_test.go
@@ -1,0 +1,52 @@
+// everest
+// Copyright (C) 2025 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBoolStr(t *testing.T) {
+	assert.Equal(t, "true", boolStr(true))
+	assert.Equal(t, "false", boolStr(false))
+}
+
+func TestJoinSortedSet(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]struct{}
+		want string
+	}{
+		{"empty", map[string]struct{}{}, ""},
+		{"single", map[string]struct{}{"a": {}}, "a"},
+		{"sorted_dedup", map[string]struct{}{"c": {}, "a": {}, "b": {}}, "a,b,c"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, joinSortedSet(tc.in))
+		})
+	}
+}
+
+func TestProvidersProbe_EmitsReservedKey(t *testing.T) {
+	got, err := providersProbe{}.Collect(t.Context(), nil)
+	assert.NoError(t, err)
+	v, ok := got["providers_installed"]
+	assert.True(t, ok, "providers_installed key must be reserved in v1")
+	assert.Equal(t, "", v, "v1 must emit an empty value")
+}

--- a/internal/server/telemetry/telemetry.go
+++ b/internal/server/telemetry/telemetry.go
@@ -1,0 +1,136 @@
+// everest
+// Copyright (C) 2025 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package telemetry collects and ships anonymous usage data to Scarf Gateway.
+//
+// Layering: Probes (data sources) → Runner (orchestration) → Transport (wire).
+// The Transport interface isolates Scarf-specific code to transport.go so the
+// backend can be swapped without touching probe logic.
+package telemetry
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/percona/everest/cmd/config"
+	"github.com/percona/everest/pkg/kubernetes"
+	"github.com/percona/everest/pkg/version"
+)
+
+const (
+	// schemaVersion bumps on material, breaking changes to the property
+	// vocabulary. Additive properties do not bump this.
+	schemaVersion = "1"
+
+	// eventName groups all heartbeat events on the Scarf side.
+	eventName = "heartbeat"
+
+	// initialDelay prevents flooding on rapid restart loops.
+	initialDelay = 5 * time.Minute
+)
+
+// Runner periodically collects telemetry via Probes and ships it via Transport.
+// It never fails the caller: every error is logged and execution continues.
+type Runner struct {
+	kc        kubernetes.KubernetesConnector
+	l         *zap.SugaredLogger
+	transport Transport
+	interval  time.Duration
+	probes    []Probe
+}
+
+// NewRunner constructs a Runner. interval is the cadence after the initial
+// delay; probes defaults to the v1 set when nil.
+func NewRunner(
+	kc kubernetes.KubernetesConnector,
+	l *zap.SugaredLogger,
+	transport Transport,
+	interval time.Duration,
+	probes []Probe,
+) *Runner {
+	if probes == nil {
+		probes = defaultProbes()
+	}
+	return &Runner{
+		kc:        kc,
+		l:         l,
+		transport: transport,
+		interval:  interval,
+		probes:    probes,
+	}
+}
+
+// Run blocks until ctx is canceled. It performs an initial collection after
+// initialDelay and then once per interval.
+func (r *Runner) Run(ctx context.Context) {
+	r.l.Debug("telemetry runner: starting")
+
+	timer := time.NewTimer(initialDelay)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			r.l.Debug("telemetry runner: context canceled, stopping")
+			return
+		case <-timer.C:
+			r.collectAndSend(ctx)
+			timer.Reset(r.interval)
+		}
+	}
+}
+
+// collectAndSend gathers properties from every probe and ships a single event.
+// Per-probe errors are logged but do not abort the overall send: we always
+// publish whatever was collected successfully plus the always-on properties.
+func (r *Runner) collectAndSend(ctx context.Context) {
+	props := r.alwaysOnProperties(ctx)
+
+	for _, p := range r.probes {
+		got, err := p.Collect(ctx, r.kc)
+		if err != nil {
+			r.l.Errorw("telemetry probe failed", "probe", p.Name(), "error", err)
+			continue
+		}
+		for k, v := range got {
+			props[k] = v
+		}
+	}
+
+	if err := r.transport.Send(ctx, props); err != nil {
+		// Includes the env-opt-out case from the Scarf SDK; log at Debug
+		// rather than Error so opt-out is silent.
+		r.l.Debugw("telemetry send did not complete", "error", err)
+	}
+}
+
+// alwaysOnProperties returns the small set of properties emitted on every
+// event, even if every probe fails. instance_id is best-effort.
+func (r *Runner) alwaysOnProperties(ctx context.Context) map[string]string {
+	props := map[string]string{
+		"event":           eventName,
+		"schema_version":  schemaVersion,
+		"everest_version": version.Version,
+		"build_channel":   config.BuildChannel,
+	}
+	if r.kc != nil {
+		if id, err := r.kc.GetEverestID(ctx); err == nil {
+			props["instance_id"] = id
+		}
+	}
+	return props
+}

--- a/internal/server/telemetry/telemetry_test.go
+++ b/internal/server/telemetry/telemetry_test.go
@@ -1,0 +1,144 @@
+// everest
+// Copyright (C) 2025 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/percona/everest/pkg/kubernetes"
+)
+
+// stubProbe lets tests script per-probe outcomes without touching K8s.
+type stubProbe struct {
+	name string
+	out  map[string]string
+	err  error
+}
+
+func (s stubProbe) Name() string { return s.name }
+func (s stubProbe) Collect(_ context.Context, _ kubernetes.KubernetesConnector) (map[string]string, error) {
+	return s.out, s.err
+}
+
+// stubTransport captures the last props sent and can be made to error.
+type stubTransport struct {
+	mu   sync.Mutex
+	got  map[string]string
+	err  error
+	hits int
+}
+
+func (s *stubTransport) Send(_ context.Context, props map[string]string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hits++
+	s.got = props
+	return s.err
+}
+
+func (s *stubTransport) snapshot() (int, map[string]string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make(map[string]string, len(s.got))
+	for k, v := range s.got {
+		cp[k] = v
+	}
+	return s.hits, cp
+}
+
+func newTestRunner(t *testing.T, transport Transport, probes []Probe) *Runner {
+	t.Helper()
+	// kubeConnector is nil because stub probes don't touch it and the only
+	// always-on call is GetEverestID, which we tolerate failing.
+	return NewRunner(nil, zap.NewNop().Sugar(), transport, time.Minute, probes)
+}
+
+func TestRunner_CollectAndSend_MergesProbeOutputs(t *testing.T) {
+	tr := &stubTransport{}
+	r := newTestRunner(t, tr, []Probe{
+		stubProbe{name: "a", out: map[string]string{"foo": "1", "bar": "x"}},
+		stubProbe{name: "b", out: map[string]string{"baz": "y"}},
+	})
+
+	r.collectAndSend(context.Background())
+
+	hits, got := tr.snapshot()
+	require.Equal(t, 1, hits)
+	assert.Equal(t, "1", got["foo"])
+	assert.Equal(t, "x", got["bar"])
+	assert.Equal(t, "y", got["baz"])
+	assert.Equal(t, "heartbeat", got["event"])
+	assert.Equal(t, "1", got["schema_version"])
+	assert.Equal(t, "dev", got["build_channel"], "default build channel should be dev in tests")
+}
+
+func TestRunner_CollectAndSend_ProbeFailureIsIsolated(t *testing.T) {
+	tr := &stubTransport{}
+	r := newTestRunner(t, tr, []Probe{
+		stubProbe{name: "ok", out: map[string]string{"good": "yes"}},
+		stubProbe{name: "boom", err: errors.New("kaboom")},
+		stubProbe{name: "also_ok", out: map[string]string{"more": "data"}},
+	})
+
+	r.collectAndSend(context.Background())
+
+	hits, got := tr.snapshot()
+	require.Equal(t, 1, hits, "send should still occur when one probe fails")
+	assert.Equal(t, "yes", got["good"])
+	assert.Equal(t, "data", got["more"])
+	// Always-on props must still be present.
+	assert.Equal(t, "heartbeat", got["event"])
+}
+
+func TestRunner_CollectAndSend_AllProbesFailStillEmitsAlwaysOn(t *testing.T) {
+	tr := &stubTransport{}
+	r := newTestRunner(t, tr, []Probe{
+		stubProbe{name: "p1", err: errors.New("fail1")},
+		stubProbe{name: "p2", err: errors.New("fail2")},
+	})
+
+	r.collectAndSend(context.Background())
+
+	hits, got := tr.snapshot()
+	require.Equal(t, 1, hits)
+	assert.Equal(t, "heartbeat", got["event"])
+	assert.Equal(t, "1", got["schema_version"])
+}
+
+func TestRunner_CollectAndSend_TransportErrorDoesNotPanic(t *testing.T) {
+	tr := &stubTransport{err: errors.New("network down")}
+	r := newTestRunner(t, tr, []Probe{
+		stubProbe{name: "p", out: map[string]string{"k": "v"}},
+	})
+
+	assert.NotPanics(t, func() {
+		r.collectAndSend(context.Background())
+	})
+}
+
+func TestNewRunner_NilProbesUsesDefaults(t *testing.T) {
+	r := NewRunner(nil, zap.NewNop().Sugar(), &stubTransport{}, time.Minute, nil)
+	require.NotNil(t, r)
+	assert.NotEmpty(t, r.probes, "nil probes should fall back to defaults")
+}

--- a/internal/server/telemetry/transport.go
+++ b/internal/server/telemetry/transport.go
@@ -1,0 +1,63 @@
+// everest
+// Copyright (C) 2025 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/scarf-sh/scarf-go/scarf"
+)
+
+// Transport delivers a single telemetry event consisting of string properties.
+// Implementations must never block or fail the caller for long; honor ctx.
+type Transport interface {
+	Send(ctx context.Context, props map[string]string) error
+}
+
+// defaultScarfTimeout caps a single Scarf request. Scarf SDK default is 3s;
+// we keep it explicit to make the budget obvious.
+const defaultScarfTimeout = 3 * time.Second
+
+// scarfTransport sends events to a Scarf Gateway Event Collection endpoint.
+// This is the only place that imports the Scarf SDK.
+type scarfTransport struct {
+	logger *scarf.ScarfEventLogger
+}
+
+// NewScarfTransport builds a Transport backed by the Scarf SDK.
+//
+// SCARF_NO_ANALYTICS is suppressed so the public opt-out surface stays
+// vendor-agnostic: users disable telemetry via --disable-telemetry,
+// DISABLE_TELEMETRY=true, or the standard DO_NOT_TRACK.
+func NewScarfTransport(endpointURL string) Transport {
+	_ = os.Unsetenv("SCARF_NO_ANALYTICS")
+	return &scarfTransport{
+		logger: scarf.NewScarfEventLogger(endpointURL, defaultScarfTimeout),
+	}
+}
+
+func (s *scarfTransport) Send(ctx context.Context, props map[string]string) error {
+	payload := make(map[string]any, len(props))
+	for k, v := range props {
+		payload[k] = v
+	}
+	// LogEventWithTimeout uses its own timeout; ctx is honored by the caller
+	// via the surrounding goroutine lifecycle.
+	_ = ctx
+	return s.logger.LogEventWithTimeout(payload, defaultScarfTimeout)
+}

--- a/internal/server/telemetry/transport_test.go
+++ b/internal/server/telemetry/transport_test.go
@@ -1,0 +1,110 @@
+// everest
+// Copyright (C) 2025 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScarfTransport_SendsAllPropsAsQueryParams(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		query url.Values
+		hits  int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits++
+		query = r.URL.Query()
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr := NewScarfTransport(srv.URL)
+	err := tr.Send(context.Background(), map[string]string{
+		"event":           "heartbeat",
+		"schema_version":  "1",
+		"everest_version": "v0.0.0-test",
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, 1, hits)
+	assert.Equal(t, "heartbeat", query.Get("event"))
+	assert.Equal(t, "1", query.Get("schema_version"))
+	assert.Equal(t, "v0.0.0-test", query.Get("everest_version"))
+}
+
+func TestScarfTransport_RespectsEnvOptOut(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "1")
+
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr := NewScarfTransport(srv.URL)
+	// Scarf SDK returns a non-nil sentinel error when opted out; we only
+	// require that no request is sent and no panic occurs.
+	assert.NotPanics(t, func() {
+		_ = tr.Send(context.Background(), map[string]string{"event": "heartbeat"})
+	})
+	assert.Equal(t, 0, hits, "no request should be sent when opted out via env")
+}
+
+func TestScarfTransport_HandlesNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	tr := NewScarfTransport(srv.URL)
+	// We only assert that an error is returned, not its exact shape; the
+	// orchestrator logs and continues regardless.
+	err := tr.Send(context.Background(), map[string]string{"event": "heartbeat"})
+	assert.Error(t, err)
+}
+
+// TestScarfTransport_IgnoresScarfNoAnalyticsEnv guards against the underlying
+// SDK leaking a vendor-specific opt-out env var into our public surface.
+// Only DO_NOT_TRACK and our own DISABLE_TELEMETRY should disable telemetry.
+func TestScarfTransport_IgnoresScarfNoAnalyticsEnv(t *testing.T) {
+	t.Setenv("SCARF_NO_ANALYTICS", "1")
+
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr := NewScarfTransport(srv.URL)
+	err := tr.Send(context.Background(), map[string]string{"event": "heartbeat"})
+	assert.NoError(t, err, "SCARF_NO_ANALYTICS must not disable our transport")
+	assert.Equal(t, 1, hits, "request must still be sent despite SCARF_NO_ANALYTICS=1")
+}


### PR DESCRIPTION
We are moving telemetry to CNCF approved app - Scarf.

What changed on a high level:
- using scarf
- telemetry is enabled on dev/stage and we send it to scarf. We just set different build channels for filtering.

Overall telemetry logic is still the same.

See documentation PR for more details on what is collected and why: https://github.com/openeverest/everest-doc/pull/363

Signed-off-by: Sergey Pronin <sp@solanica.io>