### PR TITLE
Preset selection for instance creation flow

### DIFF
--- a/.github/workflows/feature-build.yaml
+++ b/.github/workflows/feature-build.yaml
@@ -314,7 +314,6 @@ jobs:
 
 
       - name: VS - update
-        if: matrix.arch == 'amd64'
         run: |
           cd percona-version-service
           make init
@@ -329,7 +328,6 @@ jobs:
           cat "$VERSION.yaml"
 
       - name: Build and Push VS dev image
-        if: matrix.arch == 'amd64'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: percona-version-service
@@ -513,9 +511,10 @@ jobs:
             $IMAGE_PREFIX/openeverest-operator-bundle-dev:$VERSION-amd64 \
             $IMAGE_PREFIX/openeverest-operator-bundle-dev:$VERSION-arm64
           
-          # Version Service (AMD64 only)
+          # Version Service
           docker buildx imagetools create -t $IMAGE_PREFIX/version-service-dev:$VS_TAG \
-            $IMAGE_PREFIX/version-service-dev:$VS_TAG-amd64
+            $IMAGE_PREFIX/version-service-dev:$VS_TAG-amd64 \
+            $IMAGE_PREFIX/version-service-dev:$VS_TAG-arm64
           
           # Catalog
           docker buildx imagetools create -t $IMAGE_PREFIX/openeverest-catalog-dev:$VERSION \

--- a/.github/workflows/feature-build.yaml
+++ b/.github/workflows/feature-build.yaml
@@ -314,6 +314,7 @@ jobs:
 
 
       - name: VS - update
+        if: matrix.arch == 'amd64'
         run: |
           cd percona-version-service
           make init
@@ -328,6 +329,7 @@ jobs:
           cat "$VERSION.yaml"
 
       - name: Build and Push VS dev image
+        if: matrix.arch == 'amd64'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: percona-version-service
@@ -511,10 +513,9 @@ jobs:
             $IMAGE_PREFIX/openeverest-operator-bundle-dev:$VERSION-amd64 \
             $IMAGE_PREFIX/openeverest-operator-bundle-dev:$VERSION-arm64
           
-          # Version Service
+          # Version Service (AMD64 only)
           docker buildx imagetools create -t $IMAGE_PREFIX/version-service-dev:$VS_TAG \
-            $IMAGE_PREFIX/version-service-dev:$VS_TAG-amd64 \
-            $IMAGE_PREFIX/version-service-dev:$VS_TAG-arm64
+            $IMAGE_PREFIX/version-service-dev:$VS_TAG-amd64
           
           # Catalog
           docker buildx imagetools create -t $IMAGE_PREFIX/openeverest-catalog-dev:$VERSION \

