### PR TITLE
instance: implement everestctl instance create

### DIFF
--- a/commands/instance.go
+++ b/commands/instance.go
@@ -32,4 +32,5 @@ var instanceCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(instanceCmd)
 	instanceCmd.AddCommand(instance.GetCreateCmd())
+	instanceCmd.AddCommand(instance.GetStatusCmd())
 }

--- a/commands/instance.go
+++ b/commands/instance.go
@@ -1,0 +1,35 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package commands ...
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openeverest/openeverest/v2/commands/instance"
+)
+
+var instanceCmd = &cobra.Command{
+	Use:   "instance <command> [flags]",
+	Short: "Manage Everest instances",
+	Long:  "Manage Everest instances",
+	RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+}
+
+func init() {
+	rootCmd.AddCommand(instanceCmd)
+	instanceCmd.AddCommand(instance.GetCreateCmd())
+}

--- a/commands/instance/create.go
+++ b/commands/instance/create.go
@@ -32,37 +32,37 @@ var (
 	createCmd = &cobra.Command{
 		Use:   "create [flags]",
 		Args:  cobra.NoArgs,
-		Short: "Create a new database instance",
-		Long: `Provision a new database instance through the Everest API.
+		Short: "Create a new instance",
+		Long: `Provision a new instance through the Everest API.
 
 The provider, name, and namespace flags are required. Version and topology are
 resolved automatically from the provider's defaults if not specified. Use --set
 to override any Instance spec field using dot-notation paths rooted at the spec
 (e.g. --set components.engine.replicas=3 or --set backup.enabled=true).`,
 		Example: `  # Minimal: server defaults for all components
-  everestctl instance create --name my-mongo --namespace everest --provider psmdb
+  everestctl instance create --name my-mongo --namespace everest --provider percona-server-mongodb
 
   # Override component fields via --set
-  everestctl instance create --name my-mongo --namespace everest --provider psmdb \
+  everestctl instance create --name my-mongo --namespace everest --provider percona-server-mongodb \
     --set components.engine.replicas=3 \
     --set components.engine.storage.size=50Gi
 
   # Enable backup alongside component config
-  everestctl instance create --name my-mongo --namespace everest --provider psmdb \
+  everestctl instance create --name my-mongo --namespace everest --provider percona-server-mongodb \
     --set components.engine.replicas=3 \
     --set backup.enabled=true
 
   # Complex config via values file (like helm -f values.yaml)
-  everestctl instance create --name my-mongo --namespace everest --provider psmdb \
+  everestctl instance create --name my-mongo --namespace everest --provider percona-server-mongodb \
     -f my-values.yaml
 
   # File as base, --set overrides specific fields on top
-  everestctl instance create --name my-mongo --namespace everest --provider psmdb \
+  everestctl instance create --name my-mongo --namespace everest --provider percona-server-mongodb \
     -f my-values.yaml --set components.engine.replicas=5
 
   # Explicit version and topology
-  everestctl instance create --name my-pg --namespace everest --provider postgresql \
-    --version 16.3.0 --topology ha`,
+  everestctl instance create --name my-mongo --namespace everest --provider percona-server-mongodb \
+    --version 8.0.12 --topology sharded`,
 		PreRun: createPreRun,
 		Run:    createRun,
 	}
@@ -73,7 +73,7 @@ to override any Instance spec field using dot-notation paths rooted at the spec
 func init() {
 	createCmd.Flags().StringVar(&createOpts.Name, cli.FlagInstanceName, "", "Instance name (required)")
 	createCmd.Flags().StringVar(&createOpts.Namespace, cli.FlagInstanceNamespace, "", "Namespace to create the instance in (required)")
-	createCmd.Flags().StringVar(&createOpts.Provider, cli.FlagInstanceProvider, "", "Provider name, e.g. psmdb, postgresql, pxc (required)")
+	createCmd.Flags().StringVar(&createOpts.Provider, cli.FlagInstanceProvider, "", "Provider name, e.g. percona-server-mongodb, percona-xtradb-cluster (required)")
 	createCmd.Flags().StringVar(&createOpts.Cluster, cli.FlagInstanceCluster, "main", "Cluster name")
 	createCmd.Flags().StringVar(&createOpts.Version, cli.FlagInstanceVersion, "", "Version bundle name (default: provider's default bundle)")
 	createCmd.Flags().StringVar(&createOpts.Topology, cli.FlagInstanceTopology, "", "Topology name (default: provider's first topology)")

--- a/commands/instance/create.go
+++ b/commands/instance/create.go
@@ -1,0 +1,110 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package instance holds commands for the instance subcommand group.
+package instance
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+	instancecli "github.com/openeverest/openeverest/v2/pkg/cli/instance"
+	"github.com/openeverest/openeverest/v2/pkg/logger"
+	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+var (
+	createCmd = &cobra.Command{
+		Use:   "create [flags]",
+		Args:  cobra.NoArgs,
+		Short: "Create a new database instance",
+		Long: `Provision a new database instance through the Everest API.
+
+The provider, name, and namespace flags are required. Version and topology are
+resolved automatically from the provider's defaults if not specified. Use --set
+to override any Instance spec field using dot-notation paths rooted at the spec
+(e.g. --set components.engine.replicas=3 or --set backup.enabled=true).`,
+		Example: `  # Minimal: server defaults for all components
+  everestctl instance create --name my-mongo --namespace everest --provider psmdb
+
+  # Override component fields via --set
+  everestctl instance create --name my-mongo --namespace everest --provider psmdb \
+    --set components.engine.replicas=3 \
+    --set components.engine.storage.size=50Gi
+
+  # Enable backup alongside component config
+  everestctl instance create --name my-mongo --namespace everest --provider psmdb \
+    --set components.engine.replicas=3 \
+    --set backup.enabled=true
+
+  # Complex config via values file (like helm -f values.yaml)
+  everestctl instance create --name my-mongo --namespace everest --provider psmdb \
+    -f my-values.yaml
+
+  # File as base, --set overrides specific fields on top
+  everestctl instance create --name my-mongo --namespace everest --provider psmdb \
+    -f my-values.yaml --set components.engine.replicas=5
+
+  # Explicit version and topology
+  everestctl instance create --name my-pg --namespace everest --provider postgresql \
+    --version 16.3.0 --topology ha`,
+		PreRun: createPreRun,
+		Run:    createRun,
+	}
+	createCfg  = &instancecli.Config{}
+	createOpts = &instancecli.CreateOptions{}
+)
+
+func init() {
+	createCmd.Flags().StringVar(&createOpts.Name, cli.FlagInstanceName, "", "Instance name (required)")
+	createCmd.Flags().StringVar(&createOpts.Namespace, cli.FlagInstanceNamespace, "", "Namespace to create the instance in (required)")
+	createCmd.Flags().StringVar(&createOpts.Provider, cli.FlagInstanceProvider, "", "Provider name, e.g. psmdb, postgresql, pxc (required)")
+	createCmd.Flags().StringVar(&createOpts.Cluster, cli.FlagInstanceCluster, "main", "Cluster name")
+	createCmd.Flags().StringVar(&createOpts.Version, cli.FlagInstanceVersion, "", "Version bundle name (default: provider's default bundle)")
+	createCmd.Flags().StringVar(&createOpts.Topology, cli.FlagInstanceTopology, "", "Topology name (default: provider's first topology)")
+	createCmd.Flags().StringVar(&createOpts.Context, cli.FlagInstanceContext, "", "Context to use (default: current context)")
+	createCmd.Flags().StringVarP(&createOpts.ValuesFile, cli.FlagInstanceFile, "f", "", "Path to a YAML file with component overrides (--set takes precedence)")
+	createCmd.Flags().StringArrayVar(&createOpts.Set, cli.FlagInstanceSet, nil, "Set a spec field: --set components.engine.replicas=3 or --set backup.enabled=true (repeatable)")
+
+	_ = createCmd.MarkFlagRequired(cli.FlagInstanceName)
+	_ = createCmd.MarkFlagRequired(cli.FlagInstanceNamespace)
+	_ = createCmd.MarkFlagRequired(cli.FlagInstanceProvider)
+}
+
+func createPreRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	createCfg.Pretty = !(cmd.Flag(cli.FlagVerbose).Changed || cmd.Flag(cli.FlagJSON).Changed)
+}
+
+func createRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		output.PrintError(err, logger.GetLogger(), createCfg.Pretty)
+		os.Exit(1)
+	}
+
+	ic := instancecli.NewInstanceCreator(*createCfg, logger.GetLogger())
+	if err := ic.Run(cmd.Context(), *createOpts, cfgPath); err != nil {
+		output.PrintError(err, logger.GetLogger(), createCfg.Pretty)
+		os.Exit(1)
+	}
+}
+
+// GetCreateCmd returns the create command.
+func GetCreateCmd() *cobra.Command {
+	return createCmd
+}

