### PR TITLE
Fail CI on Go code not formatted

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -87,10 +87,6 @@ jobs:
       - name: Run linters
         run: |
           go tool golangci-lint run --new --out-format=line-number | env REVIEWDOG_GITHUB_API_TOKEN=${{ secrets.GITHUB_TOKEN }} go tool reviewdog -f=golangci-lint -reporter=github-pr-review -filter-mode=nofilter -fail-on-error=true
-      - name: Check that dev Helm chart is up-to-date
-        run: |
-          make update-dev-chart
-          git diff --exit-code
 
       - name: Check that there are no source code changes
         run: |
@@ -98,6 +94,11 @@ jobs:
           pushd tools && go mod tidy -v
           popd        && go mod tidy -v
           git status
+          git diff --exit-code
+
+      - name: Check that dev Helm chart is up-to-date
+        run: |
+          make update-dev-chart
           git diff --exit-code
 
       - name: Check the Makefile references dev version

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.0.2
 	github.com/oapi-codegen/runtime v1.4.0
-	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260630023621-cf015d47d728
+	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260630065905-57be60a0ccba
 	github.com/operator-framework/api v0.42.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20260429065444-70caa52c384a
 	github.com/rodaine/table v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -821,8 +821,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260630023621-cf015d47d728 h1:RJ4CtBZF5Wk1xvCZb1xeXEK5T8PYoWZ2f+9LfkMAYtA=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260630023621-cf015d47d728/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260630065905-57be60a0ccba h1:D7Ki0yiJHj4jh7ji7sIqIkrEN7ojhwE9MHRAKiDqtOg=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260630065905-57be60a0ccba/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
 github.com/operator-framework/api v0.42.0 h1:rkc5V3zW8RxZMjePAe12jdL7Co/hwsYo1pLnkkhuR7s=
 github.com/operator-framework/api v0.42.0/go.mod h1:bMEj+wl/8tGqcGNtxt38cLUYagu9chNsbYzb/5HQaUQ=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/pkg/cli/auth/logout.go
+++ b/pkg/cli/auth/logout.go
@@ -89,4 +89,3 @@ func (lo *Login) Logout(ctx context.Context, cfgPath string) error {
 
 	return cfg.Save(cfgPath)
 }
-

--- a/pkg/cli/instance/create.go
+++ b/pkg/cli/instance/create.go
@@ -434,4 +434,3 @@ func buildPayload(name, provider, version, topology string, specOverrides map[st
 		"spec":     specOverrides,
 	}
 }
-

