### PR TITLE
fix: use a dedicated HTTP client for S3 validation

### DIFF
--- a/internal/server/handlers/validation/backup_storage.go
+++ b/internal/server/handlers/validation/backup_storage.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package validation
 
 import (
@@ -208,10 +222,11 @@ func s3Access(
 		endpoint = nil
 	}
 
-	c := http.DefaultClient
-	c.Timeout = timeoutS3AccessSec * time.Second
-	c.Transport = &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyTLS}, //nolint:gosec
+	c := &http.Client{
+		Timeout: timeoutS3AccessSec * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyTLS}, //nolint:gosec
+		},
 	}
 	// Create a new session with the provided credentials
 	sess, err := session.NewSession(&aws.Config{


### PR DESCRIPTION
# SUMMARY

This PR prevents backup storage validation from modifying the shared `http.DefaultClient` by using a dedicated HTTP client for S3 connectivity checks. The change keeps the validation behavior the same while ensuring HTTP settings remain isolated to the current request.

Primarily affected module:

* `internal/server/handlers/validation/backup_storage.go`

# FIX

```go
// Before
c := http.DefaultClient
c.Timeout = timeoutS3AccessSec * time.Second

// After
c := &http.Client{
    Timeout: timeoutS3AccessSec * time.Second,
}
```