--- a/commands/instance/status.go
+++ b/commands/instance/status.go
@@ -1,0 +1,87 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+	instancecli "github.com/openeverest/openeverest/v2/pkg/cli/instance"
+	"github.com/openeverest/openeverest/v2/pkg/logger"
+	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+var (
+	statusCmd = &cobra.Command{
+		Use:   "status [flags]",
+		Args:  cobra.NoArgs,
+		Short: "Show the status of a database instance",
+		Long: `Fetch and display the current status of a database instance.
+
+Shows the phase, version, per-component ready/total counts, and Kubernetes
+conditions reported by the Everest API. Pass --json / --verbose to get the
+raw API response instead of the formatted table.`,
+		Example: `  # Status of an instance in the default cluster
+  everestctl instance status --name my-mongo --namespace everest
+
+  # Raw JSON output
+  everestctl instance status --name my-mongo --namespace everest --json
+
+  # Specific cluster and context
+  everestctl instance status --name my-mongo --namespace everest \
+    --cluster staging --context staging-ctx`,
+		PreRun: statusPreRun,
+		Run:    statusRun,
+	}
+	statusCfg  = &instancecli.Config{}
+	statusOpts = &instancecli.StatusOptions{}
+)
+
+func init() {
+	statusCmd.Flags().StringVar(&statusOpts.Name, cli.FlagInstanceName, "", "Instance name (required)")
+	statusCmd.Flags().StringVar(&statusOpts.Namespace, cli.FlagInstanceNamespace, "", "Namespace the instance lives in (required)")
+	statusCmd.Flags().StringVar(&statusOpts.Cluster, cli.FlagInstanceCluster, "main", "Cluster name")
+	statusCmd.Flags().StringVar(&statusOpts.Context, cli.FlagInstanceContext, "", "Context to use (default: current context)")
+
+	_ = statusCmd.MarkFlagRequired(cli.FlagInstanceName)
+	_ = statusCmd.MarkFlagRequired(cli.FlagInstanceNamespace)
+}
+
+func statusPreRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	statusCfg.Pretty = !(cmd.Flag(cli.FlagVerbose).Changed || cmd.Flag(cli.FlagJSON).Changed)
+}
+
+func statusRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		output.PrintError(err, logger.GetLogger(), statusCfg.Pretty)
+		os.Exit(1)
+	}
+
+	runner := instancecli.NewInstanceStatusRunner(*statusCfg, logger.GetLogger())
+	if err := runner.Run(cmd.Context(), *statusOpts, cfgPath); err != nil {
+		output.PrintError(err, logger.GetLogger(), statusCfg.Pretty)
+		os.Exit(1)
+	}
+}
+
+// GetStatusCmd returns the status command.
+func GetStatusCmd() *cobra.Command {
+	return statusCmd
+}

--- a/commands/instance/status.go
+++ b/commands/instance/status.go
@@ -31,8 +31,8 @@ var (
 	statusCmd = &cobra.Command{
 		Use:   "status [flags]",
 		Args:  cobra.NoArgs,
-		Short: "Show the status of a database instance",
-		Long: `Fetch and display the current status of a database instance.
+		Short: "Show the status of an instance",
+		Long: `Fetch and display the current status of an instance.
 
 Shows the phase, version, per-component ready/total counts, and Kubernetes
 conditions reported by the Everest API. Pass --json / --verbose to get the

--- a/pkg/cli/auth/login.go
+++ b/pkg/cli/auth/login.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli"
 	"github.com/openeverest/openeverest/v2/pkg/cli/config"
 	"github.com/openeverest/openeverest/v2/pkg/output"
 )
@@ -63,11 +64,11 @@ func NewLogin(cfg Config, l *zap.SugaredLogger) *Login {
 
 // Run exchanges username/password for tokens and saves them to cfgPath.
 func (lo *Login) Run(ctx context.Context, opts LoginOptions, cfgPath string) error {
-	if err := validateServerURL(opts.Server); err != nil {
+	if err := cli.ValidateServerURL(opts.Server); err != nil {
 		return err
 	}
 
-	c, err := client.NewClient(normalizeServerURL(opts.Server))
+	c, err := client.NewClient(cli.NormalizeServerURL(opts.Server))
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
@@ -123,24 +124,6 @@ func (lo *Login) Run(ctx context.Context, opts LoginOptions, cfgPath string) err
 		_, _ = fmt.Fprint(os.Stdout, output.Success("Logged in to %s as %s", opts.Server, opts.Username))
 	}
 	return nil
-}
-
-// validateServerURL returns an error if the URL scheme is not http or https.
-func validateServerURL(server string) error {
-	if !strings.HasPrefix(server, "http://") && !strings.HasPrefix(server, "https://") {
-		return fmt.Errorf("server URL must start with http:// or https://")
-	}
-	return nil
-}
-
-// normalizeServerURL ensures the URL ends with /v1 (no trailing slash).
-// The generated client resolves ./auth/token relative to this base.
-func normalizeServerURL(server string) string {
-	server = strings.TrimRight(server, "/")
-	if !strings.HasSuffix(server, "/v1") {
-		server += "/v1"
-	}
-	return server
 }
 
 // serverName strips the URL scheme from server, returning just the host[:port].

--- a/pkg/cli/auth/login_test.go
+++ b/pkg/cli/auth/login_test.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli"
 	"github.com/openeverest/openeverest/v2/pkg/cli/config"
 )
 
@@ -160,7 +161,7 @@ func TestValidateServerURL(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
-			err := validateServerURL(tc.input)
+			err := cli.ValidateServerURL(tc.input)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -185,7 +186,7 @@ func TestNormalizeServerURL(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.want, normalizeServerURL(tc.input))
+			assert.Equal(t, tc.want, cli.NormalizeServerURL(tc.input))
 		})
 	}
 }

--- a/pkg/cli/auth/logout.go
+++ b/pkg/cli/auth/logout.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/openeverest/openeverest/v2/client"
-	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+	"github.com/openeverest/openeverest/v2/pkg/cli"
 )
 
 // Logout revokes the current session on the server and removes its context, user,
