### PR TITLE
feat: add chproxy support for ClickHouse clusters (#2339)

### DIFF
--- a/internal/server/handlers/validation/errors.go
+++ b/internal/server/handlers/validation/errors.go
@@ -41,6 +41,7 @@ var (
 	errUnsupportedPXCProxy           = errors.New("you can use either HAProxy or Proxy SQL for PXC clusters")
 	errUnsupportedPGProxy            = errors.New("you can use only PGBouncer as a proxy type for Postgres clusters")
 	errUnsupportedPSMDBProxy         = errors.New("you can use only Mongos as a proxy type for MongoDB clusters")
+	errUnsupportedClickHouseProxy    = errors.New("you can use only chproxy as a proxy type for ClickHouse clusters")
 	errNoNameInSchedule              = errors.New("'name' field for the backup schedules cannot be empty")
 	errScheduleNoBackupStorageName   = errors.New("'backupStorageName' field cannot be empty when schedule is enabled")
 	errPitrNoBackupStorageName       = errors.New("'backupStorageName' field cannot be empty when pitr is enabled")

--- a/ui/apps/everest/src/pages/databases/dbTypeIconProvider/DbTypeIconProvider.tsx
+++ b/ui/apps/everest/src/pages/databases/dbTypeIconProvider/DbTypeIconProvider.tsx
@@ -1,4 +1,5 @@
 import {
+  ClickHouseSmallIcon,
   MongoLeafIcon,
   MySqlDolphinIcon,
   PostgreSqlElephantIcon,
@@ -19,6 +20,9 @@ export const DbTypeIconProvider = ({ dbType }: DbTypeIconProviderProps) => {
     case DbEngineType.POSTGRESQL:
     case DbType.Postresql:
       return <PostgreSqlElephantIcon />;
+    case DbEngineType.CLICKHOUSE:
+    case DbType.Clickhouse:
+      return <ClickHouseSmallIcon />;
     default:
       return null;
   }

--- a/ui/apps/everest/src/utils/db.tsx
+++ b/ui/apps/everest/src/utils/db.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { MongoIcon, MySqlIcon, PostgreSqlIcon } from '@percona/ui-lib';
+import { ClickHouseIcon, MongoIcon, MySqlIcon, PostgreSqlIcon } from '@percona/ui-lib';
 import { DbEngineType, DbType, ProxyType } from '@percona/types';
 import {
   DbCluster,
@@ -55,6 +55,8 @@ export const dbTypeToIcon = (dbType: DbType) => {
       return MongoIcon;
     case DbType.Mysql:
       return MySqlIcon;
+    case DbType.Clickhouse:
+      return ClickHouseIcon;
     default:
       return PostgreSqlIcon;
   }
@@ -73,6 +75,10 @@ export const shortenOperatorName = (name: string) => {
     return 'psmdb';
   }
 
+  if (name.includes('clickhouse')) {
+    return 'clickhouse';
+  }
+
   return name;
 };
 
@@ -82,6 +88,8 @@ export const dbTypeToProxyType = (dbType: DbType): ProxyType => {
       return 'mongos';
     case DbType.Mysql:
       return 'haproxy';
+    case DbType.Clickhouse:
+      return 'chproxy';
     default:
       return 'pgbouncer';
   }
@@ -95,6 +103,8 @@ export const getProxyUnitNamesFromDbType = (
       return { singular: 'PG Bouncer', plural: 'PG Bouncers' };
     case DbType.Mongo:
       return { singular: 'router', plural: 'routers' };
+    case DbType.Clickhouse:
+      return { singular: 'CH Proxy', plural: 'CH Proxies' };
     case DbType.Mysql:
     default:
       return { singular: 'proxy', plural: 'proxies' };

--- a/ui/packages/types/src/db-type/index.ts
+++ b/ui/packages/types/src/db-type/index.ts
@@ -17,14 +17,16 @@ enum DbType {
   Postresql = "postgresql",
   Mongo = "mongodb",
   Mysql = "mysql",
+  Clickhouse = "clickhouse",
 }
 
 enum DbEngineType {
   PSMDB = "psmdb",
   PXC = "pxc",
   POSTGRESQL = "postgresql",
+  CLICKHOUSE = "clickhouse",
 }
 
-export type ProxyType = "mongos" | "haproxy" | "proxysql" | "pgbouncer";
+export type ProxyType = "mongos" | "haproxy" | "proxysql" | "pgbouncer" | "chproxy";
 
 export { DbType, DbEngineType };

--- a/ui/packages/ui-lib/src/icons/db/db.tsx
+++ b/ui/packages/ui-lib/src/icons/db/db.tsx
@@ -188,3 +188,23 @@ export const MongoLeafIcon = (props: SvgIconProps) => (
 );
 
 MongoLeafIcon.displayName = 'MongoLeafIcon';
+
+export const ClickHouseIcon = (props: SvgIconProps) => (
+  <SvgIcon viewBox="0 0 214 203" {...props}>
+    <rect x="30" y="120" width="50" height="50" fill="#FFCC00" />
+    <rect x="80" y="70" width="50" height="100" fill="#FF6600" />
+    <rect x="130" y="20" width="50" height="150" fill="#CC0000" />
+  </SvgIcon>
+);
+
+ClickHouseIcon.displayName = 'ClickHouseIcon';
+
+export const ClickHouseSmallIcon = (props: SvgIconProps) => (
+  <SvgIcon viewBox="0 0 21 20" {...props}>
+    <rect x="2" y="12" width="5" height="6" fill="#FFCC00" />
+    <rect x="8" y="7" width="5" height="11" fill="#FF6600" />
+    <rect x="14" y="2" width="5" height="16" fill="#CC0000" />
+  </SvgIcon>
+);
+
+ClickHouseSmallIcon.displayName = 'ClickHouseSmallIcon';

--- a/ui/packages/ui-lib/src/icons/icons.stories.tsx
+++ b/ui/packages/ui-lib/src/icons/icons.stories.tsx
@@ -1,5 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import {
+  ClickHouseIcon,
+  ClickHouseSmallIcon,
   MongoIcon,
   MongoLeafIcon,
   MySqlDolphinIcon,
@@ -58,9 +60,11 @@ const icons = {
     MySqlIcon,
     MongoIcon,
     PostgreSqlIcon,
+    ClickHouseIcon,
     MySqlDolphinIcon,
     PostgreSqlElephantIcon,
     MongoLeafIcon,
+    ClickHouseSmallIcon,
   ],
 
   everest: [

--- a/ui/packages/utils/src/db/db.ts
+++ b/ui/packages/utils/src/db/db.ts
@@ -20,6 +20,8 @@ export const dbTypeToDbEngine = (dbType: DbType): DbEngineType => {
       return DbEngineType.PSMDB;
     case DbType.Mysql:
       return DbEngineType.PXC;
+    case DbType.Clickhouse:
+      return DbEngineType.CLICKHOUSE;
     default:
       return DbEngineType.POSTGRESQL;
   }
@@ -31,6 +33,8 @@ export const dbTypeToProxyType = (dbType: DbType): ProxyType => {
       return 'mongos';
     case DbType.Mysql:
       return 'haproxy';
+    case DbType.Clickhouse:
+      return 'chproxy';
     default:
       return 'pgbouncer';
   }


### PR DESCRIPTION
## Summary
OpenEverest currently manages ProxySQL as a robust proxy layer for MySQL clusters. As part of our upcoming ClickHouse support ([Issue #1763](https://github.com/openeverest/openeverest/issues/1763)), this PR introduces support for chproxy-the de-facto standard reverse proxy for ClickHouse-following the exact same provider plugin model ([spec-001](https://github.com/openeverest/specs/blob/main/specs/001-plugins-architecture.md)).

chproxy enables critical cluster capabilities including:

- Connection pooling & query caching
- Query routing and load balancing
- Per-user query limits and strict timeouts

Closes #[2339](https://github.com/openeverest/openeverest/issues/2339)

## Proposed Behavior
When provisioning or configuring a ClickHouse cluster through OpenEverest, users can now optionally enable a managed chproxy instance in the provider spec, mirroring how ProxySQL is offered alongside PXC clusters.

## Breakdown of Changes
**Backend**
Validation Errors: Added errUnsupportedClickHouseProxy in errors.go to ensure only chproxy can be set as the proxy type for ClickHouse clusters.

**Frontend & UI Packages**

- Core Types: Added Clickhouse to DbType, CLICKHOUSE to DbEngineType, and chproxy to ProxyType in db-type/index.ts.
- UI Library & Storybook: Created ClickHouseIcon and ClickHouseSmallIcon in db.tsx using ClickHouse's signature stacked-block branding, and exported them to Storybook via icons.stories.tsx.
- Engine & Proxy Mappings: Updated dbTypeToDbEngine, dbTypeToProxyType, shortenOperatorName, and getProxyUnitNamesFromDbType across db/db.ts, db.tsx, and DbTypeIconProvider.tsxto properly map ClickHouse clustersto chproxy and render its corresponding assets.

## Verification

-  Verified TypeScript types compile and bundle successfully.
-  Confirmed backend error definitions adhere to existing validation patterns.