### PR TITLE
Focus the dev Tiltfile on core development

### DIFF
--- a/dev/.env.example
+++ b/dev/.env.example
@@ -10,27 +10,9 @@ EVEREST_OPERATOR_DIR=
 # Mandatory.
 EVEREST_CHART_DIR=
 
-# Path to PSMDB Provider helm charts source code directory.
-# Hint:  <path to github.com/openeverest/provider-percona-server-mongodb repository directory>/charts/provider-percona-server-mongodb
-# Mandatory.
-PSMDB_PROVIDER_CHART_DIR=
-
-# Path to PXC Provider helm charts source code directory.
-# Hint:  <path to github.com/openeverest/provider-percona-xtradb-cluster repository directory>/charts/provider-percona-xtradb-cluster
-# Mandatory.
-PXC_PROVIDER_CHART_DIR=
-
-# PXC operator version for deploying into Everest DB namespaces.
-# Optional, default: 1.20.0
-#PXC_OPERATOR_VERSION=1.20.0
-
-# PSMDB operator version for deploying into Everest DB namespaces.
-# Optional, default: 1.22.0
-#PSMDB_OPERATOR_VERSION=1.22.0
-
-# PG operator version for deploying into Everest DB namespaces.
-# Optional, default: 2.8.2
-#PG_OPERATOR_VERSION=2.8.2
+# NOTE: This Tiltfile builds and deploys the OpenEverest core only. Database
+# providers (PSMDB, PXC, ...) are developed in their own repositories, each with
+# its own dev/Tiltfile. See the provider repo's dev/README.md.
 
 # Enable building debug image for Everest server.
 # Optional, default: false
@@ -47,14 +29,6 @@ PXC_PROVIDER_CHART_DIR=
 # Go build environment variables for building Everest server backend.
 # Optional, default: 'CGO_ENABLED=0 GOOS=linux'
 #EVEREST_BACKEND_BUILD_ENV='CGO_ENABLED=0 GOOS=linux'
-
-# Go build environment variables for building PSMDB provider.
-# Optional, default: 'CGO_ENABLED=0 GOOS=linux'
-#PSMDB_PROVIDER_BUILD_ENV='CGO_ENABLED=0 GOOS=linux'
-
-# Go build environment variables for building PXC provider.
-# Optional, default: 'CGO_ENABLED=0 GOOS=linux'
-#PXC_PROVIDER_BUILD_ENV='CGO_ENABLED=0 GOOS=linux'
 
 # Use K8S context from local kube.config file.
 # To get your current context name run `kubectl config view`