@@ -36,31 +36,17 @@ import (
 // if expired it is omitted and the server skips blocklisting (acceptable given the
 // 15-minute TTL). Local credentials are always cleared regardless of server response.
 func (lo *Login) Logout(ctx context.Context, cfgPath string) error {
-	cfg, err := config.Load(cfgPath)
+	sess, err := cli.LoadSession(cfgPath, "")
 	if err != nil {
 		return err
 	}
 
-	currentCtx, ok := cfg.GetCurrentContext()
-	if !ok {
-		return fmt.Errorf("no active context %q found in config", cfg.CurrentContext)
-	}
+	cfg := sess.Cfg
+	currentCtx := sess.Ctx
+	usr := sess.User
+	srv := sess.Server
 
-	usr, ok := cfg.GetUser(currentCtx.User)
-	if !ok {
-		return fmt.Errorf("user %q not found in config", currentCtx.User)
-	}
-
-	srv, ok := cfg.GetServer(currentCtx.Server)
-	if !ok {
-		return fmt.Errorf("server %q not found in config", currentCtx.Server)
-	}
-
-	if err := validateServerURL(srv.URL); err != nil {
-		return fmt.Errorf("invalid server URL in config: %w", err)
-	}
-
-	c, err := client.NewClient(normalizeServerURL(srv.URL))
+	c, err := client.NewClient(cli.NormalizeServerURL(srv.URL))
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
@@ -69,7 +55,7 @@ func (lo *Login) Logout(ctx context.Context, cfgPath string) error {
 	// blocklist it. If expired, omit it — the refresh token alone is enough.
 	var reqEditors []client.RequestEditorFn
 	if time.Now().Before(usr.ExpiresAt) {
-		reqEditors = append(reqEditors, bearerToken(usr.AccessToken))
+		reqEditors = append(reqEditors, cli.BearerToken(usr.AccessToken))
 	}
 
 	resp, err := c.RevokeAuthToken(ctx, client.RevokeAuthTokenJSONRequestBody{
@@ -104,10 +90,3 @@ func (lo *Login) Logout(ctx context.Context, cfgPath string) error {
 	return cfg.Save(cfgPath)
 }
 
-// bearerToken returns a request editor that sets the Authorization header.
-func bearerToken(token string) client.RequestEditorFn {
-	return func(_ context.Context, req *http.Request) error {
-		req.Header.Set("Authorization", "Bearer "+token)
-		return nil
-	}
-}

--- a/pkg/cli/auth/logout_test.go
+++ b/pkg/cli/auth/logout_test.go
@@ -112,7 +112,7 @@ func TestLogout_NoActiveContext(t *testing.T) {
 	lo := NewLogin(Config{}, zap.NewNop().Sugar())
 	err := lo.Logout(t.Context(), cfgPath)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing")
+	assert.Contains(t, err.Error(), "no active context")
 }
 
 func TestLogout_ExpiredToken_NoBearerHeader(t *testing.T) {

--- a/pkg/cli/auth/refresh.go
+++ b/pkg/cli/auth/refresh.go
@@ -25,37 +25,24 @@ import (
 	"time"
 
 	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli"
 	"github.com/openeverest/openeverest/v2/pkg/cli/config"
 )
 
 // Refresh exchanges the stored refresh token for a new token pair and persists it to cfgPath.
 // The caller decides when to invoke this (e.g. on 401 or when ExpiresAt is near).
 func (lo *Login) Refresh(ctx context.Context, cfgPath string) error {
-	cfg, err := config.Load(cfgPath)
+	sess, err := cli.LoadSession(cfgPath, "")
 	if err != nil {
 		return err
 	}
 
-	currentCtx, ok := cfg.GetCurrentContext()
-	if !ok {
-		return fmt.Errorf("no active context %q found in config", cfg.CurrentContext)
-	}
+	cfg := sess.Cfg
+	currentCtx := sess.Ctx
+	usr := sess.User
+	srv := sess.Server
 
-	srv, ok := cfg.GetServer(currentCtx.Server)
-	if !ok {
-		return fmt.Errorf("server %q not found in config", currentCtx.Server)
-	}
-
-	usr, ok := cfg.GetUser(currentCtx.User)
-	if !ok {
-		return fmt.Errorf("user %q not found in config", currentCtx.User)
-	}
-
-	if err := validateServerURL(srv.URL); err != nil {
-		return fmt.Errorf("invalid server URL in config: %w", err)
-	}
-
-	c, err := client.NewClient(normalizeServerURL(srv.URL))
+	c, err := client.NewClient(cli.NormalizeServerURL(srv.URL))
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}

--- a/pkg/cli/auth/refresh_test.go
+++ b/pkg/cli/auth/refresh_test.go
@@ -122,5 +122,5 @@ func TestRefresh_NoActiveContext(t *testing.T) {
 	lo := NewLogin(Config{}, zap.NewNop().Sugar())
 	err := lo.Refresh(t.Context(), cfgPath)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing")
+	assert.Contains(t, err.Error(), "no active context")
 }

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -151,6 +151,16 @@ func (c *Config) GetCurrentContext() (Context, bool) {
 	return Context{}, false
 }
 
+// GetContext returns the named context.
+func (c *Config) GetContext(name string) (Context, bool) {
+	for _, nc := range c.Contexts {
+		if nc.Name == name {
+			return nc.Context, true
+		}
+	}
+	return Context{}, false
+}
+
 // GetServer returns the server with the given name.
 func (c *Config) GetServer(name string) (Server, bool) {
 	for _, ns := range c.Servers {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -90,6 +90,27 @@ const (
 	// FlagAuthContextName is the name of the context-name flag.
 	FlagAuthContextName = "context-name"
 
+	// `instance` flags
+
+	// FlagInstanceName is the name of the instance name flag.
+	FlagInstanceName = "name"
+	// FlagInstanceNamespace is the name of the namespace flag.
+	FlagInstanceNamespace = "namespace"
+	// FlagInstanceProvider is the name of the provider flag.
+	FlagInstanceProvider = "provider"
+	// FlagInstanceCluster is the name of the cluster flag.
+	FlagInstanceCluster = "cluster"
+	// FlagInstanceVersion is the name of the version flag.
+	FlagInstanceVersion = "version"
+	// FlagInstanceTopology is the name of the topology flag.
+	FlagInstanceTopology = "topology"
+	// FlagInstanceSet is the name of the repeatable set flag for component overrides.
+	FlagInstanceSet = "set"
+	// FlagInstanceFile is the name of the values file flag for component overrides.
+	FlagInstanceFile = "file"
+	// FlagInstanceContext overrides the active context for this command.
+	FlagInstanceContext = "context"
+
 	// settings flags
 
 	// FlagOIDCIssuerURL is the name of the issuer-url flag.

--- a/pkg/cli/instance/create.go
+++ b/pkg/cli/instance/create.go
@@ -1,0 +1,491 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package instance provides CLI business logic for instance management.
+package instance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+
+	"github.com/openeverest/openeverest/v2/client"
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+type Config struct {
+	Pretty bool
+}
+
+type CreateOptions struct {
+	Name       string
+	Namespace  string
+	Provider   string
+	Cluster    string
+	Version    string
+	Topology   string
+	Context    string   // overrides the active context when set
+	ValuesFile string   // path to a YAML file with spec-level overrides (optional)
+	Set        []string // each entry: "specField.subfield=value" e.g. "components.engine.replicas=3" — takes precedence over ValuesFile
+}
+
+type InstanceCreator struct {
+	config Config
+	l      *zap.SugaredLogger
+}
+
+func NewInstanceCreator(cfg Config, l *zap.SugaredLogger) *InstanceCreator {
+	ic := &InstanceCreator{config: cfg, l: l.With("component", "instance-creator")}
+	if cfg.Pretty {
+		ic.l = zap.NewNop().Sugar()
+	}
+	return ic
+}
+
+func (ic *InstanceCreator) resolveContext(cfg *config.Config, name string) (config.Context, bool) {
+	if name != "" {
+		return cfg.GetContext(name)
+	}
+	return cfg.GetCurrentContext()
+}
+
+func (ic *InstanceCreator) Run(ctx context.Context, opts CreateOptions, cfgPath string) error {
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		return err
+	}
+
+	currentCtx, ok := ic.resolveContext(cfg, opts.Context)
+	if !ok {
+		if opts.Context != "" {
+			return fmt.Errorf("context %q not found in config", opts.Context)
+		}
+		return fmt.Errorf("no active context found in config — run 'everestctl auth login' first")
+	}
+
+	usr, ok := cfg.GetUser(currentCtx.User)
+	if !ok {
+		return fmt.Errorf("user %q not found in config", currentCtx.User)
+	}
+
+	srv, ok := cfg.GetServer(currentCtx.Server)
+	if !ok {
+		return fmt.Errorf("server %q not found in config", currentCtx.Server)
+	}
+
+	if err := validateServerURL(srv.URL); err != nil {
+		return fmt.Errorf("invalid server URL in config: %w", err)
+	}
+
+	// Refresh proactively within 30s of expiry to avoid a mid-flight 401.
+	if time.Now().After(usr.ExpiresAt.Add(-30 * time.Second)) {
+		lo := authcli.NewLogin(authcli.Config{Pretty: ic.config.Pretty}, ic.l.Desugar().Sugar())
+		if err := lo.Refresh(ctx, cfgPath); err != nil {
+			return fmt.Errorf("access token expired and refresh failed: %w", err)
+		}
+		cfg, err = config.Load(cfgPath)
+		if err != nil {
+			return err
+		}
+		usr, ok = cfg.GetUser(currentCtx.User)
+		if !ok {
+			return fmt.Errorf("user %q not found in config after refresh", currentCtx.User)
+		}
+	}
+
+	c, err := client.NewClientWithResponses(normalizeServerURL(srv.URL))
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	token := bearerToken(usr.AccessToken)
+
+	provResp, err := c.GetProviderWithResponse(ctx, opts.Cluster, opts.Provider, token)
+	if err != nil {
+		return fmt.Errorf("failed to fetch provider %q: %w", opts.Provider, err)
+	}
+
+	if provResp.StatusCode() == http.StatusNotFound {
+		return fmt.Errorf("provider %q not found in cluster %q", opts.Provider, opts.Cluster)
+	}
+
+	if provResp.StatusCode() != http.StatusOK || provResp.JSON200 == nil {
+		return fmt.Errorf("unexpected response fetching provider %q: %s", opts.Provider, provResp.Status())
+	}
+
+	prov := provResp.JSON200
+
+	resolvedVersion := opts.Version
+	if resolvedVersion == "" {
+		resolvedVersion = defaultVersion(prov)
+	}
+
+	resolvedTopology := opts.Topology
+	if resolvedTopology == "" {
+		resolvedTopology = firstTopology(prov)
+	} else if err := validateTopology(resolvedTopology, prov); err != nil {
+		return err
+	}
+
+	if len(opts.Set) > 0 {
+		if err := validateComponents(opts.Set, prov, resolvedTopology); err != nil {
+			return err
+		}
+	}
+
+	specOverrides, err := buildSpecOverrides(opts.ValuesFile, opts.Set)
+	if err != nil {
+		return err
+	}
+
+	payload := buildPayload(opts.Name, opts.Provider, resolvedVersion, resolvedTopology, specOverrides)
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to serialize instance spec: %w", err)
+	}
+
+	resp, err := c.CreateInstanceWithBodyWithResponse(
+		ctx,
+		opts.Cluster,
+		opts.Namespace,
+		"application/json",
+		bytes.NewReader(body),
+		token,
+	)
+	if err != nil {
+		return fmt.Errorf("create instance request failed: %w", err)
+	}
+
+	if resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusCreated {
+		if resp.StatusCode() == http.StatusConflict {
+			return fmt.Errorf("instance %q already exists in namespace %q", opts.Name, opts.Namespace)
+		}
+		if resp.JSONDefault != nil && resp.JSONDefault.Message != nil {
+			return fmt.Errorf("server error: %s", *resp.JSONDefault.Message)
+		}
+		return fmt.Errorf("unexpected response creating instance: %s", resp.Status())
+	}
+
+	ic.l.Infof("created instance %q in namespace %q", opts.Name, opts.Namespace)
+	if ic.config.Pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Success("Instance %q created in namespace %q", opts.Name, opts.Namespace))
+	}
+
+	return nil
+}
+
+func defaultVersion(prov *client.Provider) string {
+	if prov.Spec.Versions == nil {
+		return ""
+	}
+
+	versions := *prov.Spec.Versions
+	first := ""
+	for _, v := range versions {
+		if first == "" {
+			first = v.Name
+		}
+		if v.Default != nil && *v.Default {
+			return v.Name
+		}
+	}
+	return first
+}
+
+func firstTopology(prov *client.Provider) string {
+	if prov.Spec.Topologies == nil {
+		return ""
+	}
+
+	keys := make([]string, 0, len(*prov.Spec.Topologies))
+	for k := range *prov.Spec.Topologies {
+		keys = append(keys, k)
+	}
+
+	if len(keys) == 0 {
+		return ""
+	}
+
+	sort.Strings(keys)
+	return keys[0]
+}
+
+func validateTopology(topology string, prov *client.Provider) error {
+	if prov.Spec.Topologies == nil {
+		return nil
+	}
+	if _, ok := (*prov.Spec.Topologies)[topology]; !ok {
+		names := make([]string, 0, len(*prov.Spec.Topologies))
+		for k := range *prov.Spec.Topologies {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		return fmt.Errorf(
+			"topology %q is not available for provider %q\nvalid topologies: %s",
+			topology, providerName(prov), strings.Join(names, ", "),
+		)
+	}
+	return nil
+}
+
+// validateComponents only checks --set paths starting with "components.".
+func validateComponents(setFlags []string, prov *client.Provider, topology string) error {
+	// Topology components are the ground truth, but the API strips null entries,
+	// so fall back to spec.components (global registry) when the topology map is empty.
+	valid := map[string]struct{}{}
+	if prov.Spec.Topologies != nil {
+		if t, ok := (*prov.Spec.Topologies)[topology]; ok && t.Components != nil {
+			for name := range *t.Components {
+				valid[name] = struct{}{}
+			}
+		}
+	}
+	if len(valid) == 0 && prov.Spec.Components != nil {
+		for name := range *prov.Spec.Components {
+			valid[name] = struct{}{}
+		}
+	}
+	if len(valid) == 0 {
+		return nil // can't determine valid names; let the server validate
+	}
+
+	var invalid []string
+	seen := map[string]struct{}{}
+	for _, s := range setFlags {
+		parts := strings.SplitN(s, "=", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		segments := strings.SplitN(parts[0], ".", 3)
+		if len(segments) < 2 || segments[0] != "components" {
+			continue
+		}
+		compName := segments[1]
+		if _, done := seen[compName]; done {
+			continue
+		}
+		seen[compName] = struct{}{}
+		if _, ok := valid[compName]; !ok {
+			invalid = append(invalid, compName)
+		}
+	}
+
+	if len(invalid) == 0 {
+		return nil
+	}
+
+	validNames := make([]string, 0, len(valid))
+	for name := range valid {
+		validNames = append(validNames, name)
+	}
+	sort.Strings(validNames)
+	sort.Strings(invalid)
+
+	return fmt.Errorf(
+		"invalid component(s) for provider %q with topology %q: %s\nvalid components: %s",
+		providerName(prov),
+		topology,
+		strings.Join(invalid, ", "),
+		strings.Join(validNames, ", "),
+	)
+}
+
+func providerName(prov *client.Provider) string {
+	if prov.Metadata == nil {
+		return "<unknown>"
+	}
+	if name, ok := (*prov.Metadata)["name"]; ok {
+		if s, ok := name.(string); ok {
+			return s
+		}
+	}
+	return "<unknown>"
+}
+
+// buildSpecOverrides merges -f file values and --set overrides; --set wins.
+func buildSpecOverrides(valuesFile string, setFlags []string) (map[string]any, error) {
+	var base map[string]any
+
+	if valuesFile != "" {
+		loaded, err := loadValuesFile(valuesFile)
+		if err != nil {
+			return nil, err
+		}
+		base = loaded
+	}
+
+	overrides, err := parseSetFlags(setFlags)
+	if err != nil {
+		return nil, err
+	}
+
+	if base == nil {
+		return overrides, nil
+	}
+	if overrides == nil {
+		return base, nil
+	}
+
+	deepMerge(base, overrides)
+	return base, nil
+}
+
+func loadValuesFile(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read values file %q: %w", path, err)
+	}
+
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("cannot parse values file %q: %w", path, err)
+	}
+
+	return raw, nil
+}
+
+// deepMerge merges src into dst; src scalars overwrite dst, maps recurse.
+func deepMerge(dst, src map[string]any) {
+	for k, sv := range src {
+		dv, exists := dst[k]
+		if !exists {
+			dst[k] = sv
+			continue
+		}
+		srcMap, srcIsMap := sv.(map[string]any)
+		dstMap, dstIsMap := dv.(map[string]any)
+		if srcIsMap && dstIsMap {
+			deepMerge(dstMap, srcMap)
+		} else {
+			dst[k] = sv
+		}
+	}
+}
+
+// parseSetFlags parses "field.sub=value" entries into a nested map.
+func parseSetFlags(setFlags []string) (map[string]any, error) {
+	if len(setFlags) == 0 {
+		return nil, nil
+	}
+
+	result := map[string]any{}
+
+	for _, s := range setFlags {
+		eqIdx := strings.Index(s, "=")
+		if eqIdx < 0 {
+			return nil, fmt.Errorf("invalid --set value %q: must be in the form field.subfield=value", s)
+		}
+
+		path := s[:eqIdx]
+		rawValue := s[eqIdx+1:]
+
+		if path == "" {
+			return nil, fmt.Errorf("invalid --set flag %q: path must not be empty", s)
+		}
+
+		segments := strings.Split(path, ".")
+		value := coerceValue(rawValue)
+		if err := deepSet(result, segments, value); err != nil {
+			return nil, fmt.Errorf("conflicting --set paths at %q: %w", path, err)
+		}
+	}
+
+	return result, nil
+}
+
+func coerceValue(s string) any {
+	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return i
+	}
+	if b, err := strconv.ParseBool(s); err == nil {
+		return b
+	}
+	return s
+}
+
+func deepSet(m map[string]any, path []string, value any) error {
+	if len(path) == 1 {
+		m[path[0]] = value
+		return nil
+	}
+
+	child, ok := m[path[0]]
+	if !ok {
+		child = map[string]any{}
+		m[path[0]] = child
+	}
+
+	childMap, ok := child.(map[string]any)
+	if !ok {
+		return fmt.Errorf("cannot set sub-field of scalar value at %q", path[0])
+	}
+
+	return deepSet(childMap, path[1:], value)
+}
+
+// buildPayload builds the Instance JSON payload; explicit flags win over --set/-f.
+func buildPayload(name, provider, version, topology string, specOverrides map[string]any) map[string]any {
+	if specOverrides == nil {
+		specOverrides = map[string]any{}
+	}
+
+	specOverrides["provider"] = provider
+	if version != "" {
+		specOverrides["version"] = version
+	}
+	if topology != "" {
+		specOverrides["topology"] = map[string]any{"type": topology}
+	}
+
+	return map[string]any{
+		"metadata": map[string]any{"name": name},
+		"spec":     specOverrides,
+	}
+}
+
+func validateServerURL(server string) error {
+	if !strings.HasPrefix(server, "http://") && !strings.HasPrefix(server, "https://") {
+		return fmt.Errorf("server URL must start with http:// or https://")
+	}
+	return nil
+}
+
+func normalizeServerURL(server string) string {
+	server = strings.TrimRight(server, "/")
+	if !strings.HasSuffix(server, "/v1") {
+		server += "/v1"
+	}
+	return server
+}
+
+func bearerToken(token string) client.RequestEditorFn {
+	return func(_ context.Context, req *http.Request) error {
+		req.Header.Set("Authorization", "Bearer "+token)
+		return nil
+	}
+}

--- a/pkg/cli/instance/create.go
+++ b/pkg/cli/instance/create.go
@@ -32,8 +32,8 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli"
 	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
-	"github.com/openeverest/openeverest/v2/pkg/cli/config"
 	"github.com/openeverest/openeverest/v2/pkg/output"
 )
 
@@ -66,63 +66,30 @@ func NewInstanceCreator(cfg Config, l *zap.SugaredLogger) *InstanceCreator {
 	return ic
 }
 
-func (ic *InstanceCreator) resolveContext(cfg *config.Config, name string) (config.Context, bool) {
-	if name != "" {
-		return cfg.GetContext(name)
-	}
-	return cfg.GetCurrentContext()
-}
-
 func (ic *InstanceCreator) Run(ctx context.Context, opts CreateOptions, cfgPath string) error {
-	cfg, err := config.Load(cfgPath)
+	sess, err := cli.LoadSession(cfgPath, opts.Context)
 	if err != nil {
 		return err
 	}
 
-	currentCtx, ok := ic.resolveContext(cfg, opts.Context)
-	if !ok {
-		if opts.Context != "" {
-			return fmt.Errorf("context %q not found in config", opts.Context)
-		}
-		return fmt.Errorf("no active context found in config — run 'everestctl auth login' first")
-	}
-
-	usr, ok := cfg.GetUser(currentCtx.User)
-	if !ok {
-		return fmt.Errorf("user %q not found in config", currentCtx.User)
-	}
-
-	srv, ok := cfg.GetServer(currentCtx.Server)
-	if !ok {
-		return fmt.Errorf("server %q not found in config", currentCtx.Server)
-	}
-
-	if err := validateServerURL(srv.URL); err != nil {
-		return fmt.Errorf("invalid server URL in config: %w", err)
-	}
-
 	// Refresh proactively within 30s of expiry to avoid a mid-flight 401.
-	if time.Now().After(usr.ExpiresAt.Add(-30 * time.Second)) {
+	if time.Now().After(sess.User.ExpiresAt.Add(-30 * time.Second)) {
 		lo := authcli.NewLogin(authcli.Config{Pretty: ic.config.Pretty}, ic.l.Desugar().Sugar())
 		if err := lo.Refresh(ctx, cfgPath); err != nil {
 			return fmt.Errorf("access token expired and refresh failed: %w", err)
 		}
-		cfg, err = config.Load(cfgPath)
+		sess, err = cli.LoadSession(cfgPath, opts.Context)
 		if err != nil {
 			return err
 		}
-		usr, ok = cfg.GetUser(currentCtx.User)
-		if !ok {
-			return fmt.Errorf("user %q not found in config after refresh", currentCtx.User)
-		}
 	}
 
-	c, err := client.NewClientWithResponses(normalizeServerURL(srv.URL))
+	c, err := client.NewClientWithResponses(cli.NormalizeServerURL(sess.Server.URL))
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	token := bearerToken(usr.AccessToken)
+	token := cli.BearerToken(sess.User.AccessToken)
 
 	provResp, err := c.GetProviderWithResponse(ctx, opts.Cluster, opts.Provider, token)
 	if err != nil {
@@ -468,24 +435,3 @@ func buildPayload(name, provider, version, topology string, specOverrides map[st
 	}
 }
 
-func validateServerURL(server string) error {
-	if !strings.HasPrefix(server, "http://") && !strings.HasPrefix(server, "https://") {
-		return fmt.Errorf("server URL must start with http:// or https://")
-	}
-	return nil
-}
-
-func normalizeServerURL(server string) string {
-	server = strings.TrimRight(server, "/")
-	if !strings.HasSuffix(server, "/v1") {
-		server += "/v1"
-	}
-	return server
-}
-
-func bearerToken(token string) client.RequestEditorFn {
-	return func(_ context.Context, req *http.Request) error {
-		req.Header.Set("Authorization", "Bearer "+token)
-		return nil
-	}
-}

--- a/pkg/cli/instance/create_test.go
+++ b/pkg/cli/instance/create_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli"
 	"github.com/openeverest/openeverest/v2/pkg/cli/config"
 )
 
@@ -431,17 +432,17 @@ func TestBuildSpecOverrides_SetOnly(t *testing.T) {
 
 func TestValidateServerURL(t *testing.T) {
 	t.Parallel()
-	assert.NoError(t, validateServerURL("http://localhost:8080"))
-	assert.NoError(t, validateServerURL("https://prod.example.com"))
-	assert.Error(t, validateServerURL("localhost:8080"))
-	assert.Error(t, validateServerURL("ftp://bad.example.com"))
+	assert.NoError(t, cli.ValidateServerURL("http://localhost:8080"))
+	assert.NoError(t, cli.ValidateServerURL("https://prod.example.com"))
+	assert.Error(t, cli.ValidateServerURL("localhost:8080"))
+	assert.Error(t, cli.ValidateServerURL("ftp://bad.example.com"))
 }
 
 func TestNormalizeServerURL(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, "http://localhost:8080/v1", normalizeServerURL("http://localhost:8080"))
-	assert.Equal(t, "http://localhost:8080/v1", normalizeServerURL("http://localhost:8080/"))
-	assert.Equal(t, "http://localhost:8080/v1", normalizeServerURL("http://localhost:8080/v1"))
+	assert.Equal(t, "http://localhost:8080/v1", cli.NormalizeServerURL("http://localhost:8080"))
+	assert.Equal(t, "http://localhost:8080/v1", cli.NormalizeServerURL("http://localhost:8080/"))
+	assert.Equal(t, "http://localhost:8080/v1", cli.NormalizeServerURL("http://localhost:8080/v1"))
 }
 
 // ---- Run integration tests --------------------------------------------------

--- a/pkg/cli/instance/create_test.go
+++ b/pkg/cli/instance/create_test.go
@@ -1,0 +1,686 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+)
+
+// ---- helpers ----------------------------------------------------------------
+
+func boolPtr(b bool) *bool   { return &b }
+func strPtr(s string) *string { return &s }
+
+// buildProvider builds a minimal Provider fixture for tests.
+func buildProvider(name string, versions []struct {
+	name     string
+	isDefault bool
+}, topologies map[string][]string) *client.Provider {
+	meta := map[string]any{"name": name}
+
+	var vers []struct {
+		Components *map[string]string `json:"components,omitempty"`
+		Default    *bool              `json:"default,omitempty"`
+		Name       string             `json:"name"`
+	}
+	for _, v := range versions {
+		v := v
+		vers = append(vers, struct {
+			Components *map[string]string `json:"components,omitempty"`
+			Default    *bool              `json:"default,omitempty"`
+			Name       string             `json:"name"`
+		}{
+			Name:    v.name,
+			Default: boolPtr(v.isDefault),
+		})
+	}
+
+	topos := map[string]struct {
+		Components *map[string]struct {
+			Optional *bool `json:"optional,omitempty"`
+		} `json:"components,omitempty"`
+		ConfigSchema *map[string]any `json:"configSchema,omitempty"`
+	}{}
+	for topo, comps := range topologies {
+		compMap := map[string]struct {
+			Optional *bool `json:"optional,omitempty"`
+		}{}
+		for _, c := range comps {
+			compMap[c] = struct{ Optional *bool `json:"optional,omitempty"` }{}
+		}
+		topos[topo] = struct {
+			Components *map[string]struct {
+				Optional *bool `json:"optional,omitempty"`
+			} `json:"components,omitempty"`
+			ConfigSchema *map[string]any `json:"configSchema,omitempty"`
+		}{Components: &compMap}
+	}
+
+	globalComps := map[string]struct {
+		CustomSpecSchema *map[string]any `json:"customSpecSchema,omitempty"`
+		Type             *string         `json:"type,omitempty"`
+	}{}
+	for _, comps := range topologies {
+		for _, c := range comps {
+			globalComps[c] = struct {
+				CustomSpecSchema *map[string]any `json:"customSpecSchema,omitempty"`
+				Type             *string         `json:"type,omitempty"`
+			}{Type: strPtr(c + "-type")}
+		}
+	}
+
+	prov := &client.Provider{
+		Metadata: &meta,
+	}
+	prov.Spec.Versions = &vers
+	prov.Spec.Topologies = &topos
+	prov.Spec.Components = &globalComps
+	return prov
+}
+
+// newTestConfig returns a config with a single context pointing at serverURL.
+func newTestConfig(serverURL string) *config.Config {
+	host := serverURL[len("http://"):]
+	srvName := host
+	userName := "admin@" + srvName
+	return &config.Config{
+		APIVersion:     "config.openeverest.io/v1alpha1",
+		Kind:           "ClientConfig",
+		CurrentContext: userName,
+		Contexts: []config.NamedContext{
+			{Name: userName, Context: config.Context{Server: srvName, User: userName}},
+		},
+		Servers: []config.NamedServer{
+			{Name: srvName, Server: config.Server{URL: serverURL}},
+		},
+		Users: []config.NamedUser{
+			{Name: userName, User: config.User{
+				AccessToken:  "test-token",
+				RefreshToken: "rt-test",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}},
+		},
+	}
+}
+
+// ---- defaultVersion ---------------------------------------------------------
+
+func TestDefaultVersion_ReturnsDefaultBundle(t *testing.T) {
+	t.Parallel()
+	prov := buildProvider("psmdb", []struct {
+		name      string
+		isDefault bool
+	}{
+		{"7.0", false},
+		{"8.0", true},
+	}, nil)
+	assert.Equal(t, "8.0", defaultVersion(prov))
+}
+
+func TestDefaultVersion_FallsBackToFirst(t *testing.T) {
+	t.Parallel()
+	prov := buildProvider("psmdb", []struct {
+		name      string
+		isDefault bool
+	}{
+		{"7.0", false},
+		{"8.0", false},
+	}, nil)
+	assert.Equal(t, "7.0", defaultVersion(prov))
+}
+
+func TestDefaultVersion_NoVersions(t *testing.T) {
+	t.Parallel()
+	prov := &client.Provider{}
+	assert.Equal(t, "", defaultVersion(prov))
+}
+
+// ---- firstTopology ----------------------------------------------------------
+
+func TestFirstTopology_AlphabeticalOrder(t *testing.T) {
+	t.Parallel()
+	prov := buildProvider("psmdb", nil, map[string][]string{
+		"standalone":  {"engine"},
+		"replicaset":  {"engine", "proxy"},
+	})
+	assert.Equal(t, "replicaset", firstTopology(prov))
+}
+
+func TestFirstTopology_NoTopologies(t *testing.T) {
+	t.Parallel()
+	prov := &client.Provider{}
+	assert.Equal(t, "", firstTopology(prov))
+}
+
+// ---- validateTopology -------------------------------------------------------
+
+func TestValidateTopology_Valid(t *testing.T) {
+	t.Parallel()
+	prov := buildProvider("psmdb", nil, map[string][]string{"replicaset": {"engine"}})
+	assert.NoError(t, validateTopology("replicaset", prov))
+}
+
+func TestValidateTopology_Invalid(t *testing.T) {
+	t.Parallel()
+	prov := buildProvider("psmdb", nil, map[string][]string{
+		"standalone": {"engine"},
+		"replicaset": {"engine"},
+	})
+	err := validateTopology("sharded", prov)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sharded")
+	assert.Contains(t, err.Error(), "replicaset")
+	assert.Contains(t, err.Error(), "standalone")
+}
+
+// ---- validateComponents -----------------------------------------------------
+
+func TestValidateComponents_ValidPath(t *testing.T) {
+	t.Parallel()
+	prov := buildProvider("psmdb", nil, map[string][]string{"replicaset": {"engine", "proxy"}})
+	err := validateComponents([]string{"components.engine.replicas=3"}, prov, "replicaset")
+	assert.NoError(t, err)
+}
+
+func TestValidateComponents_InvalidComponent(t *testing.T) {
+	t.Parallel()
+	prov := buildProvider("psmdb", nil, map[string][]string{"replicaset": {"engine", "proxy"}})
+	err := validateComponents([]string{"components.mongos.replicas=3"}, prov, "replicaset")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mongos")
+	assert.Contains(t, err.Error(), "engine")
+	assert.Contains(t, err.Error(), "proxy")
+}
+
+func TestValidateComponents_NonComponentPathSkipped(t *testing.T) {
+	t.Parallel()
+	// --set backup.enabled=true is not a components.* path — must not be rejected
+	prov := buildProvider("psmdb", nil, map[string][]string{"replicaset": {"engine"}})
+	err := validateComponents([]string{"backup.enabled=true"}, prov, "replicaset")
+	assert.NoError(t, err)
+}
+
+func TestValidateComponents_EmptyTopologyFallsBackToGlobal(t *testing.T) {
+	t.Parallel()
+	// Topology has no components (simulates API stripping null entries).
+	// Validation should fall back to spec.components.
+	prov := buildProvider("psmdb", nil, map[string][]string{"replicaset": {"engine"}})
+	// Override: topology map exists but components map is nil inside it.
+	empty := map[string]struct {
+		Components *map[string]struct {
+			Optional *bool `json:"optional,omitempty"`
+		} `json:"components,omitempty"`
+		ConfigSchema *map[string]any `json:"configSchema,omitempty"`
+	}{
+		"replicaset": {Components: nil},
+	}
+	prov.Spec.Topologies = &empty
+	// engine IS in spec.components (set by buildProvider), so this should pass.
+	err := validateComponents([]string{"components.engine.replicas=3"}, prov, "replicaset")
+	assert.NoError(t, err)
+}
+
+// ---- parseSetFlags ----------------------------------------------------------
+
+func TestParseSetFlags_IntCoercion(t *testing.T) {
+	t.Parallel()
+	m, err := parseSetFlags([]string{"components.engine.replicas=3"})
+	require.NoError(t, err)
+	comps := m["components"].(map[string]any)
+	engine := comps["engine"].(map[string]any)
+	assert.Equal(t, int64(3), engine["replicas"])
+}
+
+func TestParseSetFlags_BoolCoercion(t *testing.T) {
+	t.Parallel()
+	m, err := parseSetFlags([]string{"backup.enabled=true"})
+	require.NoError(t, err)
+	backup := m["backup"].(map[string]any)
+	assert.Equal(t, true, backup["enabled"])
+}
+
+func TestParseSetFlags_StringFallback(t *testing.T) {
+	t.Parallel()
+	m, err := parseSetFlags([]string{"components.engine.storage.size=50Gi"})
+	require.NoError(t, err)
+	comps := m["components"].(map[string]any)
+	engine := comps["engine"].(map[string]any)
+	storage := engine["storage"].(map[string]any)
+	assert.Equal(t, "50Gi", storage["size"])
+}
+
+func TestParseSetFlags_MissingEquals(t *testing.T) {
+	t.Parallel()
+	_, err := parseSetFlags([]string{"components.engine.replicas"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be in the form")
+}
+
+func TestParseSetFlags_EmptyPath(t *testing.T) {
+	t.Parallel()
+	_, err := parseSetFlags([]string{"=value"})
+	require.Error(t, err)
+}
+
+func TestParseSetFlags_ConflictingPaths(t *testing.T) {
+	t.Parallel()
+	// First sets engine to a scalar, second tries to descend into it.
+	_, err := parseSetFlags([]string{"components.engine=5", "components.engine.replicas=3"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting")
+}
+
+func TestParseSetFlags_Empty(t *testing.T) {
+	t.Parallel()
+	m, err := parseSetFlags(nil)
+	require.NoError(t, err)
+	assert.Nil(t, m)
+}
+
+// ---- deepMerge --------------------------------------------------------------
+
+func TestDeepMerge_ScalarOverride(t *testing.T) {
+	t.Parallel()
+	dst := map[string]any{"a": 1}
+	src := map[string]any{"a": 2}
+	deepMerge(dst, src)
+	assert.Equal(t, 2, dst["a"])
+}
+
+func TestDeepMerge_NestedMerge(t *testing.T) {
+	t.Parallel()
+	dst := map[string]any{"engine": map[string]any{"replicas": 1, "size": "10Gi"}}
+	src := map[string]any{"engine": map[string]any{"replicas": 3}}
+	deepMerge(dst, src)
+	eng := dst["engine"].(map[string]any)
+	assert.Equal(t, 3, eng["replicas"])
+	assert.Equal(t, "10Gi", eng["size"]) // preserved
+}
+
+func TestDeepMerge_NewKey(t *testing.T) {
+	t.Parallel()
+	dst := map[string]any{"a": 1}
+	src := map[string]any{"b": 2}
+	deepMerge(dst, src)
+	assert.Equal(t, 1, dst["a"])
+	assert.Equal(t, 2, dst["b"])
+}
+
+// ---- buildPayload -----------------------------------------------------------
+
+func TestBuildPayload_BasicFields(t *testing.T) {
+	t.Parallel()
+	p := buildPayload("my-db", "psmdb", "8.0", "replicaset", nil)
+	spec := p["spec"].(map[string]any)
+	assert.Equal(t, "psmdb", spec["provider"])
+	assert.Equal(t, "8.0", spec["version"])
+	topo := spec["topology"].(map[string]any)
+	assert.Equal(t, "replicaset", topo["type"])
+	meta := p["metadata"].(map[string]any)
+	assert.Equal(t, "my-db", meta["name"])
+}
+
+func TestBuildPayload_ExplicitFlagsWinOverOverrides(t *testing.T) {
+	t.Parallel()
+	overrides := map[string]any{"provider": "wrong", "version": "wrong"}
+	p := buildPayload("db", "psmdb", "8.0", "standalone", overrides)
+	spec := p["spec"].(map[string]any)
+	assert.Equal(t, "psmdb", spec["provider"])
+	assert.Equal(t, "8.0", spec["version"])
+}
+
+func TestBuildPayload_EmptyVersionAndTopologyOmitted(t *testing.T) {
+	t.Parallel()
+	p := buildPayload("db", "psmdb", "", "", nil)
+	spec := p["spec"].(map[string]any)
+	_, hasVersion := spec["version"]
+	_, hasTopology := spec["topology"]
+	assert.False(t, hasVersion)
+	assert.False(t, hasTopology)
+}
+
+// ---- loadValuesFile ---------------------------------------------------------
+
+func TestLoadValuesFile_Valid(t *testing.T) {
+	t.Parallel()
+	f := filepath.Join(t.TempDir(), "values.yaml")
+	require.NoError(t, os.WriteFile(f, []byte("components:\n  engine:\n    replicas: 3\n"), 0600))
+	m, err := loadValuesFile(f)
+	require.NoError(t, err)
+	comps := m["components"].(map[string]any)
+	engine := comps["engine"].(map[string]any)
+	assert.Equal(t, 3, engine["replicas"])
+}
+
+func TestLoadValuesFile_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := loadValuesFile("/nonexistent/values.yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot read")
+}
+
+func TestLoadValuesFile_InvalidYAML(t *testing.T) {
+	t.Parallel()
+	f := filepath.Join(t.TempDir(), "bad.yaml")
+	require.NoError(t, os.WriteFile(f, []byte(":\t:bad"), 0600))
+	_, err := loadValuesFile(f)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot parse")
+}
+
+// ---- buildSpecOverrides -----------------------------------------------------
+
+func TestBuildSpecOverrides_SetWinsOverFile(t *testing.T) {
+	t.Parallel()
+	f := filepath.Join(t.TempDir(), "values.yaml")
+	require.NoError(t, os.WriteFile(f, []byte("components:\n  engine:\n    replicas: 1\n"), 0600))
+	m, err := buildSpecOverrides(f, []string{"components.engine.replicas=5"})
+	require.NoError(t, err)
+	comps := m["components"].(map[string]any)
+	engine := comps["engine"].(map[string]any)
+	assert.Equal(t, int64(5), engine["replicas"])
+}
+
+func TestBuildSpecOverrides_FileOnly(t *testing.T) {
+	t.Parallel()
+	f := filepath.Join(t.TempDir(), "values.yaml")
+	require.NoError(t, os.WriteFile(f, []byte("backup:\n  enabled: true\n"), 0600))
+	m, err := buildSpecOverrides(f, nil)
+	require.NoError(t, err)
+	backup := m["backup"].(map[string]any)
+	assert.Equal(t, true, backup["enabled"])
+}
+
+func TestBuildSpecOverrides_SetOnly(t *testing.T) {
+	t.Parallel()
+	m, err := buildSpecOverrides("", []string{"components.engine.replicas=3"})
+	require.NoError(t, err)
+	comps := m["components"].(map[string]any)
+	engine := comps["engine"].(map[string]any)
+	assert.Equal(t, int64(3), engine["replicas"])
+}
+
+// ---- validateServerURL / normalizeServerURL ---------------------------------
+
+func TestValidateServerURL(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, validateServerURL("http://localhost:8080"))
+	assert.NoError(t, validateServerURL("https://prod.example.com"))
+	assert.Error(t, validateServerURL("localhost:8080"))
+	assert.Error(t, validateServerURL("ftp://bad.example.com"))
+}
+
+func TestNormalizeServerURL(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "http://localhost:8080/v1", normalizeServerURL("http://localhost:8080"))
+	assert.Equal(t, "http://localhost:8080/v1", normalizeServerURL("http://localhost:8080/"))
+	assert.Equal(t, "http://localhost:8080/v1", normalizeServerURL("http://localhost:8080/v1"))
+}
+
+// ---- Run integration tests --------------------------------------------------
+
+// newRunServer returns a test server that handles /v1/clusters/main/providers/{p}
+// and /v1/clusters/main/namespaces/{ns}/instances with the provided handlers.
+func newRunServer(t *testing.T, providerHandler, createHandler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/providers/psmdb", providerHandler)
+	mux.HandleFunc("/v1/clusters/main/namespaces/", createHandler)
+	return httptest.NewServer(mux)
+}
+
+func psmdbProvider() *client.Provider {
+	return buildProvider("psmdb", []struct {
+		name      string
+		isDefault bool
+	}{{"8.0", true}}, map[string][]string{
+		"replicaset": {"engine", "proxy"},
+		"standalone": {"engine"},
+	})
+}
+
+func TestRun_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	provHandler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(psmdbProvider())
+	}
+	createHandler := func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}
+
+	srv := newRunServer(t, provHandler, createHandler)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	ic := NewInstanceCreator(Config{}, zap.NewNop().Sugar())
+	err := ic.Run(context.Background(), CreateOptions{
+		Name:      "my-db",
+		Namespace: "everest",
+		Provider:  "psmdb",
+		Cluster:   "main",
+	}, cfgPath)
+	assert.NoError(t, err)
+}
+
+func TestRun_ProviderNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := newRunServer(t,
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNotFound) },
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusCreated) },
+	)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	ic := NewInstanceCreator(Config{}, zap.NewNop().Sugar())
+	err := ic.Run(context.Background(), CreateOptions{
+		Name:      "my-db",
+		Namespace: "everest",
+		Provider:  "psmdb",
+		Cluster:   "main",
+	}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRun_InstanceAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	provHandler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(psmdbProvider())
+	}
+	createHandler := func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}
+
+	srv := newRunServer(t, provHandler, createHandler)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	ic := NewInstanceCreator(Config{}, zap.NewNop().Sugar())
+	err := ic.Run(context.Background(), CreateOptions{
+		Name:      "my-db",
+		Namespace: "everest",
+		Provider:  "psmdb",
+		Cluster:   "main",
+	}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestRun_InvalidTopology(t *testing.T) {
+	t.Parallel()
+
+	provHandler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(psmdbProvider())
+	}
+
+	srv := newRunServer(t, provHandler, func(w http.ResponseWriter, _ *http.Request) {})
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	ic := NewInstanceCreator(Config{}, zap.NewNop().Sugar())
+	err := ic.Run(context.Background(), CreateOptions{
+		Name:      "my-db",
+		Namespace: "everest",
+		Provider:  "psmdb",
+		Cluster:   "main",
+		Topology:  "sharded",
+	}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sharded")
+	assert.Contains(t, err.Error(), "valid topologies")
+}
+
+func TestRun_InvalidComponent(t *testing.T) {
+	t.Parallel()
+
+	provHandler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(psmdbProvider())
+	}
+
+	srv := newRunServer(t, provHandler, func(w http.ResponseWriter, _ *http.Request) {})
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	ic := NewInstanceCreator(Config{}, zap.NewNop().Sugar())
+	err := ic.Run(context.Background(), CreateOptions{
+		Name:      "my-db",
+		Namespace: "everest",
+		Provider:  "psmdb",
+		Cluster:   "main",
+		Set:       []string{"components.mongos.replicas=3"},
+	}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mongos")
+	assert.Contains(t, err.Error(), "valid components")
+}
+
+func TestRun_NoActiveContext(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, (&config.Config{
+		APIVersion:     "config.openeverest.io/v1alpha1",
+		Kind:           "ClientConfig",
+		CurrentContext: "missing",
+	}).Save(cfgPath))
+
+	ic := NewInstanceCreator(Config{}, zap.NewNop().Sugar())
+	err := ic.Run(context.Background(), CreateOptions{
+		Name:      "my-db",
+		Namespace: "everest",
+		Provider:  "psmdb",
+		Cluster:   "main",
+	}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active context")
+}
+
+func TestRun_ContextFlag(t *testing.T) {
+	t.Parallel()
+
+	provHandler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(psmdbProvider())
+	}
+	createHandler := func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}
+
+	srv := newRunServer(t, provHandler, createHandler)
+	defer srv.Close()
+
+	// Config has two contexts; currentContext points to "other".
+	host := srv.URL[len("http://"):]
+	cfg := &config.Config{
+		APIVersion:     "config.openeverest.io/v1alpha1",
+		Kind:           "ClientConfig",
+		CurrentContext: "other@other",
+		Contexts: []config.NamedContext{
+			{Name: "other@other", Context: config.Context{Server: "other", User: "other@other"}},
+			{Name: "admin@" + host, Context: config.Context{Server: host, User: "admin@" + host}},
+		},
+		Servers: []config.NamedServer{
+			{Name: host, Server: config.Server{URL: srv.URL}},
+		},
+		Users: []config.NamedUser{
+			{Name: "admin@" + host, User: config.User{
+				AccessToken: "test-token",
+				ExpiresAt:   time.Now().Add(time.Hour),
+			}},
+		},
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	ic := NewInstanceCreator(Config{}, zap.NewNop().Sugar())
+	err := ic.Run(context.Background(), CreateOptions{
+		Name:      "my-db",
+		Namespace: "everest",
+		Provider:  "psmdb",
+		Cluster:   "main",
+		Context:   "admin@" + host,
+	}, cfgPath)
+	assert.NoError(t, err)
+}
+
+func TestRun_UnknownContext(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig("http://localhost:9999").Save(cfgPath))
+
+	ic := NewInstanceCreator(Config{}, zap.NewNop().Sugar())
+	err := ic.Run(context.Background(), CreateOptions{
+		Name:      "my-db",
+		Namespace: "everest",
+		Provider:  "psmdb",
+		Cluster:   "main",
+		Context:   "nonexistent",
+	}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent")
+}