--- a/pkg/cli/instance/create_test.go
+++ b/pkg/cli/instance/create_test.go
@@ -36,14 +36,15 @@ import (
 
 // ---- helpers ----------------------------------------------------------------
 
-func boolPtr(b bool) *bool   { return &b }
+func boolPtr(b bool) *bool    { return &b }
 func strPtr(s string) *string { return &s }
 
 // buildProvider builds a minimal Provider fixture for tests.
 func buildProvider(name string, versions []struct {
-	name     string
+	name      string
 	isDefault bool
-}, topologies map[string][]string) *client.Provider {
+}, topologies map[string][]string,
+) *client.Provider {
 	meta := map[string]any{"name": name}
 
 	var vers []struct {
@@ -74,7 +75,9 @@ func buildProvider(name string, versions []struct {
 			Optional *bool `json:"optional,omitempty"`
 		}{}
 		for _, c := range comps {
-			compMap[c] = struct{ Optional *bool `json:"optional,omitempty"` }{}
+			compMap[c] = struct {
+				Optional *bool `json:"optional,omitempty"`
+			}{}
 		}
 		topos[topo] = struct {
 			Components *map[string]struct {
@@ -168,8 +171,8 @@ func TestDefaultVersion_NoVersions(t *testing.T) {
 func TestFirstTopology_AlphabeticalOrder(t *testing.T) {
 	t.Parallel()
 	prov := buildProvider("psmdb", nil, map[string][]string{
-		"standalone":  {"engine"},
-		"replicaset":  {"engine", "proxy"},
+		"standalone": {"engine"},
+		"replicaset": {"engine", "proxy"},
 	})
 	assert.Equal(t, "replicaset", firstTopology(prov))
 }
@@ -372,7 +375,7 @@ func TestBuildPayload_EmptyVersionAndTopologyOmitted(t *testing.T) {
 func TestLoadValuesFile_Valid(t *testing.T) {
 	t.Parallel()
 	f := filepath.Join(t.TempDir(), "values.yaml")
-	require.NoError(t, os.WriteFile(f, []byte("components:\n  engine:\n    replicas: 3\n"), 0600))
+	require.NoError(t, os.WriteFile(f, []byte("components:\n  engine:\n    replicas: 3\n"), 0o600))
 	m, err := loadValuesFile(f)
 	require.NoError(t, err)
 	comps := m["components"].(map[string]any)
@@ -390,7 +393,7 @@ func TestLoadValuesFile_MissingFile(t *testing.T) {
 func TestLoadValuesFile_InvalidYAML(t *testing.T) {
 	t.Parallel()
 	f := filepath.Join(t.TempDir(), "bad.yaml")
-	require.NoError(t, os.WriteFile(f, []byte(":\t:bad"), 0600))
+	require.NoError(t, os.WriteFile(f, []byte(":\t:bad"), 0o600))
 	_, err := loadValuesFile(f)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot parse")
@@ -401,7 +404,7 @@ func TestLoadValuesFile_InvalidYAML(t *testing.T) {
 func TestBuildSpecOverrides_SetWinsOverFile(t *testing.T) {
 	t.Parallel()
 	f := filepath.Join(t.TempDir(), "values.yaml")
-	require.NoError(t, os.WriteFile(f, []byte("components:\n  engine:\n    replicas: 1\n"), 0600))
+	require.NoError(t, os.WriteFile(f, []byte("components:\n  engine:\n    replicas: 1\n"), 0o600))
 	m, err := buildSpecOverrides(f, []string{"components.engine.replicas=5"})
 	require.NoError(t, err)
 	comps := m["components"].(map[string]any)
@@ -412,7 +415,7 @@ func TestBuildSpecOverrides_SetWinsOverFile(t *testing.T) {
 func TestBuildSpecOverrides_FileOnly(t *testing.T) {
 	t.Parallel()
 	f := filepath.Join(t.TempDir(), "values.yaml")
-	require.NoError(t, os.WriteFile(f, []byte("backup:\n  enabled: true\n"), 0600))
+	require.NoError(t, os.WriteFile(f, []byte("backup:\n  enabled: true\n"), 0o600))
 	m, err := buildSpecOverrides(f, nil)
 	require.NoError(t, err)
 	backup := m["backup"].(map[string]any)

--- a/pkg/cli/instance/status_test.go
+++ b/pkg/cli/instance/status_test.go
@@ -54,19 +54,19 @@ func TestInstanceStatus_HappyPath(t *testing.T) {
 				Total *int32  `json:"total,omitempty"`
 			} `json:"components,omitempty"`
 			Conditions *[]struct {
-				LastTransitionTime    time.Time                          `json:"lastTransitionTime"`
-				Message               string                             `json:"message"`
-				ObservedGeneration    *int64                             `json:"observedGeneration,omitempty"`
-				Reason                string                             `json:"reason"`
-				Status                client.InstanceStatusConditionsStatus `json:"status"`
-				Type                  string                             `json:"type"`
+				LastTransitionTime time.Time                             `json:"lastTransitionTime"`
+				Message            string                                `json:"message"`
+				ObservedGeneration *int64                                `json:"observedGeneration,omitempty"`
+				Reason             string                                `json:"reason"`
+				Status             client.InstanceStatusConditionsStatus `json:"status"`
+				Type               string                                `json:"type"`
 			} `json:"conditions,omitempty"`
 			ConnectionSecretRef *struct {
 				Name *string `json:"name,omitempty"`
 			} `json:"connectionSecretRef,omitempty"`
-			Message *string                      `json:"message,omitempty"`
-			Phase   *client.InstanceStatusPhase  `json:"phase,omitempty"`
-			Version *string                      `json:"version,omitempty"`
+			Message *string                     `json:"message,omitempty"`
+			Phase   *client.InstanceStatusPhase `json:"phase,omitempty"`
+			Version *string                     `json:"version,omitempty"`
 		}{
 			Phase:   &phase,
 			Version: &version,
@@ -82,12 +82,12 @@ func TestInstanceStatus_HappyPath(t *testing.T) {
 				{Ready: &ready, Total: &total, State: &state},
 			},
 			Conditions: &[]struct {
-				LastTransitionTime    time.Time                          `json:"lastTransitionTime"`
-				Message               string                             `json:"message"`
-				ObservedGeneration    *int64                             `json:"observedGeneration,omitempty"`
-				Reason                string                             `json:"reason"`
-				Status                client.InstanceStatusConditionsStatus `json:"status"`
-				Type                  string                             `json:"type"`
+				LastTransitionTime time.Time                             `json:"lastTransitionTime"`
+				Message            string                                `json:"message"`
+				ObservedGeneration *int64                                `json:"observedGeneration,omitempty"`
+				Reason             string                                `json:"reason"`
+				Status             client.InstanceStatusConditionsStatus `json:"status"`
+				Type               string                                `json:"type"`
 			}{
 				{Type: "Available", Status: condStatus, Reason: "Ready", Message: "All replicas are ready"},
 			},
@@ -194,12 +194,12 @@ func TestInstanceStatus_JSONOutput(t *testing.T) {
 				Total *int32  `json:"total,omitempty"`
 			} `json:"components,omitempty"`
 			Conditions *[]struct {
-				LastTransitionTime    time.Time                             `json:"lastTransitionTime"`
-				Message               string                                `json:"message"`
-				ObservedGeneration    *int64                                `json:"observedGeneration,omitempty"`
-				Reason                string                                `json:"reason"`
-				Status                client.InstanceStatusConditionsStatus `json:"status"`
-				Type                  string                                `json:"type"`
+				LastTransitionTime time.Time                             `json:"lastTransitionTime"`
+				Message            string                                `json:"message"`
+				ObservedGeneration *int64                                `json:"observedGeneration,omitempty"`
+				Reason             string                                `json:"reason"`
+				Status             client.InstanceStatusConditionsStatus `json:"status"`
+				Type               string                                `json:"type"`
 			} `json:"conditions,omitempty"`
 			ConnectionSecretRef *struct {
 				Name *string `json:"name,omitempty"`


### PR DESCRIPTION
Let's prevent unformatted Go code getting merged by CI checking `make format` before `make update-dev-chart` 😉 

Also updates latest helm chart and fix unformatted code.