### PR TITLE
fix(ui): add missing noreferrer to external links

### DIFF
--- a/ui/apps/everest/src/components/app-bar/help-icon/HelpIcon.tsx
+++ b/ui/apps/everest/src/components/app-bar/help-icon/HelpIcon.tsx
@@ -56,7 +56,7 @@ const AppBarHelpIcon = () => {
           underline="none"
           color="inherit"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
           href="https://openeverest.io/support/"
         >
           <MenuItem onClick={handleClose}>
@@ -67,7 +67,7 @@ const AppBarHelpIcon = () => {
           underline="none"
           color="inherit"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
           href="https://openeverest.io/docs/"
         >
           <MenuItem onClick={handleClose}>
@@ -78,7 +78,7 @@ const AppBarHelpIcon = () => {
           underline="none"
           color="inherit"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
           href="https://github.com/openeverest/openeverest/issues"
         >
           <MenuItem onClick={handleClose}>
@@ -89,7 +89,7 @@ const AppBarHelpIcon = () => {
           underline="none"
           color="inherit"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
           href="https://openeverest.io/#community"
         >
           <MenuItem onClick={handleClose}>

--- a/ui/apps/everest/src/components/app-bar/help-icon/HelpIcon.tsx
+++ b/ui/apps/everest/src/components/app-bar/help-icon/HelpIcon.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useContext, useState } from 'react';
 import {
   Divider,

--- a/ui/apps/everest/src/components/empty-state-databases/empty-state-databases.tsx
+++ b/ui/apps/everest/src/components/empty-state-databases/empty-state-databases.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Box, Link, Typography } from '@mui/material';
 import CreateDbButton from 'components/create-db-button/create-db-button';
 import EmptyState from 'components/empty-state';

--- a/ui/apps/everest/src/components/empty-state-databases/empty-state-databases.tsx
+++ b/ui/apps/everest/src/components/empty-state-databases/empty-state-databases.tsx
@@ -25,7 +25,7 @@ const EmptyStateDatabases = ({
                   Click{' '}
                   <Link
                     target="_blank"
-                    rel="noopener"
+                    rel="noopener noreferrer"
                     href="https://openeverest.io/documentation/current/administer/rbac.html"
                   >
                     here

--- a/ui/apps/everest/src/components/empty-state/empty-state.tsx
+++ b/ui/apps/everest/src/components/empty-state/empty-state.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {
   Button,
   Divider,
@@ -11,7 +25,11 @@ import { EmptyStateIcon } from '@percona/ui-lib';
 
 const ContactSupportLink = ({ msg }: { msg: string }) => {
   return (
-    <Link target="_blank" rel="noopener noreferrer" href="https://openeverest.io/support/">
+    <Link
+      target="_blank"
+      rel="noopener noreferrer"
+      href="https://openeverest.io/support/"
+    >
       <Button
         startIcon={
           <HelpIcon

--- a/ui/apps/everest/src/components/empty-state/empty-state.tsx
+++ b/ui/apps/everest/src/components/empty-state/empty-state.tsx
@@ -11,7 +11,7 @@ import { EmptyStateIcon } from '@percona/ui-lib';
 
 const ContactSupportLink = ({ msg }: { msg: string }) => {
   return (
-    <Link target="_blank" rel="noopener" href="https://openeverest.io/support/">
+    <Link target="_blank" rel="noopener noreferrer" href="https://openeverest.io/support/">
       <Button
         startIcon={
           <HelpIcon

--- a/ui/apps/everest/src/components/linked-alert/LinkedAlert.tsx
+++ b/ui/apps/everest/src/components/linked-alert/LinkedAlert.tsx
@@ -34,7 +34,7 @@ const LinkedAlert = ({
             underline="none"
             color="inherit"
             target="_blank"
-            rel="noopener"
+            rel="noopener noreferrer"
             {...linkProps}
           >
             {linkContent}

--- a/ui/apps/everest/src/components/linked-alert/LinkedAlert.tsx
+++ b/ui/apps/everest/src/components/linked-alert/LinkedAlert.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Alert, Box, Link, Stack } from '@mui/material';
 import { LinkedAlertProps } from './LinkedAlert.types';
 

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/connection-details.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/connection-details.tsx
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/connection-details.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/connection-details.tsx
@@ -58,6 +58,7 @@ export const ConnectionDetails = ({
             <Link
               href="https://openeverest.io/documentation/current/networking/nodeport_support.html"
               target="_blank"
+              rel="noopener noreferrer"
             >
               instructions
             </Link>

--- a/ui/apps/everest/src/pages/login/Login.tsx
+++ b/ui/apps/everest/src/pages/login/Login.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Box, Button, Divider, Stack, Typography, Link } from '@mui/material';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';

--- a/ui/apps/everest/src/pages/login/Login.tsx
+++ b/ui/apps/everest/src/pages/login/Login.tsx
@@ -20,7 +20,7 @@ const LoginLinkButton = ({
   href: string;
 }) => {
   return (
-    <Link target="_blank" rel="noopener" href={href}>
+    <Link target="_blank" rel="noopener noreferrer" href={href}>
       <Button startIcon={icon}>{text}</Button>
     </Link>
   );


### PR DESCRIPTION
## Summary

Several external links in the UI were using `target="_blank"` with only `rel="noopener"`, missing the `noreferrer` attribute. This PR updates all affected files to use `rel="noopener noreferrer"`, hardening security against reverse tabnapping and preventing the `Referer` header from leaking the origin URL to external third-party sites.

Closes #2481 

## Changes Made

Updated `rel="noopener"` to `rel="noopener noreferrer"` in the following files:

- `ui/apps/everest/src/pages/login/Login.tsx`
- `ui/apps/everest/src/components/empty-state/empty-state.tsx`
- `ui/apps/everest/src/components/empty-state-databases/empty-state-databases.tsx`
- `ui/apps/everest/src/components/app-bar/help-icon/HelpIcon.tsx`
- `ui/apps/everest/src/components/linked-alert/LinkedAlert.tsx`
- `ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/connection-details.tsx`

## Before & After

```tsx
// Before
<a href="https://example.com" target="_blank" rel="noopener">

// After
<a href="https://example.com" target="_blank" rel="noopener noreferrer">
```

## Why It Matters

- **Security** — Fully protects against reverse tabnapping attacks, including in legacy browsers where `noopener` alone is insufficient
- **Privacy** — `noreferrer` prevents the browser from sending the `Referer` header, stopping the origin URL from leaking to external third-party sites
- **Consistency** — All external links across the UI now follow the same secure pattern

## References

- [MDN Web Docs — Link types: noopener](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/noopener)
- [web.dev — Links to cross-origin destinations are unsafe](https://web.dev/external-anchors-use-rel-noopener/)


## Checklist

- [x] All `target="_blank"` links now include `rel="noopener noreferrer"`
- [x] No existing functionality or styling affected
- [x] Changes verified across all affected files