--- a/pkg/cli/instance/status.go
+++ b/pkg/cli/instance/status.go
@@ -1,0 +1,170 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli"
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+)
+
+// StatusOptions holds the inputs for the status command.
+type StatusOptions struct {
+	Name      string
+	Namespace string
+	Cluster   string
+	Context   string
+}
+
+// InstanceStatusRunner fetches and prints the status of an instance.
+type InstanceStatusRunner struct {
+	config Config
+	l      *zap.SugaredLogger
+}
+
+// NewInstanceStatusRunner creates a new InstanceStatusRunner.
+func NewInstanceStatusRunner(cfg Config, l *zap.SugaredLogger) *InstanceStatusRunner {
+	is := &InstanceStatusRunner{config: cfg, l: l.With("component", "instance-status")}
+	if cfg.Pretty {
+		is.l = zap.NewNop().Sugar()
+	}
+	return is
+}
+
+// Run fetches the instance and prints its status to stdout.
+func (is *InstanceStatusRunner) Run(ctx context.Context, opts StatusOptions, cfgPath string) error {
+	sess, err := cli.LoadSession(cfgPath, opts.Context)
+	if err != nil {
+		return err
+	}
+
+	// Refresh proactively within 30s of expiry to avoid a mid-flight 401.
+	if time.Now().After(sess.User.ExpiresAt.Add(-30 * time.Second)) {
+		lo := authcli.NewLogin(authcli.Config{Pretty: is.config.Pretty}, is.l.Desugar().Sugar())
+		if err := lo.Refresh(ctx, cfgPath); err != nil {
+			return fmt.Errorf("access token expired and refresh failed: %w", err)
+		}
+		sess, err = cli.LoadSession(cfgPath, opts.Context)
+		if err != nil {
+			return err
+		}
+	}
+
+	c, err := client.NewClientWithResponses(cli.NormalizeServerURL(sess.Server.URL))
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	token := cli.BearerToken(sess.User.AccessToken)
+
+	resp, err := c.GetInstanceWithResponse(ctx, opts.Cluster, opts.Namespace, opts.Name, token)
+	if err != nil {
+		return fmt.Errorf("failed to fetch instance %q: %w", opts.Name, err)
+	}
+
+	if resp.StatusCode() == http.StatusNotFound {
+		return fmt.Errorf("instance %q not found in namespace %q", opts.Name, opts.Namespace)
+	}
+
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return fmt.Errorf("unexpected response fetching instance %q: %s", opts.Name, resp.Status())
+	}
+
+	if !is.config.Pretty {
+		return json.NewEncoder(os.Stdout).Encode(resp.JSON200)
+	}
+
+	printInstanceStatus(resp.JSON200, opts.Namespace)
+	return nil
+}
+
+func printInstanceStatus(inst *client.Instance, namespace string) {
+	name := "-"
+	if inst.Metadata != nil {
+		if n, ok := (*inst.Metadata)["name"]; ok {
+			if s, ok := n.(string); ok {
+				name = s
+			}
+		}
+	}
+
+	phase := "-"
+	message := "-"
+	version := "-"
+
+	if inst.Status != nil {
+		if inst.Status.Phase != nil {
+			phase = string(*inst.Status.Phase)
+		}
+		if inst.Status.Message != nil && *inst.Status.Message != "" {
+			message = *inst.Status.Message
+		}
+		if inst.Status.Version != nil && *inst.Status.Version != "" {
+			version = *inst.Status.Version
+		}
+	}
+
+	fmt.Fprintf(os.Stdout, "Instance:  %s\n", name)
+	fmt.Fprintf(os.Stdout, "Namespace: %s\n", namespace)
+	fmt.Fprintf(os.Stdout, "Phase:     %s\n", phase)
+	fmt.Fprintf(os.Stdout, "Version:   %s\n", version)
+	fmt.Fprintf(os.Stdout, "Message:   %s\n", message)
+
+	if inst.Status != nil && inst.Status.Components != nil && len(*inst.Status.Components) > 0 {
+		fmt.Fprintln(os.Stdout, "\nComponents:")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "  STATE\tREADY\tTOTAL")
+		for _, comp := range *inst.Status.Components {
+			state := "-"
+			if comp.State != nil {
+				state = *comp.State
+			}
+			var ready, total int32
+			if comp.Ready != nil {
+				ready = *comp.Ready
+			}
+			if comp.Total != nil {
+				total = *comp.Total
+			}
+			fmt.Fprintf(w, "  %s\t%d\t%d\n", state, ready, total)
+		}
+		w.Flush() //nolint:errcheck
+	}
+
+	if inst.Status != nil && inst.Status.Conditions != nil && len(*inst.Status.Conditions) > 0 {
+		fmt.Fprintln(os.Stdout, "\nConditions:")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "  TYPE\tSTATUS\tREASON\tMESSAGE")
+		for _, cond := range *inst.Status.Conditions {
+			msg := cond.Message
+			if msg == "" {
+				msg = "-"
+			}
+			fmt.Fprintf(w, "  %s\t%s\t%s\t%s\n", cond.Type, string(cond.Status), cond.Reason, msg)
+		}
+		w.Flush() //nolint:errcheck
+	}
+}