--- a/dev/README.md
+++ b/dev/README.md
@@ -39,9 +39,10 @@ NOTE: for MacOS tilt needs to have installed and runing `docker-desktop` tool. T
 
 9. Clone [helm-charts](https://github.com/openeverest/helm-charts).
 
-10. Clone [provider-percona-server-mongodb](https://github.com/openeverest/provider-percona-server-mongodb).
-
-11. Clone [provider-percona-xtradb-cluster](https://github.com/openeverest/provider-percona-xtradb-cluster).
+> **NOTE**: This Tiltfile is focused on OpenEverest **core** development (the
+> API server, controller, CRDs and UI). Database providers (PSMDB, PXC, ...) are
+> developed in their own repositories, each with its own `dev/Tiltfile`. See
+> [Developing providers](#developing-providers) below.
 
 ## Set up the environment
 
@@ -89,8 +90,6 @@ Copy file dev/.env.example to dev/.env and set the following environment variabl
 ```sh
 EVEREST_OPERATOR_DIR=<path to github.com/percona/everest-operator repository directory>
 EVEREST_CHART_DIR=<path to github.com/openeverest/helm-charts>/charts/everest
-PSMDB_PROVIDER_CHART_DIR=<path to github.com/openeverest/provider-percona-server-mongodb repository directory>/charts/provider-percona-server-mongodb
-PXC_PROVIDER_CHART_DIR=<path to github.com/openeverest/provider-percona-xtradb-cluster repository directory>/charts/provider-percona-xtradb-cluster
 ```
 
 or set environment variables manually in the terminal:
@@ -98,12 +97,10 @@ or set environment variables manually in the terminal:
 ```sh
 export EVEREST_OPERATOR_DIR=<path to github.com/percona/everest-operator repository directory>
 export EVEREST_CHART_DIR=<path to github.com/openeverest/helm-charts>/charts/everest
-export PSMDB_PROVIDER_CHART_DIR=<path to github.com/openeverest/provider-percona-server-mongodb repository directory>/charts/provider-percona-server-mongodb
-export PXC_PROVIDER_CHART_DIR=<path to github.com/openeverest/provider-percona-xtradb-cluster repository directory>/charts/provider-percona-xtradb-cluster
 ```
 
 For OpenEverest v2 development use `v2` branch of `EVEREST_CHART_DIR`.
-If your Tilt environment starts with errors, ensure you have the latest pull of `main` branch for `PSMDB_PROVIDER_CHART_DIR` and `PXC_PROVIDER_CHART_DIR`, and latest `v2` branch for `EVEREST_CHART_DIR`.
+If your Tilt environment starts with errors, ensure you have the latest `v2` branch for `EVEREST_CHART_DIR`.
 
 2. Set namespaces for the Everest components:
 
@@ -123,14 +120,7 @@ helm registry login ghcr.io -u <github-user> -p <token>
 ```
 If `HELLO_PLUGIN_CHART` is not set, Tilt skips the plugin step entirely.
 
-4. (Optional) If you want to test a specific version of a given DB operator you can set the following environment variables in .env file or in the terminal:
-```sh
-export PXC_OPERATOR_VERSION=1.19.0
-export PSMDB_OPERATOR_VERSION=1.22.0
-export PG_OPERATOR_VERSION=2.8.2
-```
-
-5. (Optional) If you want to debug Everest Server and/or Everest operator remotely, you can set the following environment variables in .env file or in the terminal: 
+4. (Optional) If you want to debug Everest Server and/or Everest operator remotely, you can set the following environment variables in .env file or in the terminal: 
 ```sh
 export EVEREST_DEBUG=true
 export EVEREST_OPERATOR_DEBUG=true
@@ -145,7 +135,7 @@ Refer to instructions in your IDE on how to setup remote debugging.
 
 For GoLand, you can refer to [this](https://www.jetbrains.com/help/go/attach-to-running-go-processes-with-debugger.html#step-2-create-the-go-remote-run-debug-configuration) link.
 
-6. Start Tilt:
+5. Start Tilt:
 ```sh
 make dev-up
 ```
@@ -174,3 +164,29 @@ tilt as described in [Set up the environment](#set-up-the-environment) section
 but then run a local dev instance of the frontend by running `make dev` from
 the frontend repo. This dev instance will be available at http://localhost:3000
 while still connecting to the everest API server running inside k8s.
+
+## Developing providers
+
+This Tiltfile builds and deploys the OpenEverest core only. Each provider
+repository ships its own `dev/Tiltfile` that installs a released OpenEverest
+core and then builds and deploys just that provider. For day-to-day provider
+development, use the provider repo's `make dev-up` (see its `dev/README.md`).
+
+### Testing a provider against a locally built core
+
+When you need a provider to run against the core you are building from source,
+run two Tilt instances against the same cluster:
+
+1. Start this core dev environment as usual (`make dev-up`). It manages
+   `everest-system` and the core CRDs.
+2. In the provider repo, start its Tilt instance on a different port with the
+   core installation disabled:
+
+   ```sh
+   INSTALL_OPENEVEREST=false tilt up -f dev/Tiltfile --port 10351
+   ```
+
+The two instances manage disjoint Kubernetes objects (core owns
+`everest-system` + the core CRDs; the provider owns its own namespace + the
+database operator), so they run side by side without conflicting.
+

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -56,25 +56,11 @@ if not os.path.exists(everest_chart_dir):
     fail('Chart dir does not exist: {0}'.format(everest_chart_dir))
 print('Using chart dir: {0}'.format(everest_chart_dir))
 
-psmdb_provider_chart_dir = os.getenv('PSMDB_PROVIDER_CHART_DIR')
-if not psmdb_provider_chart_dir:
-    fail('PSMDB_PROVIDER_CHART_DIR must be set')
-psmdb_provider_chart_dir = os.path.realpath(psmdb_provider_chart_dir)
-if not os.path.exists(psmdb_provider_chart_dir):
-    fail('PSMDB Provider chart dir does not exist: {0}'.format(psmdb_provider_chart_dir))
-print('Using PSMDB Provider chart dir: {0}'.format(psmdb_provider_chart_dir))
-psmdb_provider_dir = os.path.dirname(os.path.dirname(psmdb_provider_chart_dir))
-print('Using PSMDB Provider dir: {0}'.format(psmdb_provider_dir))
-
-pxc_provider_chart_dir = os.getenv('PXC_PROVIDER_CHART_DIR')
-if not pxc_provider_chart_dir:
-    fail('PXC_PROVIDER_CHART_DIR must be set')
-pxc_provider_chart_dir = os.path.realpath(pxc_provider_chart_dir)
-if not os.path.exists(pxc_provider_chart_dir):
-    fail('PXC Provider chart dir does not exist: {0}'.format(pxc_provider_chart_dir))
-print('Using PXC Provider chart dir: {0}'.format(pxc_provider_chart_dir))
-pxc_provider_dir = os.path.dirname(os.path.dirname(pxc_provider_chart_dir))
-print('Using PXC Provider dir: {0}'.format(pxc_provider_dir))
+# NOTE: This Tiltfile is focused on OpenEverest CORE development only. Database
+# providers (PSMDB, PXC, ...) are developed in their own repositories, each with
+# its own dev/Tiltfile. To exercise a provider against this locally built core,
+# run the provider's Tiltfile in a separate Tilt instance with
+# INSTALL_OPENEVEREST=false (see the provider repo's dev/README.md).
 
 # Optional: Hello Plugin (installed from OCI Helm chart)
 # Set HELLO_PLUGIN_CHART to the OCI chart reference, e.g.:
@@ -88,14 +74,6 @@ if hello_plugin_chart:
 else:
     print('HELLO_PLUGIN_CHART not set — skipping hello plugin')
 
-# Optional env vars
-pxc_operator_version = os.getenv('PXC_OPERATOR_VERSION', '1.19.0')
-print('Using PXC operator version: {0}'.format(pxc_operator_version))
-psmdb_operator_version = os.getenv('PSMDB_OPERATOR_VERSION', '1.22.0')
-print('Using PSMDB operator version: {0}'.format(psmdb_operator_version))
-pg_operator_version = os.getenv('PG_OPERATOR_VERSION', '2.8.2')
-print('Using PG operator version: {0}'.format(pg_operator_version))
-
 # Check for Everest operator Go build options
 go_default_build_env = 'CGO_ENABLED=0 GOOS=linux'
 everest_operator_build_env = os.getenv('EVEREST_OPERATOR_BUILD_ENV', go_default_build_env)
@@ -104,14 +82,6 @@ print('Using Everest operator build ENV vars: {0}'.format(everest_operator_build
 # Check for Everest server backend Go build options
 everest_backend_build_env = os.getenv('EVEREST_BACKEND_BUILD_ENV', go_default_build_env)
 print('Using Everest server backend build ENV vars: {0}'.format(everest_backend_build_env))
-
-# Check for PSMDB provider Go build options
-psmdb_provider_build_env = os.getenv('PSMDB_PROVIDER_BUILD_ENV', go_default_build_env)
-print('Using PSMDB provider build ENV vars: {0}'.format(psmdb_provider_build_env))
-
-# Check for PXC provider Go build options
-pxc_provider_build_env = os.getenv('PXC_PROVIDER_BUILD_ENV', go_default_build_env)
-print('Using PXC provider build ENV vars: {0}'.format(pxc_provider_build_env))
 
 # External resources set up
 k8s_context = os.getenv('K8S_CONTEXT', '')
@@ -154,7 +124,7 @@ watch_settings(
 local('[ -x %s/bin/kustomize ] || make -C %s kustomize' % (operator_dir, operator_dir), quiet=True)
 
 # Create namespace
-load('ext://namespace', 'namespace_create', 'namespace_inject')
+load('ext://namespace', 'namespace_create')
 namespace_create(EVEREST_NAMESPACE)
 k8s_resource(
   objects=[
@@ -164,7 +134,7 @@ k8s_resource(
 )
 
 #################################
-## Install DB engine operators ##
+########## Namespaces ###########
 #################################
 
 # Create namespaces
@@ -184,216 +154,6 @@ for namespace in namespaces:
   resource_deps = [
     'namespaces',
   ])
-
-##################################
-## Percona XtraDB Cluster (PXC) ##
-##################################
-
-# Helper function: check if all operator manifest files exist (used as sync guard before k8s_yaml)
-def db_operator_manifests_present(cache_dir, operator_name, version):
-    for manifest_type in ['crd', 'rbac', 'operator']:
-        filename = '{0}/{1}-operator-v{2}-{3}.yaml'.format(cache_dir, operator_name, version, manifest_type)
-        if not os.path.exists(filename):
-            print('Missing db operator manifest, will download: {0}'.format(filename))
-            return False
-    return True
-
-# Synchronous guard: download PXC manifests if missing, ensuring files exist before k8s_yaml() is called
-pxc_base_url = 'https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/v{0}/deploy'.format(pxc_operator_version)
-if not db_operator_manifests_present(cache_dir, 'pxc', pxc_operator_version):
-    local(
-        'for manifest in crd rbac operator; do curl -s {0}/$manifest.yaml -o {1}/pxc-operator-v{2}-$manifest.yaml; done'.format(pxc_base_url, cache_dir, pxc_operator_version),
-    )
-
-# Async local resource: redundant if sync guard ran, but provides cleanup and serves as task dependency
-local_resource(
-  'pxc-download-manifests',
-  'for manifest in crd rbac operator; do test -f {0}/pxc-operator-v{1}-$manifest.yaml || curl -s {2}/$manifest.yaml -o {0}/pxc-operator-v{1}-$manifest.yaml; done'.format(cache_dir, pxc_operator_version, pxc_base_url),
-  resource_deps=['namespaces'],
-  labels=["db-operators"]
-)
-
-# Identify namespaces that use PXC operator
-pxc_namespaces = [ns['name'] for ns in config_yaml['namespaces'] if 'pxc' in ns['operators']]
-
-# Deploy PXC CRDs (separately to avoid conflicts with multiple operator deployments)
-if pxc_namespaces:
-  pxc_crd_file = '{0}/pxc-operator-v{1}-crd.yaml'.format(cache_dir, pxc_operator_version)
-  pxc_crd_objects = [
-    'perconaxtradbclusterbackups.pxc.percona.com:customresourcedefinition',
-    'perconaxtradbclusterrestores.pxc.percona.com:customresourcedefinition',
-    'perconaxtradbclusters.pxc.percona.com:customresourcedefinition',
-  ]
-  
-  k8s_yaml(pxc_crd_file)
-  k8s_resource(
-    objects=pxc_crd_objects,
-    new_name='pxc-crds',
-    resource_deps=[
-      'pxc-download-manifests',
-    ],
-    labels=["db-operators"]
-  )
-
-# Deploy PXC operator to each namespace
-for namespace in pxc_namespaces:
-  rbac_file = '{0}/pxc-operator-v{1}-rbac.yaml'.format(cache_dir, pxc_operator_version)
-  operator_file = '{0}/pxc-operator-v{1}-operator.yaml'.format(cache_dir, pxc_operator_version)
-  
-  k8s_yaml(namespace_inject(rbac_file, namespace))
-  k8s_yaml(namespace_inject(operator_file, namespace))
-  
-  # Determine deployment name (include namespace suffix if multiple namespaces)
-  deployment_suffix = ':deployment:' + namespace if len(pxc_namespaces) > 1 else ''
-  
-  k8s_resource(
-    workload='percona-xtradb-cluster-operator{0}'.format(deployment_suffix),
-    objects=[
-      'percona-xtradb-cluster-operator:serviceaccount:{0}'.format(namespace),
-      'percona-xtradb-cluster-operator:role:{0}'.format(namespace),
-      'service-account-percona-xtradb-cluster-operator:rolebinding:{0}'.format(namespace),
-    ],
-    resource_deps=[
-      'namespaces',
-      'pxc-crds',
-    ],
-    new_name='pxc:{0}'.format(namespace),
-    labels=["db-operators"]
-  )
-
-#####################################
-### Percona Server MongoDB (PSMDB) ##
-#####################################
-#
-## Download PSMDB operator manifests
-#psmdb_base_url = 'https://raw.githubusercontent.com/percona/percona-server-mongodb-operator/v{0}/deploy'.format(psmdb_operator_version)
-#
-#local_resource(
-#  'psmdb-download-manifests',
-#  'for manifest in crd rbac operator; do test -f {0}/psmdb-operator-v{1}-$manifest.yaml || curl -s {2}/$manifest.yaml -o {0}/psmdb-operator-v{1}-$manifest.yaml; done'.format(cache_dir, psmdb_operator_version, psmdb_base_url),
-#  resource_deps=['namespaces'],
-#  labels=["db-operators"]
-#)
-#
-## Identify namespaces that use PSMDB operator
-#psmdb_namespaces = [ns['name'] for ns in config_yaml['namespaces'] if 'psmdb' in ns['operators']]
-#
-## Deploy PSMDB CRDs (separately to avoid conflicts with multiple operator deployments)
-#if psmdb_namespaces:
-#  psmdb_crd_file = '{0}/psmdb-operator-v{1}-crd.yaml'.format(cache_dir, psmdb_operator_version)
-#  psmdb_crd_objects = [
-#    'perconaservermongodbbackups.psmdb.percona.com:customresourcedefinition',
-#    'perconaservermongodbrestores.psmdb.percona.com:customresourcedefinition',
-#    'perconaservermongodbs.psmdb.percona.com:customresourcedefinition',
-#  ]
-#  
-#  k8s_yaml(psmdb_crd_file)
-#  k8s_resource(
-#    objects=psmdb_crd_objects,
-#    new_name='psmdb-crds',
-#    resource_deps=[
-#      'psmdb-download-manifests',
-#    ],
-#    labels=["db-operators"]
-#  )
-#
-## Deploy PSMDB operator to each namespace
-#for namespace in psmdb_namespaces:
-#  rbac_file = '{0}/psmdb-operator-v{1}-rbac.yaml'.format(cache_dir, psmdb_operator_version)
-#  operator_file = '{0}/psmdb-operator-v{1}-operator.yaml'.format(cache_dir, psmdb_operator_version)
-#  
-#  k8s_yaml(namespace_inject(rbac_file, namespace))
-#  k8s_yaml(namespace_inject(operator_file, namespace))
-#  
-#  # Determine deployment name (include namespace suffix if multiple namespaces)
-#  deployment_suffix = ':deployment:' + namespace if len(psmdb_namespaces) > 1 else ''
-#  
-#  k8s_resource(
-#    workload='percona-server-mongodb-operator{0}'.format(deployment_suffix),
-#    objects=[
-#      'percona-server-mongodb-operator:serviceaccount:{0}'.format(namespace),
-#      'percona-server-mongodb-operator:role:{0}'.format(namespace),
-#      'service-account-percona-server-mongodb-operator:rolebinding:{0}'.format(namespace),
-#    ],
-#    resource_deps=[
-#      'namespaces',
-#      'psmdb-crds',
-#    ],
-#    new_name='psmdb:{0}'.format(namespace),
-#    labels=["db-operators"]
-#  )
-
-#############################
-## Percona PostgreSQL (PG) ##
-#############################
-
-# Synchronous guard: download PG manifests if missing, ensuring files exist before k8s_yaml() is called
-pg_base_url = 'https://raw.githubusercontent.com/percona/percona-postgresql-operator/v{0}/deploy'.format(pg_operator_version)
-if not db_operator_manifests_present(cache_dir, 'pg', pg_operator_version):
-    local(
-        'for manifest in crd rbac operator; do curl -s {0}/$manifest.yaml -o {1}/pg-operator-v{2}-$manifest.yaml; done'.format(pg_base_url, cache_dir, pg_operator_version),
-    )
-
-# Async local resource: redundant if sync guard ran, but provides cleanup and serves as task dependency
-local_resource(
-  'pg-download-manifests',
-  'for manifest in crd rbac operator; do test -f {0}/pg-operator-v{1}-$manifest.yaml || curl -s {2}/$manifest.yaml -o {0}/pg-operator-v{1}-$manifest.yaml; done'.format(cache_dir, pg_operator_version, pg_base_url),
-  resource_deps=['namespaces'],
-  labels=["db-operators"]
-)
-
-# Identify namespaces that use PG operator
-pg_namespaces = [ns['name'] for ns in config_yaml['namespaces'] if 'pg' in ns['operators']]
-
-# Deploy PG CRDs (separately to avoid conflicts with multiple operator deployments)
-if pg_namespaces:
-  pg_crd_file = '{0}/pg-operator-v{1}-crd.yaml'.format(cache_dir, pg_operator_version)
-  pg_crd_objects = [
-    'perconapgbackups.pgv2.percona.com:customresourcedefinition',
-    'perconapgclusters.pgv2.percona.com:customresourcedefinition',
-    'perconapgrestores.pgv2.percona.com:customresourcedefinition',
-    'postgresclusters.postgres-operator.crunchydata.com:customresourcedefinition',
-    'crunchybridgeclusters.postgres-operator.crunchydata.com:customresourcedefinition',
-    'perconapgupgrades.pgv2.percona.com:customresourcedefinition',
-    'pgadmins.postgres-operator.crunchydata.com:customresourcedefinition',
-    'pgupgrades.postgres-operator.crunchydata.com:customresourcedefinition',
-  ]
-  
-  k8s_yaml(pg_crd_file)
-  k8s_resource(
-    objects=pg_crd_objects,
-    new_name='pg-crds',
-    resource_deps=[
-      'pg-download-manifests',
-    ],
-    labels=["db-operators"]
-  )
-
-# Deploy PG operator to each namespace
-for namespace in pg_namespaces:
-  rbac_file = '{0}/pg-operator-v{1}-rbac.yaml'.format(cache_dir, pg_operator_version)
-  operator_file = '{0}/pg-operator-v{1}-operator.yaml'.format(cache_dir, pg_operator_version)
-  
-  k8s_yaml(namespace_inject(rbac_file, namespace))
-  k8s_yaml(namespace_inject(operator_file, namespace))
-  
-  # Determine deployment name (include namespace suffix if multiple namespaces)
-  deployment_suffix = ':deployment:' + namespace if len(pg_namespaces) > 1 else ''
-  
-  k8s_resource(
-    workload='percona-postgresql-operator{0}'.format(deployment_suffix),
-    objects=[
-      'percona-postgresql-operator:serviceaccount:{0}'.format(namespace),
-      'percona-postgresql-operator:role:{0}'.format(namespace),
-      'percona-postgresql-operator:rolebinding:{0}'.format(namespace),
-    ],
-    resource_deps=[
-      'namespaces',
-      'pg-crds',
-    ],
-    new_name='pg:{0}'.format(namespace),
-    labels=["db-operators"]
-  )
 
 ################################
 ### Deploy Everest Helm chart ##
@@ -1070,209 +830,4 @@ k8s_resource(
   labels=["everest"]
 )
 
-#######################################
-### Deploy PSMDB Provider Helm chart ##
-#######################################
-
-# Synchronous guard: download PSMDB provider chart dependencies if missing
-if not helm_remote_deps_present(psmdb_provider_chart_dir):
-    local(
-        'cd {0} && helm dependency build'.format(psmdb_provider_chart_dir),
-    )
-
-# Named resource: ensures PSMDB provider dependencies are built before templating
-local_resource(
-    'provider-percona-server-mongodb-deps',
-    'cd {chart_dir} && helm dependency build'.format(
-        chart_dir=psmdb_provider_chart_dir,
-    ),
-    deps=[
-        '{0}/Chart.yaml'.format(psmdb_provider_chart_dir),
-    ],
-    labels=['providers'],
-)
-
-# Re-run make generate when the definition folder changes (updates provider-spec.yaml in the Helm chart)
-local_resource(
-  'provider-percona-server-mongodb-generate',
-  'make -C {0} generate'.format(psmdb_provider_dir),
-  deps=[
-    '{0}/definition'.format(psmdb_provider_dir),
-  ],
-  labels=['providers'],
-)
-
-# Build the PSMDB provider binary locally to take advantage of the go cache
-local_resource(
-  'provider-percona-server-mongodb-build',
-  'cd {provider_dir} && {build_env} go build -o bin/provider ./cmd/provider/'.format(
-    provider_dir=psmdb_provider_dir,
-    build_env=psmdb_provider_build_env,
-  ),
-  deps=[
-    '{0}/go.mod'.format(psmdb_provider_dir),
-    '{0}/go.sum'.format(psmdb_provider_dir),
-    '{0}/internal'.format(psmdb_provider_dir),
-    '{0}/cmd/provider'.format(psmdb_provider_dir),
-  ],
-  ignore=[
-    '{0}/**/*_test.go'.format(psmdb_provider_dir),
-  ],
-  resource_deps=['provider-percona-server-mongodb-generate'],
-  labels=['providers'],
-)
-
-# Live update the PSMDB provider without generating a new pod
-docker_build_with_restart('ghcr.io/openeverest/provider-percona-server-mongodb-dev',
-  context=psmdb_provider_dir,
-  dockerfile='./psmdb-provider.Dockerfile',
-  target='dev',
-  entrypoint=['/home/provider/provider'],
-  only=['{0}/bin/provider'.format(psmdb_provider_dir)],
-  live_update=[
-    sync('{0}/bin/provider'.format(psmdb_provider_dir), '/home/provider/provider'),
-  ]
-)
-
-psmdb_provider_yaml = helm(
-    psmdb_provider_chart_dir,
-    name='provider-percona-server-mongodb',
-    namespace='default',
-    set=['securityContext.readOnlyRootFilesystem=false'],
-)
-k8s_yaml(psmdb_provider_yaml)
-k8s_resource(
-  workload='provider-percona-server-mongodb',
-  objects=[
-    'provider-percona-server-mongodb:serviceaccount',
-    'provider-percona-server-mongodb:clusterrole',
-    'provider-percona-server-mongodb:clusterrolebinding',
-    'percona-server-mongodb:provider',
-    'percona-backup-mongodb:backupclass',
-  ],
-  resource_deps = [
-    'crds',
-    'provider-percona-server-mongodb-deps',
-    'provider-percona-server-mongodb-generate',
-    'provider-percona-server-mongodb-build',
-  ],
-  new_name='provider-percona-server-mongodb',
-  labels=["providers"]
-)
-k8s_resource(
-  workload='provider-percona-server-mongodb-operator',
-  objects=[
-    'perconaservermongodbbackups.psmdb.percona.com:customresourcedefinition:default',
-    'perconaservermongodbrestores.psmdb.percona.com:customresourcedefinition:default',
-    'perconaservermongodbs.psmdb.percona.com:customresourcedefinition:default',
-    'provider-percona-server-mongodb-operator:serviceaccount:default',
-    'provider-percona-server-mongodb-operator:clusterrole:default',
-    'service-account-provider-percona-server-mongodb-operator:clusterrolebinding:default'
-  ],
-  resource_deps = [
-    'crds',
-    'provider-percona-server-mongodb-deps',
-  ],
-  new_name='provider-percona-server-mongodb-operator',
-  labels=["providers"]
-)
-
-####################################
-### Deploy PXC Provider Helm chart ##
-####################################
-
-# Synchronous guard: download PXC provider chart dependencies if missing
-if not helm_remote_deps_present(pxc_provider_chart_dir):
-    local(
-        'cd {0} && helm dependency build'.format(pxc_provider_chart_dir),
-    )
-
-# Named resource: ensures PXC provider dependencies are built before templating
-local_resource(
-    'provider-percona-xtradb-cluster-deps',
-    'cd {chart_dir} && helm dependency build'.format(
-        chart_dir=pxc_provider_chart_dir,
-    ),
-    deps=[
-        '{0}/Chart.yaml'.format(pxc_provider_chart_dir),
-    ],
-    labels=['providers'],
-)
-
-# Re-run make generate when the definition folder changes (updates provider-spec.yaml in the Helm chart)
-local_resource(
-  'provider-percona-xtradb-cluster-generate',
-  'make -C {0} generate'.format(pxc_provider_dir),
-  deps=[
-    '{0}/definition'.format(pxc_provider_dir),
-  ],
-  labels=['providers'],
-)
-
-# Build the PXC provider binary locally to take advantage of the go cache
-local_resource(
-  'provider-percona-xtradb-cluster-build',
-  'cd {provider_dir} && {build_env} go build -o bin/provider ./cmd/provider/'.format(
-    provider_dir=pxc_provider_dir,
-    build_env=pxc_provider_build_env,
-  ),
-  deps=[
-    '{0}/go.mod'.format(pxc_provider_dir),
-    '{0}/go.sum'.format(pxc_provider_dir),
-    '{0}/internal'.format(pxc_provider_dir),
-    '{0}/cmd/provider'.format(pxc_provider_dir),
-  ],
-  ignore=[
-    '{0}/**/*_test.go'.format(pxc_provider_dir),
-  ],
-  resource_deps=['provider-percona-xtradb-cluster-generate'],
-  labels=['providers'],
-)
-
-# Live update the PXC provider without generating a new pod
-docker_build_with_restart('ghcr.io/openeverest/provider-percona-xtradb-cluster-dev',
-  context=pxc_provider_dir,
-  dockerfile='./pxc-provider.Dockerfile',
-  target='dev',
-  entrypoint=['/home/provider/provider'],
-  only=['{0}/bin/provider'.format(pxc_provider_dir)],
-  live_update=[
-    sync('{0}/bin/provider'.format(pxc_provider_dir), '/home/provider/provider'),
-  ]
-)
-
-pxc_provider_yaml = helm(
-    pxc_provider_chart_dir,
-    name='provider-percona-xtradb-cluster',
-    namespace='default',
-    skip_crds=True,
-    set=['securityContext.readOnlyRootFilesystem=false'],
-)
-k8s_yaml(pxc_provider_yaml)
-k8s_resource(
-  workload='provider-percona-xtradb-cluster',
-  objects=[
-    'provider-percona-xtradb-cluster:serviceaccount',
-    'provider-percona-xtradb-cluster:clusterrole',
-    'provider-percona-xtradb-cluster:clusterrolebinding',
-    'percona-xtradb-cluster:provider',
-  ],
-  resource_deps = [
-    'crds',
-    'provider-percona-xtradb-cluster-deps',
-    'provider-percona-xtradb-cluster-generate',
-    'provider-percona-xtradb-cluster-build',
-  ],
-  new_name='provider-percona-xtradb-cluster',
-  labels=["providers"]
-)
-k8s_resource(
-  workload='provider-percona-xtradb-cluster-operator',
-  resource_deps = [
-    'crds',
-    'provider-percona-xtradb-cluster-deps',
-  ],
-  new_name='provider-percona-xtradb-cluster-operator',
-  labels=["providers"]
-)
 

--- a/dev/config.yaml.example
+++ b/dev/config.yaml.example
@@ -7,18 +7,8 @@ namespaces:
     backupStorages:
       - bs-msp-1
       - bs-msp-2
-    # List of DB operators that will be deployed into DB namespace
-    operators:
-      - pxc
-      - psmdb
-      - pg
   - name: the-dark-side
     # List of BackupStorages that will be created automatically in this namespace
     backupStorages:
       - bs-tds-1
       - bs-tds-2
-    # List of DB operators that will be deployed into DB namespace
-    operators:
-      - pxc
-      - psmdb
-      - pg

--- a/dev/psmdb-provider.Dockerfile
+++ b/dev/psmdb-provider.Dockerfile
@@ -1,6 +1,0 @@
-FROM alpine AS dev
-WORKDIR /home/provider
-RUN chown 65534:65534 /home/provider
-COPY --chown=65534:65534 ./bin/provider ./provider
-USER 65534:65534
-ENTRYPOINT ["/home/provider/provider"]

--- a/dev/pxc-provider.Dockerfile
+++ b/dev/pxc-provider.Dockerfile
@@ -1,6 +1,0 @@
-FROM alpine AS dev
-WORKDIR /home/provider
-RUN chown 65534:65534 /home/provider
-COPY --chown=65534:65534 ./bin/provider ./provider
-USER 65534:65534
-ENTRYPOINT ["/home/provider/provider"]


### PR DESCRIPTION
## Why

The dev Tiltfile built and deployed everything — the core plus every database provider and their operators — in a single instance. As providers moved into their own repositories (each with its own Tilt setup), this coupling made the
core dev environment heavier than it needs to be and tied core iteration to provider chart locations.

Decoupling lets core developers run a lean environment, while provider developers iterate in their own repos against a released core. The two can still be combined when needed.

## What

- Removes provider and database-operator wiring from `dev/Tiltfile`:
  - the PSMDB/PXC provider build + deploy sections, and
  - the PXC/PG/PSMDB operator manifest download + deploy sections.
- Drops the now-unused environment variables and config  (`*_PROVIDER_CHART_DIR`, `*_PROVIDER_BUILD_ENV`, `*_OPERATOR_VERSION`,  per-namespace `operators`) from `dev/.env.example` and  `dev/config.yaml.example`.
- Deletes the unused provider Dockerfiles from `dev/`.
- Updates `dev/README.md` to describe the core-only focus and document how to run a provider against a core built from source (two Tilt instances on the  same cluster, with the provider started using `INSTALL_OPENEVEREST=false`).

The core environment (API server, controller, CRDs, UI, monitoring, MinIO, plugins) is unchanged.

## Result

`make dev-up` now brings up just the OpenEverest core. Providers are developed in their own repositories; they install a released core and deploy themselves, and can target a locally built core when integration testing is required.

## Related PRs
* https://github.com/openeverest/provider-percona-server-mongodb/pull/59
* https://github.com/openeverest/provider-percona-xtradb-cluster/pull/4
* https://github.com/openeverest/provider-sdk/pull/14