--- a/ui/apps/everest/src/api/instanceApi.ts
+++ b/ui/apps/everest/src/api/instanceApi.ts
@@ -29,7 +29,9 @@ export const createDbInstanceFn = async (
   data: CreateDbInstancePayload['spec'],
   presetName?: string
 ) => {
-  const metadata: any = { name: instanceName };
+  const metadata: { name: string; annotations?: Record<string, string> } = {
+    name: instanceName,
+  };
   if (presetName) {
     metadata.annotations = { [INSTANCE_PRESET_ANNOTATION]: presetName };
   }

--- a/ui/apps/everest/src/api/instanceApi.ts
+++ b/ui/apps/everest/src/api/instanceApi.ts
@@ -20,19 +20,26 @@ import {
   InstanceConnectionDetails,
 } from 'shared-types/api.types';
 import { api } from './api';
+import { INSTANCE_PRESET_ANNOTATION } from 'consts';
 
 export const createDbInstanceFn = async (
   clusterName: string,
   instanceName: string,
   namespace: string,
-  data: CreateDbInstancePayload['spec']
+  data: CreateDbInstancePayload['spec'],
+  presetName?: string
 ) => {
+  const metadata: any = { name: instanceName };
+  if (presetName) {
+    metadata.annotations = { [INSTANCE_PRESET_ANNOTATION]: presetName };
+  }
+
   const payload: CreateDbInstancePayload = {
     apiVersion: 'core.openeverest.io/v1alpha1',
     kind: 'Instance',
     // TODO this TS error should gone after BE types updates
     // @ts-ignore
-    metadata: { name: instanceName },
+    metadata,
     spec: {
       ...data,
     },

--- a/ui/apps/everest/src/components/actionable-alert/backups-actionable-alert/BackupsActionableAlert.tsx
+++ b/ui/apps/everest/src/components/actionable-alert/backups-actionable-alert/BackupsActionableAlert.tsx
@@ -25,6 +25,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { BackupStorageFormValues } from 'shared-types/backupStorages.types';
 import { useRBACPermissions } from 'hooks/rbac';
 import { useClusterName } from 'hooks/api/useClusterName';
+import { useDatabaseFormContextOptional } from 'pages/database-form/database-form-context';
 
 const BackupsActionableAlert = ({ namespace }: BackupsActionableAlertProps) => {
   const [openCreateEditModal, setOpenCreateEditModal] = useState(false);
@@ -33,6 +34,11 @@ const BackupsActionableAlert = ({ namespace }: BackupsActionableAlertProps) => {
   const queryClient = useQueryClient();
   const clusterName = useClusterName();
   const { canCreate } = useRBACPermissions('backup-storages', `${namespace}/*`);
+
+  // Get preset frozen state from context (may be null if outside provider)
+  const formContext = useDatabaseFormContextOptional();
+  const isPresetFrozen = formContext?.isPresetFrozen || false;
+
   const handleCloseModal = () => {
     setOpenCreateEditModal(false);
   };
@@ -55,7 +61,7 @@ const BackupsActionableAlert = ({ namespace }: BackupsActionableAlertProps) => {
         buttonMessage={Messages.addStorage}
         data-testid="no-storage-message"
         onClick={() => setOpenCreateEditModal(true)}
-        {...(!canCreate && { action: undefined })}
+        {...((!canCreate || isPresetFrozen) && { action: undefined })}
       />
       {openCreateEditModal && (
         <CreateEditModalStorage

--- a/ui/apps/everest/src/components/ui-generator/api-providers/fallbacks/monitoring-empty-fallback.tsx
+++ b/ui/apps/everest/src/components/ui-generator/api-providers/fallbacks/monitoring-empty-fallback.tsx
@@ -24,6 +24,7 @@ import {
 import { useRBACPermissions } from 'hooks/rbac';
 import type { EmptyStateFallbackProps } from '../types';
 import { Messages } from './monitoring-empty-fallback.messages';
+import { useDatabaseFormContextOptional } from 'pages/database-form/database-form-context';
 
 export const MonitoringEmptyFallback = ({
   namespace,
@@ -36,6 +37,10 @@ export const MonitoringEmptyFallback = ({
     'monitoring-configs',
     `${namespace}/*`
   );
+
+  // Get preset frozen state from context (may be null if outside provider)
+  const formContext = useDatabaseFormContextOptional();
+  const isPresetFrozen = formContext?.isPresetFrozen || false;
 
   const handleSubmit = (_isEditMode: boolean, data: EndpointFormType) => {
     const { name, url, verifyTLS, user, password } = data;
@@ -66,7 +71,7 @@ export const MonitoringEmptyFallback = ({
         buttonMessage={Messages.addMonitoringEndpoint}
         data-testid="monitoring-empty-fallback"
         onClick={() => setOpenModal(true)}
-        {...(!canCreate && { action: undefined })}
+        {...((!canCreate || isPresetFrozen) && { action: undefined })}
       />
       {openModal && (
         <CreateEditEndpointModal

--- a/ui/apps/everest/src/components/ui-generator/ui-component/ui-component.tsx
+++ b/ui/apps/everest/src/components/ui-generator/ui-component/ui-component.tsx
@@ -48,9 +48,7 @@ const UIComponent: React.FC<ComponentProps> = ({ item, name }) => {
   const isPresetFrozen = formContext?.isPresetFrozen || false;
 
   const isDisabled =
-    !!loadingDefaultsForEdition ||
-    !!fieldParams?.disabled ||
-    isPresetFrozen;
+    !!loadingDefaultsForEdition || !!fieldParams?.disabled || isPresetFrozen;
   const resolvedValidation = resolveValidationForMode(validation, formMode);
   const errorObj = get(errors, name);
   const error = errorObj?.message as string | undefined;

--- a/ui/apps/everest/src/components/ui-generator/ui-component/ui-component.tsx
+++ b/ui/apps/everest/src/components/ui-generator/ui-component/ui-component.tsx
@@ -22,6 +22,7 @@ import { getMappedParams, MappedFieldProps } from './utils/get-mapped-params';
 import { resolveValidationForMode } from '../utils/validation/resolve-validation-for-mode';
 import { buildFieldProps } from './utils/build-field-props';
 import { applyFieldWrappers } from './utils/field-wrappers';
+import { useDatabaseFormContextOptional } from 'pages/database-form/database-form-context';
 
 type ComponentByType<T extends Component['uiType']> = Extract<
   Component,
@@ -42,7 +43,14 @@ const UIComponent: React.FC<ComponentProps> = ({ item, name }) => {
   const { providerObject, loadingDefaultsForEdition, formMode } =
     useUiGeneratorContext();
 
-  const isDisabled = !!loadingDefaultsForEdition || !!fieldParams?.disabled;
+  // Get preset frozen state from context (may be null if outside provider)
+  const formContext = useDatabaseFormContextOptional();
+  const isPresetFrozen = formContext?.isPresetFrozen || false;
+
+  const isDisabled =
+    !!loadingDefaultsForEdition ||
+    !!fieldParams?.disabled ||
+    isPresetFrozen;
   const resolvedValidation = resolveValidationForMode(validation, formMode);
   const errorObj = get(errors, name);
   const error = errorObj?.message as string | undefined;

--- a/ui/apps/everest/src/consts.ts
+++ b/ui/apps/everest/src/consts.ts
@@ -46,6 +46,7 @@ export enum DbWizardForm {
   provider = 'provider',
   k8sNamespace = 'k8sNamespace',
   topology = 'topology.type',
+  instancePreset = 'instancePreset',
 }
 
 export const DbWizardFormFields = {
@@ -56,3 +57,5 @@ export const DbWizardFormFields = {
 export const EKS_DEFAULT_LOAD_BALANCER_CONFIG = 'eks-default';
 
 export const EMPTY_LOAD_BALANCER_CONFIGURATION = '- No configuration -';
+
+export const INSTANCE_PRESET_ANNOTATION = 'openeverest.io/instance-preset';

--- a/ui/apps/everest/src/hooks/api/db-instances/useCreateDbInstance.ts
+++ b/ui/apps/everest/src/hooks/api/db-instances/useCreateDbInstance.ts
@@ -65,13 +65,20 @@ export const useCreateDbInstance = (
 ) =>
   useMutation({
     mutationFn: ({ formValue }: CreateInstanceHookArgType) => {
-      const { dbName, k8sNamespace } = formValue;
+      const { dbName, k8sNamespace, instancePreset } = formValue;
+
+      // Extract preset name from object or string format
+      const presetName =
+        typeof instancePreset === 'object' && instancePreset !== null
+          ? instancePreset.value
+          : instancePreset;
 
       return createDbInstanceFn(
         'main',
         dbName,
         k8sNamespace || '',
-        buildCreateInstanceSpec(formValue)
+        buildCreateInstanceSpec(formValue),
+        presetName || undefined
       );
     },
     ...options,

--- a/ui/apps/everest/src/hooks/api/instance-presets/api.ts
+++ b/ui/apps/everest/src/hooks/api/instance-presets/api.ts
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { api } from 'api/api';
+import { GetInstancePresetsPayload, InstancePreset } from 'shared-types/api.types';
+
+export const getInstancePresetsFn = async (
+  clusterName: string,
+  provider?: string
+): Promise<GetInstancePresetsPayload> => {
+  const params = provider ? { provider } : {};
+  const { data } = await api.get<GetInstancePresetsPayload>(
+    `clusters/${clusterName}/instance-presets`,
+    { params }
+  );
+  return data;
+};
+
+export const getInstancePresetFn = async (
+  clusterName: string,
+  name: string
+): Promise<InstancePreset> => {
+  const { data } = await api.get<InstancePreset>(
+    `clusters/${clusterName}/instance-presets/${name}`
+  );
+  return data;
+};
+
+export const resolveInstancePresetFn = async (
+  clusterName: string,
+  name: string,
+  namespace: string
+): Promise<InstancePreset> => {
+  const { data } = await api.get<InstancePreset>(
+    `clusters/${clusterName}/instance-presets/${name}/resolve`,
+    { params: { namespace } }
+  );
+  return data;
+};

--- a/ui/apps/everest/src/hooks/api/instance-presets/api.ts
+++ b/ui/apps/everest/src/hooks/api/instance-presets/api.ts
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 import { api } from 'api/api';
-import { GetInstancePresetsPayload, InstancePreset } from 'shared-types/api.types';
+import {
+  GetInstancePresetsPayload,
+  InstancePreset,
+} from 'shared-types/api.types';
 
 export const getInstancePresetsFn = async (
   clusterName: string,

--- a/ui/apps/everest/src/hooks/api/instance-presets/index.ts
+++ b/ui/apps/everest/src/hooks/api/instance-presets/index.ts
@@ -12,19 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './backups';
-export * from './backup-storages';
-export * from './db-cluster';
-export * from './db-clusters';
-export * from './db-engines';
-export * from './monitoring';
-export * from './restores';
-export * from './kubernetesClusters';
-export * from './namespaces';
-export * from './version';
-export * from './pod-scheduling-policies';
-export * from './splitHorizon';
-export * from './schema/useSchema';
-export * from './db-instances';
-export * from './db-instance';
-export * from './instance-presets';
+export * from './useInstancePresets';
+export * from './useInstancePreset';
+export * from './useResolvedInstancePreset';

--- a/ui/apps/everest/src/hooks/api/instance-presets/useInstancePreset.ts
+++ b/ui/apps/everest/src/hooks/api/instance-presets/useInstancePreset.ts
@@ -12,19 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './backups';
-export * from './backup-storages';
-export * from './db-cluster';
-export * from './db-clusters';
-export * from './db-engines';
-export * from './monitoring';
-export * from './restores';
-export * from './kubernetesClusters';
-export * from './namespaces';
-export * from './version';
-export * from './pod-scheduling-policies';
-export * from './splitHorizon';
-export * from './schema/useSchema';
-export * from './db-instances';
-export * from './db-instance';
-export * from './instance-presets';
+import { useQuery } from '@tanstack/react-query';
+import { InstancePreset } from 'shared-types/api.types';
+import { getInstancePresetFn } from './api';
+import { useClusterName } from '../useClusterName';
+
+export const useInstancePreset = (name?: string) => {
+  const clusterName = useClusterName();
+
+  return useQuery<InstancePreset, Error>({
+    queryKey: ['instance-preset', clusterName, name],
+    queryFn: () => getInstancePresetFn(clusterName, name!),
+    enabled: !!clusterName && !!name,
+  });
+};

--- a/ui/apps/everest/src/hooks/api/instance-presets/useInstancePresets.ts
+++ b/ui/apps/everest/src/hooks/api/instance-presets/useInstancePresets.ts
@@ -12,19 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './backups';
-export * from './backup-storages';
-export * from './db-cluster';
-export * from './db-clusters';
-export * from './db-engines';
-export * from './monitoring';
-export * from './restores';
-export * from './kubernetesClusters';
-export * from './namespaces';
-export * from './version';
-export * from './pod-scheduling-policies';
-export * from './splitHorizon';
-export * from './schema/useSchema';
-export * from './db-instances';
-export * from './db-instance';
-export * from './instance-presets';
+import { useQuery } from '@tanstack/react-query';
+import { GetInstancePresetsPayload } from 'shared-types/api.types';
+import { getInstancePresetsFn } from './api';
+import { useClusterName } from '../useClusterName';
+
+export const useInstancePresets = (provider?: string) => {
+  const clusterName = useClusterName();
+
+  return useQuery<GetInstancePresetsPayload, Error>({
+    queryKey: ['instance-presets', clusterName, provider],
+    queryFn: () => getInstancePresetsFn(clusterName, provider),
+    enabled: !!clusterName,
+  });
+};

--- a/ui/apps/everest/src/hooks/api/instance-presets/useResolvedInstancePreset.ts
+++ b/ui/apps/everest/src/hooks/api/instance-presets/useResolvedInstancePreset.ts
@@ -17,7 +17,10 @@ import { InstancePreset } from 'shared-types/api.types';
 import { resolveInstancePresetFn } from './api';
 import { useClusterName } from '../useClusterName';
 
-export const useResolvedInstancePreset = (name?: string, namespace?: string) => {
+export const useResolvedInstancePreset = (
+  name?: string,
+  namespace?: string
+) => {
   const clusterName = useClusterName();
 
   return useQuery<InstancePreset, Error>({

--- a/ui/apps/everest/src/hooks/api/instance-presets/useResolvedInstancePreset.ts
+++ b/ui/apps/everest/src/hooks/api/instance-presets/useResolvedInstancePreset.ts
@@ -12,19 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './backups';
-export * from './backup-storages';
-export * from './db-cluster';
-export * from './db-clusters';
-export * from './db-engines';
-export * from './monitoring';
-export * from './restores';
-export * from './kubernetesClusters';
-export * from './namespaces';
-export * from './version';
-export * from './pod-scheduling-policies';
-export * from './splitHorizon';
-export * from './schema/useSchema';
-export * from './db-instances';
-export * from './db-instance';
-export * from './instance-presets';
+import { useQuery } from '@tanstack/react-query';
+import { InstancePreset } from 'shared-types/api.types';
+import { resolveInstancePresetFn } from './api';
+import { useClusterName } from '../useClusterName';
+
+export const useResolvedInstancePreset = (name?: string, namespace?: string) => {
+  const clusterName = useClusterName();
+
+  return useQuery<InstancePreset, Error>({
+    queryKey: ['instance-preset-resolved', clusterName, name, namespace],
+    queryFn: () => resolveInstancePresetFn(clusterName, name!, namespace!),
+    enabled: !!clusterName && !!name && !!namespace,
+  });
+};

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps-old/monitoring/monitoring.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps-old/monitoring/monitoring.tsx
@@ -36,6 +36,7 @@ import { convertMonitoringInstancesPayloadToTableFormat } from 'pages/settings/m
 import { useRBACPermissions } from 'hooks/rbac';
 import { WizardMode } from 'shared-types/wizard.types.ts';
 import { MonitoringConfig } from 'shared-types/api.types';
+import { useDatabaseFormContextOptional } from 'pages/database-form/database-form-context';
 
 export const Monitoring = () => {
   const [openCreateEditModal, setOpenCreateEditModal] = useState(false);
@@ -51,6 +52,10 @@ export const Monitoring = () => {
   const { mutate: createMonitoringInstance, isPending: creatingInstance } =
     useCreateMonitoringInstance();
   const { setValue } = useFormContext();
+
+  // Get preset frozen state from context (may be null if outside provider)
+  const formContext = useDatabaseFormContextOptional();
+  const isPresetFrozen = formContext?.isPresetFrozen || false;
 
   const monitoringInstancesResult = useMonitoringInstancesList([
     {
@@ -159,7 +164,7 @@ export const Monitoring = () => {
           buttonMessage={Messages.addMonitoringEndpoint}
           data-testid="monitoring-warning"
           onClick={() => setOpenCreateEditModal(true)}
-          {...(!canCreate && { action: undefined })}
+          {...((!canCreate || isPresetFrozen) && { action: undefined })}
         />
       )}
       <FormGroup sx={{ mt: 2 }}>

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/backup-step/schedules.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/backup-step/schedules.tsx
@@ -38,6 +38,7 @@ import { ScheduleWizardMode, WizardMode } from 'shared-types/wizard.types';
 import { BackupStorageCRD } from 'shared-types/backupStorages.types';
 import { useBackupClassesList } from 'hooks/api/backup-classes/useBackupClasses';
 import { useClusterName } from 'hooks/api/useClusterName';
+import { useDatabaseFormContext } from '../../../database-form-context';
 
 /** Form field path where wizard stores the flat schedules array. */
 export const BACKUP_SCHEDULES_FIELD = 'backup.schedules';
@@ -53,6 +54,7 @@ export const Schedules = ({ backupStorages }: Props) => {
   const dbWizardMode = useDatabasePageMode();
   const clusterName = useClusterName();
   const { data: backupClasses = [] } = useBackupClassesList(clusterName);
+  const { isPresetFrozen } = useDatabaseFormContext();
 
   const [openScheduleModal, setOpenScheduleModal] = useState(false);
   const [mode, setMode] = useState<ScheduleWizardMode>(WizardMode.New);
@@ -84,7 +86,8 @@ export const Schedules = ({ backupStorages }: Props) => {
     }
   }, [backupClasses, selectedClassName, setValue]);
 
-  const createButtonDisabled = openScheduleModal || backupStorages.length === 0;
+  const createButtonDisabled =
+    openScheduleModal || backupStorages.length === 0 || isPresetFrozen;
 
   const handleDelete = (name: string) => {
     setValue(

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/base-step.browser.test.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/base-step.browser.test.tsx
@@ -16,6 +16,7 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TestWrapper } from 'utils/test';
 import { WizardMode } from 'shared-types/wizard.types';
 import { DbWizardFormFields } from 'consts';
@@ -77,13 +78,21 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => {
     resolver: zodResolver(schema),
   });
 
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
   return (
     <TestWrapper>
-      <DatabaseFormProvider value={contextValue}>
-        <FormProvider {...methods}>
-          <form>{children}</form>
-        </FormProvider>
-      </DatabaseFormProvider>
+      <QueryClientProvider client={queryClient}>
+        <DatabaseFormProvider value={contextValue}>
+          <FormProvider {...methods}>
+            <form>{children}</form>
+          </FormProvider>
+        </DatabaseFormProvider>
+      </QueryClientProvider>
     </TestWrapper>
   );
 };

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/base-step.browser.test.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/base-step.browser.test.tsx
@@ -67,6 +67,7 @@ const contextValue = {
   sectionsOrder: [],
   providerObject: undefined,
   hasBackupStep: false,
+  isPresetFrozen: false,
 };
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/base-step.test.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/base-step.test.tsx
@@ -62,6 +62,7 @@ const makeContextValue = (topologies: string[] = ['replica']) => ({
   sectionsOrder: [],
   providerObject: undefined,
   hasBackupStep: false,
+  isPresetFrozen: false,
 });
 
 interface WrapperProps {

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/base-step.test.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/base-step.test.tsx
@@ -16,6 +16,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TestWrapper } from 'utils/test';
 import { WizardMode } from 'shared-types/wizard.types';
 import { DbWizardFormFields } from 'consts';
@@ -44,6 +45,17 @@ vi.mock('hooks/rbac', () => ({
 
 vi.mock('../../../hooks/use-database-page-mode', () => ({
   useDatabasePageMode: vi.fn(() => WizardMode.New),
+}));
+
+vi.mock('hooks/api/useClusterName', () => ({
+  useClusterName: vi.fn(() => 'test-cluster'),
+}));
+
+vi.mock('hooks/api/instance-presets/useResolvedInstancePreset', () => ({
+  useResolvedInstancePreset: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+  })),
 }));
 
 const makeDefaultValues = (topologyType = 'replica') => ({
@@ -84,13 +96,21 @@ const Wrapper = ({
     ...(schema ? { resolver: zodResolver(schema) } : {}),
   });
 
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
   return (
     <TestWrapper>
-      <DatabaseFormProvider value={makeContextValue(topologies)}>
-        <FormProvider {...methods}>
-          <form>{children}</form>
-        </FormProvider>
-      </DatabaseFormProvider>
+      <QueryClientProvider client={queryClient}>
+        <DatabaseFormProvider value={makeContextValue(topologies)}>
+          <FormProvider {...methods}>
+            <form>{children}</form>
+          </FormProvider>
+        </DatabaseFormProvider>
+      </QueryClientProvider>
     </TestWrapper>
   );
 };

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/base-step.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/base-step.tsx
@@ -1,4 +1,3 @@
-// everest
 // Copyright (C) 2023 Percona LLC
 // Copyright (C) 2026 The OpenEverest Contributors
 //
@@ -27,6 +26,8 @@ import { useNamespacePermissionsForResource } from 'hooks/rbac';
 import { useNamespaces } from 'hooks/index.ts';
 import { FormMode } from 'components/ui-generator/ui-generator.types.js';
 import { useDatabaseFormContext } from 'pages/database-form/database-form-context';
+import { PresetSelector } from './preset-selector';
+import { usePresetLoader } from '../../../hooks/use-preset-loader';
 
 export const BaseInfoStep = ({ loadingDefaultsForEdition }: StepProps) => {
   const mode = useDatabasePageMode();
@@ -34,12 +35,15 @@ export const BaseInfoStep = ({ loadingDefaultsForEdition }: StepProps) => {
   const { data: namespaces = [] } = useNamespaces({
     refetchInterval: 10 * 1000,
   });
-  const { topologies, hasMultipleTopologies } = useDatabaseFormContext();
+  const { topologies, hasMultipleTopologies, isPresetFrozen } =
+    useDatabaseFormContext();
   const { watch, setValue, getFieldState } = useFormContext();
 
-  // const dbType: DbType = watch(DbWizardFormFields.dbType);
-  // const dbNamespace = watch(DbWizardFormFields.k8sNamespace);
+  const provider = watch(DbWizardFormFields.provider);
   const currentTopology = watch(DbWizardFormFields.topology);
+
+  // Load preset when selected
+  usePresetLoader();
 
   // const [dbEnginesFoDbEngineTypes, dbEnginesFoDbEngineTypesFetching] =
   //   useDBEnginesForDbEngineTypes(dbTypeToDbEngine(dbType));
@@ -141,6 +145,10 @@ export const BaseInfoStep = ({ loadingDefaultsForEdition }: StepProps) => {
         pageDescription={Messages.pageDescription}
       />
       <FormGroup sx={{ mt: 3 }}>
+        <PresetSelector
+          provider={provider}
+          disabled={mode === FormMode.Restore || loadingDefaultsForEdition}
+        />
         <AutoCompleteInput
           labelProps={{
             sx: { mt: 1 },
@@ -149,7 +157,10 @@ export const BaseInfoStep = ({ loadingDefaultsForEdition }: StepProps) => {
           label={Messages.labels.k8sNamespace}
           loading={isLoading}
           options={namespaces}
-          disabled={mode === FormMode.Restore || loadingDefaultsForEdition}
+          disabled={
+            mode === FormMode.Restore ||
+            loadingDefaultsForEdition
+          }
           // onChange={onNamespaceChange}
           autoCompleteProps={{
             disableClearable: true,
@@ -169,7 +180,10 @@ export const BaseInfoStep = ({ loadingDefaultsForEdition }: StepProps) => {
             name={DbWizardFormFields.topology}
             label="Database Topology"
             selectFieldProps={{
-              disabled: mode === FormMode.Restore || loadingDefaultsForEdition,
+              disabled:
+                mode === FormMode.Restore ||
+                loadingDefaultsForEdition ||
+                isPresetFrozen,
             }}
           >
             {topologies.map((topology) => (

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/base-step.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/base-step.tsx
@@ -157,10 +157,7 @@ export const BaseInfoStep = ({ loadingDefaultsForEdition }: StepProps) => {
           label={Messages.labels.k8sNamespace}
           loading={isLoading}
           options={namespaces}
-          disabled={
-            mode === FormMode.Restore ||
-            loadingDefaultsForEdition
-          }
+          disabled={mode === FormMode.Restore || loadingDefaultsForEdition}
           // onChange={onNamespaceChange}
           autoCompleteProps={{
             disableClearable: true,

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/preset-selector.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/preset-selector.tsx
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AutoCompleteInput } from '@percona/ui-lib';
+import { DbWizardFormFields } from 'consts';
+import { useInstancePresets } from 'hooks/api/instance-presets/useInstancePresets';
+import { useMemo } from 'react';
+import { InstancePreset } from 'shared-types/api.types';
+
+export const Messages = {
+  labels: {
+    preset: 'Default Configuration',
+  },
+  noPresets: 'No default configurations available for this provider',
+};
+
+interface PresetSelectorProps {
+  provider?: string;
+  disabled?: boolean;
+}
+
+export const PresetSelector = ({ provider, disabled }: PresetSelectorProps) => {
+  const { data: presetsData, isLoading } = useInstancePresets(provider);
+
+  const presetOptions = useMemo(() => {
+    if (!presetsData?.items) return [];
+    return presetsData.items.map((preset: InstancePreset) => ({
+      label: preset.metadata?.name || '',
+      value: preset.metadata?.name || '',
+    }));
+  }, [presetsData]);
+
+  return (
+    <AutoCompleteInput
+      name={DbWizardFormFields.instancePreset}
+      label={Messages.labels.preset}
+      loading={isLoading}
+      disabled={disabled || isLoading}
+      options={presetOptions}
+      autoCompleteProps={{
+        isOptionEqualToValue: (option: any, value: any) => {
+          return option.value === value?.value || option.value === value;
+        },
+        noOptionsText: Messages.noPresets,
+        disableClearable: false,
+      }}
+    />
+  );
+};

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/preset-selector.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/base-step/preset-selector.tsx
@@ -20,9 +20,9 @@ import { InstancePreset } from 'shared-types/api.types';
 
 export const Messages = {
   labels: {
-    preset: 'Default Configuration',
+    preset: 'Template',
   },
-  noPresets: 'No default configurations available for this provider',
+  noPresets: 'No templates available for this provider',
 };
 
 interface PresetSelectorProps {
@@ -49,8 +49,13 @@ export const PresetSelector = ({ provider, disabled }: PresetSelectorProps) => {
       disabled={disabled || isLoading}
       options={presetOptions}
       autoCompleteProps={{
-        isOptionEqualToValue: (option: any, value: any) => {
-          return option.value === value?.value || option.value === value;
+        isOptionEqualToValue: (
+          option: { label: string; value: string },
+          value: { label: string; value: string } | string
+        ) => {
+          return (
+            option.value === (typeof value === 'string' ? value : value?.value)
+          );
         },
         noOptionsText: Messages.noPresets,
         disableClearable: false,

--- a/ui/apps/everest/src/pages/database-form/database-form-context.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-context.tsx
@@ -28,6 +28,7 @@ type DatabaseFormContextType = {
   sectionsOrder?: string[];
   providerObject?: Provider;
   hasBackupStep: boolean;
+  isPresetFrozen?: boolean;
 };
 
 const DatabaseFormContext = createContext<DatabaseFormContextType | null>(null);
@@ -42,4 +43,13 @@ export const useDatabaseFormContext = () => {
     );
   }
   return context;
+};
+
+/**
+ * Optional version of useDatabaseFormContext that returns null
+ * instead of throwing when used outside DatabaseFormProvider.
+ * Useful for components that may be used both inside and outside the form.
+ */
+export const useDatabaseFormContextOptional = () => {
+  return useContext(DatabaseFormContext);
 };

--- a/ui/apps/everest/src/pages/database-form/database-form-schema.ts
+++ b/ui/apps/everest/src/pages/database-form/database-form-schema.ts
@@ -29,6 +29,16 @@ const basicInfoFieldsSchema = z.object({
     .max(MAX_DB_CLUSTER_NAME_LENGTH, Messages.errors.dbName.tooLong)
     .nonempty(),
   [DbWizardFormFields.k8sNamespace]: z.string().nullable(),
+  [DbWizardFormFields.instancePreset]: z
+    .union([
+      z.string(),
+      z.object({
+        label: z.string(),
+        value: z.string(),
+      }),
+    ])
+    .nullable()
+    .optional(),
   topology: z.object({ type: z.string() }),
 });
 

--- a/ui/apps/everest/src/pages/database-form/database-form.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form.tsx
@@ -178,6 +178,21 @@ export const DatabasePage = () => {
     name: DbWizardFormFields.k8sNamespace,
   });
 
+  const selectedPreset = useWatch({
+    control,
+    name: DbWizardFormFields.instancePreset,
+  });
+
+  // Determine if preset freezing is active
+  const isPresetFrozen = useMemo(() => {
+    // Check if a preset is selected
+    const presetValue =
+      typeof selectedPreset === 'object' && selectedPreset !== null
+        ? selectedPreset.value
+        : selectedPreset;
+    return Boolean(presetValue);
+  }, [selectedPreset]);
+
   // Static step definitions
   const staticSteps = useMemo((): StepDefinition[] => {
     const steps: StepDefinition[] = [
@@ -404,6 +419,7 @@ export const DatabasePage = () => {
         sectionsOrder: engine.sectionsOrder,
         providerObject,
         hasBackupStep: hasBackupStep && mode !== FormMode.Restore,
+        isPresetFrozen,
       }}
     >
       <Stack direction={isDesktop ? 'row' : 'column'}>

--- a/ui/apps/everest/src/pages/database-form/database-preview/sections/base-step.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-preview/sections/base-step.tsx
@@ -20,13 +20,25 @@ export const PreviewSectionOne = ({
   topology,
   provider,
   k8sNamespace,
-}: SectionProps) => (
-  <>
-    {k8sNamespace && <PreviewContentText text={`Namespace: ${k8sNamespace}`} />}
-    {provider && <PreviewContentText text={`Provider: ${provider}`} />}
-    {dbName && <PreviewContentText text={`Name: ${dbName}`} />}
-    {topology && topology?.type && (
-      <PreviewContentText text={`Topology: ${topology?.type}`} />
-    )}
-  </>
-);
+  instancePreset,
+}: SectionProps) => {
+  // Extract preset name from instancePreset (can be string or object)
+  const presetName =
+    typeof instancePreset === 'object' && instancePreset !== null
+      ? instancePreset.label || instancePreset.value
+      : instancePreset;
+
+  return (
+    <>
+      {k8sNamespace && (
+        <PreviewContentText text={`Namespace: ${k8sNamespace}`} />
+      )}
+      {provider && <PreviewContentText text={`Provider: ${provider}`} />}
+      {dbName && <PreviewContentText text={`Name: ${dbName}`} />}
+      {topology && topology?.type && (
+        <PreviewContentText text={`Topology: ${topology?.type}`} />
+      )}
+      {presetName && <PreviewContentText text={`Template: ${presetName}`} />}
+    </>
+  );
+};

--- a/ui/apps/everest/src/pages/database-form/hooks/use-is-preset-mode.ts
+++ b/ui/apps/everest/src/pages/database-form/hooks/use-is-preset-mode.ts
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useFormContext } from 'react-hook-form';
+import { DbWizardFormFields } from 'consts';
+
+/**
+ * Hook to determine if form should be read-only based on preset selection.
+ * Phase 1: Form is read-only when a preset is selected.
+ * Phase 2: Form will be editable with preset overrides.
+ */
+export const useIsPresetMode = (): boolean => {
+  const { watch } = useFormContext();
+  const selectedPreset = watch(DbWizardFormFields.instancePreset);
+
+  // Check if preset is selected (handle both object and string formats)
+  const hasPreset = selectedPreset
+    ? typeof selectedPreset === 'object'
+      ? !!selectedPreset.value
+      : !!selectedPreset
+    : false;
+
+  // Phase 1: Return true when preset is selected (form will be read-only)
+  // Phase 2: This will be updated to allow editing
+  return hasPreset;
+};

--- a/ui/apps/everest/src/pages/database-form/hooks/use-preset-loader.ts
+++ b/ui/apps/everest/src/pages/database-form/hooks/use-preset-loader.ts
@@ -19,16 +19,16 @@ import { useResolvedInstancePreset } from 'hooks/api/instance-presets/useResolve
 
 /**
  * Hook to load a preset and populate form fields when a preset is selected.
- * 
+ *
  * When a preset is selected, this hook:
  * 1. Fetches the resolved preset with namespace-specific defaults applied
  * 2. Populates the form with the preset's Instance spec
  * 3. Triggers form field freezing via DatabaseFormContext.isPresetFrozen
- * 
+ *
  * The preset freezing feature disables all UI schema form fields except:
  * - The preset selector itself (to allow switching presets)
  * - Basic metadata fields that aren't part of the Instance spec
- * 
+ *
  * This aligns with RBAC deploy-only permissions: users with only "deploy"
  * permission can create instances from presets but cannot customize them.
  * The backend validates that deploy-only users' instances match their selected
@@ -63,11 +63,7 @@ export const usePresetLoader = () => {
     // 1. We have the resolved preset data
     // 2. We have both preset name and namespace
     // 3. This preset is different from the last loaded one (allow changing presets)
-    if (
-      !resolvedPreset?.spec ||
-      !presetName ||
-      !namespace
-    ) {
+    if (!resolvedPreset?.spec || !presetName || !namespace) {
       return;
     }
 
@@ -81,7 +77,7 @@ export const usePresetLoader = () => {
 
     // Get current form values to preserve base fields
     const currentValues = getValues();
-    
+
     // Populate form with preset values
     const spec = resolvedPreset.spec;
 

--- a/ui/apps/everest/src/pages/database-form/hooks/use-preset-loader.ts
+++ b/ui/apps/everest/src/pages/database-form/hooks/use-preset-loader.ts
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useEffect, useRef } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { DbWizardFormFields } from 'consts';
+import { useResolvedInstancePreset } from 'hooks/api/instance-presets/useResolvedInstancePreset';
+
+/**
+ * Hook to load a preset and populate form fields when a preset is selected.
+ * 
+ * When a preset is selected, this hook:
+ * 1. Fetches the resolved preset with namespace-specific defaults applied
+ * 2. Populates the form with the preset's Instance spec
+ * 3. Triggers form field freezing via DatabaseFormContext.isPresetFrozen
+ * 
+ * The preset freezing feature disables all UI schema form fields except:
+ * - The preset selector itself (to allow switching presets)
+ * - Basic metadata fields that aren't part of the Instance spec
+ * 
+ * This aligns with RBAC deploy-only permissions: users with only "deploy"
+ * permission can create instances from presets but cannot customize them.
+ * The backend validates that deploy-only users' instances match their selected
+ * preset exactly (see internal/server/handlers/rbac/instance.go).
+ */
+export const usePresetLoader = () => {
+  const { watch, reset, getValues } = useFormContext();
+  const lastLoadedPresetRef = useRef<string | null>(null);
+
+  const selectedPreset = watch(DbWizardFormFields.instancePreset);
+  const namespace = watch(DbWizardFormFields.k8sNamespace);
+
+  // Get preset name - handle both object and string formats
+  const presetName =
+    typeof selectedPreset === 'object' && selectedPreset !== null
+      ? selectedPreset.value
+      : selectedPreset;
+
+  const { data: resolvedPreset, isLoading } = useResolvedInstancePreset(
+    presetName,
+    namespace
+  );
+
+  useEffect(() => {
+    // If preset is cleared/unselected, reset the ref
+    if (!presetName) {
+      lastLoadedPresetRef.current = null;
+      return;
+    }
+
+    // Only load preset if:
+    // 1. We have the resolved preset data
+    // 2. We have both preset name and namespace
+    // 3. This preset is different from the last loaded one (allow changing presets)
+    if (
+      !resolvedPreset?.spec ||
+      !presetName ||
+      !namespace
+    ) {
+      return;
+    }
+
+    // Skip if this exact preset was already loaded (prevent re-loading on re-render)
+    if (lastLoadedPresetRef.current === presetName) {
+      return;
+    }
+
+    // Mark this preset as loaded
+    lastLoadedPresetRef.current = presetName;
+
+    // Get current form values to preserve base fields
+    const currentValues = getValues();
+    
+    // Populate form with preset values
+    const spec = resolvedPreset.spec;
+
+    // Build the new form state by merging preset spec with current base values
+    const newValues = {
+      ...currentValues,
+      // Preserve base fields
+      [DbWizardFormFields.provider]: currentValues[DbWizardFormFields.provider],
+      [DbWizardFormFields.dbName]: currentValues[DbWizardFormFields.dbName],
+      [DbWizardFormFields.k8sNamespace]: namespace,
+      [DbWizardFormFields.instancePreset]: selectedPreset,
+      // Apply preset spec - this merges directly into the form as the Instance spec
+      ...spec,
+    };
+
+    // Reset form with new values
+    reset(newValues, { keepDefaultValues: false });
+  }, [resolvedPreset, presetName, namespace, reset, getValues, selectedPreset]);
+
+  return {
+    isLoadingPreset: isLoading,
+    hasPreset: !!presetName,
+    resolvedPreset,
+  };
+};

--- a/ui/apps/everest/src/pages/database-form/utils/get-default-values.ts
+++ b/ui/apps/everest/src/pages/database-form/utils/get-default-values.ts
@@ -21,4 +21,5 @@ export const getDbWizardDefaultValues = (
   [DbWizardFormFields.provider]: providerName,
   [DbWizardFormFields.dbName]: `inst-${generateShortUID()}`,
   [DbWizardFormFields.k8sNamespace]: '',
+  [DbWizardFormFields.instancePreset]: null,
 });

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/sections/basic-info-section/basic-info-section.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/sections/basic-info-section/basic-info-section.tsx
@@ -16,32 +16,45 @@ import OverviewSection from '../../overview-section';
 import OverviewSectionRow from '../../overview-section-row';
 import { Messages } from '../../cluster-overview.messages';
 import type { BasicInfoSectionProps } from './basic-info-section.types';
+import { INSTANCE_PRESET_ANNOTATION } from 'consts';
 
 const BasicInfoSection = ({
   instance,
   namespace,
   loading,
-}: BasicInfoSectionProps) => (
-  <OverviewSection
-    dataTestId="basic-information"
-    title={Messages.titles.basicInformation}
-    loading={loading}
-  >
-    <OverviewSectionRow
-      label={Messages.fields.name}
-      content={instance.metadata?.name}
-    />
-    <OverviewSectionRow label={Messages.fields.namespace} content={namespace} />
-    <OverviewSectionRow label="Provider" content={instance.spec?.provider} />
-    <OverviewSectionRow
-      label="Topology"
-      content={instance.spec?.topology?.type ?? 'default'}
-    />
-    <OverviewSectionRow
-      label={Messages.fields.status}
-      content={instance.status?.phase}
-    />
-  </OverviewSection>
-);
+}: BasicInfoSectionProps) => {
+  // Extract preset name from instance annotations
+  const presetName =
+    instance.metadata?.annotations?.[INSTANCE_PRESET_ANNOTATION];
+
+  return (
+    <OverviewSection
+      dataTestId="basic-information"
+      title={Messages.titles.basicInformation}
+      loading={loading}
+    >
+      <OverviewSectionRow
+        label={Messages.fields.name}
+        content={instance.metadata?.name}
+      />
+      <OverviewSectionRow
+        label={Messages.fields.namespace}
+        content={namespace}
+      />
+      <OverviewSectionRow label="Provider" content={instance.spec?.provider} />
+      <OverviewSectionRow
+        label="Topology"
+        content={instance.spec?.topology?.type ?? 'default'}
+      />
+      {presetName && (
+        <OverviewSectionRow label="Template" content={presetName} />
+      )}
+      <OverviewSectionRow
+        label={Messages.fields.status}
+        content={instance.status?.phase}
+      />
+    </OverviewSection>
+  );
+};
 
 export default BasicInfoSection;

--- a/ui/apps/everest/src/shared-types/api.types.ts
+++ b/ui/apps/everest/src/shared-types/api.types.ts
@@ -43,3 +43,7 @@ export type UpdateDbInstancePayload =
 
 export type GetNamespacesPayload =
   HttpApi.components['schemas']['NamespaceList'];
+
+export type InstancePreset = CrdsGen.components['schemas']['InstancePreset'];
+export type GetInstancePresetsPayload =
+  CrdsGen.components['schemas']['InstancePresetList'];


### PR DESCRIPTION
This PR adds Preset selection for instance creation flow, implementing phase 1 of https://github.com/openeverest/specs/blob/main/specs/006-preset.md.

* Select Preset in Instance creation flow
* If Preset is selected, only namespace and instance name are editable. This is equivalent of newly introduced `deploy` permission on RBAC.
* If Preset is unselected, keeping the value as it is.