--- a/pkg/cli/instance/status_test.go
+++ b/pkg/cli/instance/status_test.go
@@ -1,0 +1,234 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+)
+
+func TestInstanceStatus_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	phase := client.InstanceStatusPhaseReady
+	version := "1.22.0"
+	msg := "All replicas are ready"
+	ready := int32(3)
+	total := int32(3)
+	state := "Running"
+	condStatus := client.InstanceStatusConditionsStatusTrue
+
+	inst := &client.Instance{
+		Metadata: &map[string]interface{}{"name": "my-mongo"},
+		Status: &struct {
+			Components *[]struct {
+				Pods *[]struct {
+					Name *string `json:"name,omitempty"`
+				} `json:"pods,omitempty"`
+				Ready *int32  `json:"ready,omitempty"`
+				State *string `json:"state,omitempty"`
+				Total *int32  `json:"total,omitempty"`
+			} `json:"components,omitempty"`
+			Conditions *[]struct {
+				LastTransitionTime    time.Time                          `json:"lastTransitionTime"`
+				Message               string                             `json:"message"`
+				ObservedGeneration    *int64                             `json:"observedGeneration,omitempty"`
+				Reason                string                             `json:"reason"`
+				Status                client.InstanceStatusConditionsStatus `json:"status"`
+				Type                  string                             `json:"type"`
+			} `json:"conditions,omitempty"`
+			ConnectionSecretRef *struct {
+				Name *string `json:"name,omitempty"`
+			} `json:"connectionSecretRef,omitempty"`
+			Message *string                      `json:"message,omitempty"`
+			Phase   *client.InstanceStatusPhase  `json:"phase,omitempty"`
+			Version *string                      `json:"version,omitempty"`
+		}{
+			Phase:   &phase,
+			Version: &version,
+			Message: &msg,
+			Components: &[]struct {
+				Pods *[]struct {
+					Name *string `json:"name,omitempty"`
+				} `json:"pods,omitempty"`
+				Ready *int32  `json:"ready,omitempty"`
+				State *string `json:"state,omitempty"`
+				Total *int32  `json:"total,omitempty"`
+			}{
+				{Ready: &ready, Total: &total, State: &state},
+			},
+			Conditions: &[]struct {
+				LastTransitionTime    time.Time                          `json:"lastTransitionTime"`
+				Message               string                             `json:"message"`
+				ObservedGeneration    *int64                             `json:"observedGeneration,omitempty"`
+				Reason                string                             `json:"reason"`
+				Status                client.InstanceStatusConditionsStatus `json:"status"`
+				Type                  string                             `json:"type"`
+			}{
+				{Type: "Available", Status: condStatus, Reason: "Ready", Message: "All replicas are ready"},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(inst)
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewInstanceStatusRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), StatusOptions{
+		Name:      "my-mongo",
+		Namespace: "everest",
+		Cluster:   "main",
+	}, cfgPath)
+	require.NoError(t, err)
+}
+
+func TestInstanceStatus_NotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewInstanceStatusRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), StatusOptions{
+		Name:      "no-such-instance",
+		Namespace: "everest",
+		Cluster:   "main",
+	}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestInstanceStatus_ServerError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewInstanceStatusRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), StatusOptions{
+		Name:      "my-mongo",
+		Namespace: "everest",
+		Cluster:   "main",
+	}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected response")
+}
+
+func TestInstanceStatus_NoActiveContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		APIVersion: "config.openeverest.io/v1alpha1",
+		Kind:       "ClientConfig",
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewInstanceStatusRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), StatusOptions{
+		Name:      "my-mongo",
+		Namespace: "everest",
+		Cluster:   "main",
+	}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active context")
+}
+
+func TestInstanceStatus_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	phase := client.InstanceStatusPhaseReady
+	inst := &client.Instance{
+		Metadata: &map[string]interface{}{"name": "my-mongo"},
+		Status: &struct {
+			Components *[]struct {
+				Pods *[]struct {
+					Name *string `json:"name,omitempty"`
+				} `json:"pods,omitempty"`
+				Ready *int32  `json:"ready,omitempty"`
+				State *string `json:"state,omitempty"`
+				Total *int32  `json:"total,omitempty"`
+			} `json:"components,omitempty"`
+			Conditions *[]struct {
+				LastTransitionTime    time.Time                             `json:"lastTransitionTime"`
+				Message               string                                `json:"message"`
+				ObservedGeneration    *int64                                `json:"observedGeneration,omitempty"`
+				Reason                string                                `json:"reason"`
+				Status                client.InstanceStatusConditionsStatus `json:"status"`
+				Type                  string                                `json:"type"`
+			} `json:"conditions,omitempty"`
+			ConnectionSecretRef *struct {
+				Name *string `json:"name,omitempty"`
+			} `json:"connectionSecretRef,omitempty"`
+			Message *string                     `json:"message,omitempty"`
+			Phase   *client.InstanceStatusPhase `json:"phase,omitempty"`
+			Version *string                     `json:"version,omitempty"`
+		}{
+			Phase: &phase,
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(inst)
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	// Pretty=false → JSON path
+	runner := NewInstanceStatusRunner(Config{Pretty: false}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), StatusOptions{
+		Name:      "my-mongo",
+		Namespace: "everest",
+		Cluster:   "main",
+	}, cfgPath)
+	require.NoError(t, err)
+}

--- a/pkg/cli/session.go
+++ b/pkg/cli/session.go
@@ -1,0 +1,100 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+)
+
+// Session holds resolved credentials for a single Everest context.
+type Session struct {
+	Cfg    *config.Config
+	Ctx    config.Context
+	User   config.User
+	Server config.Server
+}
+
+// LoadSession loads the config, resolves the named context (or current context
+// when name is empty), and validates the server URL.
+func LoadSession(cfgPath, contextName string) (*Session, error) {
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		ctx config.Context
+		ok  bool
+	)
+	if contextName != "" {
+		ctx, ok = cfg.GetContext(contextName)
+		if !ok {
+			return nil, fmt.Errorf("context %q not found in config", contextName)
+		}
+	} else {
+		ctx, ok = cfg.GetCurrentContext()
+		if !ok {
+			return nil, fmt.Errorf("no active context found in config — run 'everestctl auth login' first")
+		}
+	}
+
+	usr, ok := cfg.GetUser(ctx.User)
+	if !ok {
+		return nil, fmt.Errorf("user %q not found in config", ctx.User)
+	}
+
+	srv, ok := cfg.GetServer(ctx.Server)
+	if !ok {
+		return nil, fmt.Errorf("server %q not found in config", ctx.Server)
+	}
+
+	if err := ValidateServerURL(srv.URL); err != nil {
+		return nil, fmt.Errorf("invalid server URL in config: %w", err)
+	}
+
+	return &Session{Cfg: cfg, Ctx: ctx, User: usr, Server: srv}, nil
+}
+
+// ValidateServerURL returns an error if the URL scheme is not http or https.
+func ValidateServerURL(server string) error {
+	if !strings.HasPrefix(server, "http://") && !strings.HasPrefix(server, "https://") {
+		return fmt.Errorf("server URL must start with http:// or https://")
+	}
+	return nil
+}
+
+// NormalizeServerURL ensures the URL ends with /v1.
+func NormalizeServerURL(server string) string {
+	server = strings.TrimRight(server, "/")
+	if !strings.HasSuffix(server, "/v1") {
+		server += "/v1"
+	}
+	return server
+}
+
+// BearerToken returns a request editor that sets the Authorization header.
+func BearerToken(token string) client.RequestEditorFn {
+	return func(_ context.Context, req *http.Request) error {
+		req.Header.Set("Authorization", "Bearer "+token)
+		return nil
+	}
+}


### PR DESCRIPTION
Add `everestctl instance create` command for provisioning database instances via the Everest API. Supports MongoDB (psmdb), PostgreSQL, and MySQL (pxc) providers, or any future provider registered in the cluster.

Happy path requires only --name, --namespace, and --provider. Version bundle and topology are resolved automatically from the provider's defaults. Component configuration supports two override mechanisms that can be used together:

- --set componenets.engine.replicas=3 for simple per-field tweaks
- -f values.yaml for complex multi-component configs (like helm -f)

When both are given, --set takes precedence over file values via deep-merge. The happy path works with zero --set and zero -f flags.

Implementation details:
- Client-side validation of component names against the provider's topology spec before any API call, with a helpful error listing valid names
- Client-side validation of user-supplied --topology against the provider's topology map
- Proactive token refresh when ExpiresAt is within 30s of expiry, so long-running sessions don't fail silently with a 401
- Raw JSON payload via CreateInstanceWithBodyWithResponse to work around anonymous nested structs in the generated client
- --cluster defaults to "main" (same as Everest UI) for future multi-cluster readiness