### PR TITLE
Plugins framework to inherit design

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -90,6 +90,13 @@ print('Using Everest debug: {0}'.format(everest_debug))
 everest_operator_debug = str2bool(os.getenv('EVEREST_OPERATOR_DEBUG', 'False'))
 print('Using Everest Operator debug: {0}'.format(everest_operator_debug))
 
+# Check whether to deploy the bundled plugin-hub sub-chart. Disabled by
+# default so local plugin-hub development can run against this core from a
+# separate Tilt instance (see openeverest/plugin-hub/dev/Tiltfile) without
+# a naming collision on the Deployment/Service.
+plugin_hub_enabled = str2bool(os.getenv('PLUGIN_HUB_ENABLED', 'False'))
+print('Using bundled plugin-hub: {0}'.format(plugin_hub_enabled))
+
 # Check whether we need to create backup storage
 need_backup_storage=False
 for namespace in config_yaml['namespaces']:
@@ -236,6 +243,7 @@ everest_yaml = helm(
         'monitoring.crds.plain=false',
         'monitoring.namespaceOverride={0}'.format(EVEREST_MONITORING_NAMESPACE),
         'server.initialAdminPassword={0}'.format(UI_ADMIN_PASSWORD),
+        'plugins.hub.enabled={0}'.format('true' if plugin_hub_enabled else 'false'),
     ],
 )
 # we don't need the catalog source

--- a/docs/process/generic-plugins-design.md
+++ b/docs/process/generic-plugins-design.md
@@ -377,6 +377,144 @@ At shell startup:
 4. Shell renders registered components at the declared extension points.
 ```
 
+### 7.1.1 Import-map contract
+
+Singleton sharing is implemented as a **native browser import map** injected
+into the host `index.html` at build time by the
+`plugin-runtime-import-map` Vite plugin. There is **no** JavaScript-level
+module loader, no SystemJS, and no runtime shim registry — the browser
+resolves bare specifiers against the map before any plugin bundle executes.
+
+**Fixed singleton set.** The following bare specifiers (and their commonly
+imported subpaths) are exposed by the host. Extending the set is a breaking
+change to the plugin runtime contract because it changes what plugin
+bundles may safely mark as `external`:
+
+- `react`, `react-dom`, `react-dom/client`
+- `react/jsx-runtime`, `react/jsx-dev-runtime`
+- `@mui/material`, `@mui/material/styles`, `@mui/icons-material`
+- `@mui/x-date-pickers`
+- `@emotion/react`, `@emotion/styled`, `@emotion/cache`
+- `react-router-dom`
+- `@openeverest/plugin-sdk`
+
+The list is frozen at the SDK version boundary; plugins built against SDK
+`X.Y` may rely on exactly these specifiers being singletons.
+
+**Native import maps do not support prefix matching.** Every consumed
+subpath must have its own entry in the map (`@mui/material` and
+`@mui/material/styles` are two distinct entries; a `@mui/material/*`
+pattern is not supported by browsers). Two consequences:
+
+- Icons: `@mui/icons-material/AddCircle` is *not* covered by mapping
+  `@mui/icons-material`. Plugins that want icons should either (a) import
+  from `@mui/icons-material` (barrel) and rely on tree-shaking in the
+  plugin's own bundle, or (b) inline SVG paths wrapped in `SvgIcon` from
+  the (singleton) `@mui/material`. Option (b) is preferred for small
+  icon counts because it avoids depending on barrel exports through the
+  import map.
+- Any future singleton with deep-import subpaths (e.g. a new MUI package)
+  must enumerate each subpath explicitly in the plugin config.
+
+**Shim files, not raw package re-exports.** Each singleton is fronted by a
+tiny shim entry under `ui/apps/everest/src/plugin-runtime/*.ts`. The shim
+imports the underlying package and re-exports its public surface. The
+import map points at the compiled shim, not at the vendored package
+chunk. This layer exists because:
+
+1. It gives the host a single place to widen or narrow the public API
+   without repackaging every dependency.
+2. It bridges the CJS→ESM boundary (see below).
+3. It gives Rollup a stable `facadeModuleId` per singleton so the host's
+   `transformIndexHtml` step can look up the emitted hashed filename and
+   write it into the import map.
+
+**CJS/ESM interop — do not `export *` from CJS packages.** `react`,
+`react-dom`, and their JSX runtimes are shipped as CommonJS. Rollup's
+CJS interop does not propagate named exports through `export *
+from 'react'` in a way plugin bundles can consume — the compiled output
+either omits the names entirely or produces synthetic wrappers that fail
+at runtime with *"The requested module 'react' does not provide an export
+named 'useCallback'"*. The correct pattern in each shim is:
+
+```ts
+// react.ts (host shim)
+import React from 'react';
+export default React;
+export const {
+  useCallback, useContext, useDebugValue, useDeferredValue, useEffect,
+  useId, useImperativeHandle, useInsertionEffect, useLayoutEffect,
+  useMemo, useReducer, useRef, useState, useSyncExternalStore,
+  useTransition,
+  Children, Component, Fragment, Profiler, PureComponent, StrictMode,
+  Suspense, cloneElement, createContext, createElement, createRef,
+  forwardRef, isValidElement, lazy, memo, startTransition, version,
+} = React;
+```
+
+The explicit destructuring produces real ESM named exports that Rollup
+can emit as an `export { ... }` clause in the compiled shim, which the
+plugin bundle can then import by name. The same pattern applies to
+`react-dom`, `react-dom/client`, `react/jsx-runtime`, and
+`react/jsx-dev-runtime`. ESM-native packages (`@mui/material`, `@emotion/*`,
+`react-router-dom`) can use `export *` safely, but the explicit pattern
+is still preferred for stability under future dependency upgrades.
+
+**Rollup `preserveEntrySignatures: 'strict'` is required.** The shims are
+declared as additional Rollup `input` entries alongside the host's own
+`index.html`. In app-mode builds Rollup defaults
+`preserveEntrySignatures` to `'exports-only'`, which tree-shakes any
+exported binding no other module in the graph imports. Because plugin
+bundles are external consumers loaded at runtime through the browser
+import map, Rollup cannot see the imports at build time and strips
+every export from the shim chunks — the compiled chunk contains the
+destructured `const` declarations but no `export { ... }` clause. The
+`plugin-runtime-import-map` plugin forces `preserveEntrySignatures:
+'strict'` on the build config so the declared exports survive verbatim.
+
+**Manifest lookup at HTML transform time.** During build, the plugin's
+`transformIndexHtml` (order `post`) walks `ctx.bundle`, matches each
+chunk's `facadeModuleId` against the shim absolute paths, and writes the
+resulting hashed filenames into the import map. During dev, Vite serves
+the `.ts` shim sources directly and the map points at
+`/src/plugin-runtime/<name>.ts`; Vite's `optimizeDeps` guarantees the
+underlying package is served from a single pre-bundled chunk that both
+host and plugin share.
+
+**CSP compatibility.** The import-map `<script>` tag is inline and
+therefore rejected by any strict `script-src` CSP unless it carries the
+per-request nonce. The plugin's `transformIndexHtml` step:
+
+1. Reads the nonce from a `<meta name="csp-nonce" content="...">` marker
+   in the HTML (which the host's CSP middleware substitutes at request
+   time via a `$NONCE` placeholder).
+2. Emits the import-map `<script>` with `nonce="{{.CSPNonce}}"` so the
+   middleware's response-time substitution attaches the correct value.
+
+Plugin bundles themselves are loaded via `import(bundleUrl)` which does
+not require a nonce (dynamic ESM imports are governed by
+`script-src-elem` for the initial fetch and by module semantics
+thereafter). The host's CSP must include the plugin-hub origin (or its
+in-cluster proxy origin) in `script-src`.
+
+**Plugin build configuration.** Plugins mark every host singleton as
+external so their bundle contains only their own code plus bare-specifier
+imports the browser resolves through the map. The recommended
+`rollupOptions.external` predicate matches by exact bare specifier or
+prefix (`pkg` or `pkg/...`):
+
+```ts
+// plugin's vite.config.ts
+external: (id) => HOST_SINGLETONS.some(
+  (pkg) => id === pkg || id.startsWith(pkg + '/')
+),
+```
+
+`HOST_SINGLETONS` must be kept in sync with the host's singleton list
+above. A mismatch either bloats the plugin bundle (host package
+duplicated) or produces a runtime `Failed to resolve module specifier`
+error (plugin imports something the host didn't map).
+
 ### 7.2 `@everest/plugin-sdk`
 
 New package at `ui/packages/plugin-sdk`. Public surface:
@@ -414,6 +552,8 @@ Plugin authors produce a single ESM file with:
 - Default export: `register(api: PluginApi): void`
 - No bundled copies of `react`, `@mui/material`, or `react-router` — import them
   from the SDK re-exports so the import map resolves to the host's singleton.
+- Every host singleton (see §7.1.1) marked `external` in the plugin's Rollup
+  config, matched by exact specifier or `startsWith(pkg + '/')` prefix.
 - Target: `esnext` modules, no dynamic `require()`.
 
 ### 7.4 UI/UX consistency requirements
@@ -446,8 +586,13 @@ core UI — plugins feel native, not bolted on.
 - **Layout patterns.** Use MUI layout primitives (`Box`, `Stack`, `Grid`,
   `Container`) for page structure. Follow the host's existing spacing rhythm
   (typically `theme.spacing(2)` / `theme.spacing(3)` between sections).
-- **Icons.** Use `@mui/icons-material` (provided by the host). For custom icons
-  not in the MUI set, use inline SVG wrapped in `SvgIcon`.
+- **Icons.** Prefer inline SVG paths wrapped in `SvgIcon` from `@mui/material`
+  (a host singleton). `@mui/icons-material` is present in the singleton set
+  as a barrel entry, but native browser import maps do not support prefix
+  matching, so deep imports like `@mui/icons-material/AddCircle` are **not**
+  resolved by the host and will 404 at runtime. If a plugin needs many icons,
+  it may bundle `@mui/icons-material` into its own chunk (accepting the size
+  cost) rather than relying on the singleton.
 
 **Prohibited:**
 

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -117,6 +117,8 @@ func (e *EverestServer) securityHeaders() echo.MiddlewareFunc {
 		Directives: map[string][]string{
 			cspbuilder.DefaultSrc: {CSPSelf},
 			cspbuilder.FontSrc:    {CSPSelf, "data:"},
+			cspbuilder.ImgSrc: {CSPSelf, "data:"},
+			cspbuilder.ScriptSrc: {CSPSelf, "$NONCE"},
 			cspbuilder.StyleSrc: {
 				CSPSelf,
 				// $NONCE will be replaced by the real nonce value

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -118,8 +118,8 @@ func (e *EverestServer) securityHeaders() echo.MiddlewareFunc {
 		Directives: map[string][]string{
 			cspbuilder.DefaultSrc: {CSPSelf},
 			cspbuilder.FontSrc:    {CSPSelf, "data:"},
-			cspbuilder.ImgSrc: {CSPSelf, "data:"},
-			cspbuilder.ScriptSrc: {CSPSelf, "$NONCE"},
+			cspbuilder.ImgSrc:     {CSPSelf, "data:"},
+			cspbuilder.ScriptSrc:  {CSPSelf, "$NONCE"},
 			cspbuilder.StyleSrc: {
 				CSPSelf,
 				// $NONCE will be replaced by the real nonce value

--- a/public/public.go
+++ b/public/public.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/public/public.go
+++ b/public/public.go
@@ -18,9 +18,13 @@ package public
 
 import "embed"
 
-// Static stores the latest version of the everest FE app
+// Static stores the latest version of the everest FE app.
+// The "all:" prefix is required so that files starting with "_" (e.g. Vite's
+// _commonjsHelpers-*.js chunk) or "." are included in the embed. Without it,
+// go/embed silently drops them and the server returns 404 for chunks
+// referenced by other bundles.
 //
-//go:embed dist/*
+//go:embed all:dist
 var Static embed.FS
 
 // Index stores the latest version of the everest FE index.html

--- a/ui/apps/everest/src/contexts/plugins/plugins.context.tsx
+++ b/ui/apps/everest/src/contexts/plugins/plugins.context.tsx
@@ -111,6 +111,42 @@ async function loadPluginDescriptors(): Promise<PluginDescriptor[]> {
   }
 }
 
+// Verifies that a plugin bundle resolved the host-provided singletons through
+// the browser import map instead of bundling its own copies. A mismatch means
+// the plugin's bundler is not externalizing `@mui/material` (or React), which
+// would fork React context and break ThemeProvider inheritance, hooks, etc.
+async function assertSingletonsShared(pluginName: string): Promise<void> {
+  if (import.meta.env.PROD) return;
+  try {
+    const muiUrl = '/src/plugin-runtime/mui-material.ts';
+    const reactUrl = '/src/plugin-runtime/react.ts';
+    const [hostMui, hostReact, pluginMui, pluginReact] = await Promise.all([
+      import('@mui/material'),
+      import('react'),
+      import(/* @vite-ignore */ muiUrl),
+      import(/* @vite-ignore */ reactUrl),
+    ]);
+    if (hostMui.Button !== pluginMui.Button) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[plugins] "${pluginName}": @mui/material is not shared with the host. ` +
+          `Plugin components will not inherit the host theme. ` +
+          `Ensure the plugin's bundler externalizes @mui/material.`
+      );
+    }
+    if (hostReact.useState !== pluginReact.useState) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[plugins] "${pluginName}": react is not shared with the host. ` +
+          `Hooks will fail with "Invalid Hook Call" errors. ` +
+          `Ensure the plugin's bundler externalizes react and react-dom.`
+      );
+    }
+  } catch {
+    // Best-effort check; ignore in environments where dynamic imports are stubbed.
+  }
+}
+
 export const PluginProvider = ({ children }: { children: ReactNode }) => {
   const [plugins, setPlugins] = useState<PluginRegistration[]>([]);
   const [loading, setLoading] = useState(true);
@@ -132,6 +168,7 @@ export const PluginProvider = ({ children }: { children: ReactNode }) => {
           const mod = await import(/* @vite-ignore */ descriptor.bundleUrl);
           const registerFn: PluginRegisterFn = mod.default || mod.register;
           if (typeof registerFn === 'function') {
+            void assertSingletonsShared(descriptor.name);
             // Build the allowed extension types set from the CR's declared extensionPoints.
             const allowedTypes = descriptor.extensionPoints?.length
               ? new Set(descriptor.extensionPoints.map((ep) => ep.type))

--- a/ui/apps/everest/src/plugin-runtime/README.md
+++ b/ui/apps/everest/src/plugin-runtime/README.md
@@ -1,0 +1,20 @@
+# Plugin runtime shims
+
+Each file in this folder re-exports a package the host provides to plugin bundles
+as a **singleton** via a browser [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap).
+
+The `plugin-runtime-import-map` Vite plugin (`../../vite-plugins/plugin-runtime-import-map.ts`):
+
+- Adds each shim as an additional Rollup entry so it becomes a stable, hashed
+  chunk in the production build.
+- Injects a `<script type="importmap">` into `index.html` that maps bare
+  specifiers (`react`, `@mui/material`, `@emotion/react`, …) to the shim URLs.
+
+Because the shims re-export from the same package the host itself imports,
+Rollup deduplicates the underlying module. Both the host and any dynamically
+loaded plugin bundle end up sharing the same instance of React, MUI, Emotion,
+and react-router, which is what makes `<ThemeProvider>` context inheritance,
+custom variants, `styleOverrides`, and hooks work across the boundary.
+
+Deep sub-paths (e.g. `@mui/material/Button`) are intentionally **not** mapped —
+plugins should use named imports (`import { Button } from '@mui/material'`).

--- a/ui/apps/everest/src/plugin-runtime/emotion-cache.ts
+++ b/ui/apps/everest/src/plugin-runtime/emotion-cache.ts
@@ -1,2 +1,16 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from '@emotion/cache';
 export { default } from '@emotion/cache';

--- a/ui/apps/everest/src/plugin-runtime/emotion-cache.ts
+++ b/ui/apps/everest/src/plugin-runtime/emotion-cache.ts
@@ -1,0 +1,2 @@
+export * from '@emotion/cache';
+export { default } from '@emotion/cache';

--- a/ui/apps/everest/src/plugin-runtime/emotion-react.ts
+++ b/ui/apps/everest/src/plugin-runtime/emotion-react.ts
@@ -1,0 +1,1 @@
+export * from '@emotion/react';

--- a/ui/apps/everest/src/plugin-runtime/emotion-react.ts
+++ b/ui/apps/everest/src/plugin-runtime/emotion-react.ts
@@ -1,1 +1,15 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from '@emotion/react';

--- a/ui/apps/everest/src/plugin-runtime/emotion-styled.ts
+++ b/ui/apps/everest/src/plugin-runtime/emotion-styled.ts
@@ -1,0 +1,2 @@
+export * from '@emotion/styled';
+export { default } from '@emotion/styled';

--- a/ui/apps/everest/src/plugin-runtime/emotion-styled.ts
+++ b/ui/apps/everest/src/plugin-runtime/emotion-styled.ts
@@ -1,2 +1,16 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from '@emotion/styled';
 export { default } from '@emotion/styled';

--- a/ui/apps/everest/src/plugin-runtime/mui-icons-material.ts
+++ b/ui/apps/everest/src/plugin-runtime/mui-icons-material.ts
@@ -1,0 +1,1 @@
+export * from '@mui/icons-material';

--- a/ui/apps/everest/src/plugin-runtime/mui-icons-material.ts
+++ b/ui/apps/everest/src/plugin-runtime/mui-icons-material.ts
@@ -1,1 +1,15 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from '@mui/icons-material';

--- a/ui/apps/everest/src/plugin-runtime/mui-material-styles.ts
+++ b/ui/apps/everest/src/plugin-runtime/mui-material-styles.ts
@@ -1,0 +1,1 @@
+export * from '@mui/material/styles';

--- a/ui/apps/everest/src/plugin-runtime/mui-material-styles.ts
+++ b/ui/apps/everest/src/plugin-runtime/mui-material-styles.ts
@@ -1,1 +1,15 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from '@mui/material/styles';

--- a/ui/apps/everest/src/plugin-runtime/mui-material.ts
+++ b/ui/apps/everest/src/plugin-runtime/mui-material.ts
@@ -1,0 +1,1 @@
+export * from '@mui/material';

--- a/ui/apps/everest/src/plugin-runtime/mui-material.ts
+++ b/ui/apps/everest/src/plugin-runtime/mui-material.ts
@@ -1,1 +1,15 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from '@mui/material';

--- a/ui/apps/everest/src/plugin-runtime/mui-x-date-pickers.ts
+++ b/ui/apps/everest/src/plugin-runtime/mui-x-date-pickers.ts
@@ -1,0 +1,1 @@
+export * from '@mui/x-date-pickers';

--- a/ui/apps/everest/src/plugin-runtime/mui-x-date-pickers.ts
+++ b/ui/apps/everest/src/plugin-runtime/mui-x-date-pickers.ts
@@ -1,1 +1,15 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from '@mui/x-date-pickers';

--- a/ui/apps/everest/src/plugin-runtime/plugin-sdk.ts
+++ b/ui/apps/everest/src/plugin-runtime/plugin-sdk.ts
@@ -1,1 +1,15 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from '@openeverest/plugin-sdk';

--- a/ui/apps/everest/src/plugin-runtime/plugin-sdk.ts
+++ b/ui/apps/everest/src/plugin-runtime/plugin-sdk.ts
@@ -1,0 +1,1 @@
+export * from '@openeverest/plugin-sdk';

--- a/ui/apps/everest/src/plugin-runtime/react-dom-client.ts
+++ b/ui/apps/everest/src/plugin-runtime/react-dom-client.ts
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Import-map shim: exposes react-dom/client as ESM named exports.
 // See the comment in ./react.ts for why explicit destructuring is required.
 import * as ReactDOMClient from 'react-dom/client';

--- a/ui/apps/everest/src/plugin-runtime/react-dom-client.ts
+++ b/ui/apps/everest/src/plugin-runtime/react-dom-client.ts
@@ -1,0 +1,5 @@
+// Import-map shim: exposes react-dom/client as ESM named exports.
+// See the comment in ./react.ts for why explicit destructuring is required.
+import * as ReactDOMClient from 'react-dom/client';
+
+export const { createRoot, hydrateRoot } = ReactDOMClient;

--- a/ui/apps/everest/src/plugin-runtime/react-dom.ts
+++ b/ui/apps/everest/src/plugin-runtime/react-dom.ts
@@ -1,0 +1,18 @@
+// Import-map shim: exposes react-dom as ESM named exports.
+// See the comment in ./react.ts for why explicit destructuring is required
+// instead of `export * from 'react-dom'`.
+import ReactDOM from 'react-dom';
+
+// eslint-disable-next-line import/no-default-export
+export default ReactDOM;
+
+export const {
+  createPortal,
+  findDOMNode,
+  flushSync,
+  hydrate,
+  render,
+  unmountComponentAtNode,
+  unstable_batchedUpdates,
+  version,
+} = ReactDOM;

--- a/ui/apps/everest/src/plugin-runtime/react-dom.ts
+++ b/ui/apps/everest/src/plugin-runtime/react-dom.ts
@@ -1,9 +1,22 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Import-map shim: exposes react-dom as ESM named exports.
 // See the comment in ./react.ts for why explicit destructuring is required
 // instead of `export * from 'react-dom'`.
 import ReactDOM from 'react-dom';
 
-// eslint-disable-next-line import/no-default-export
 export default ReactDOM;
 
 export const {

--- a/ui/apps/everest/src/plugin-runtime/react-jsx-dev-runtime.ts
+++ b/ui/apps/everest/src/plugin-runtime/react-jsx-dev-runtime.ts
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Import-map shim: exposes react/jsx-dev-runtime as ESM named exports.
 // See the comment in ./react.ts for why explicit destructuring is required.
 import * as JSXDevRuntime from 'react/jsx-dev-runtime';

--- a/ui/apps/everest/src/plugin-runtime/react-jsx-dev-runtime.ts
+++ b/ui/apps/everest/src/plugin-runtime/react-jsx-dev-runtime.ts
@@ -1,0 +1,5 @@
+// Import-map shim: exposes react/jsx-dev-runtime as ESM named exports.
+// See the comment in ./react.ts for why explicit destructuring is required.
+import * as JSXDevRuntime from 'react/jsx-dev-runtime';
+
+export const { jsxDEV, Fragment } = JSXDevRuntime;

--- a/ui/apps/everest/src/plugin-runtime/react-jsx-runtime.ts
+++ b/ui/apps/everest/src/plugin-runtime/react-jsx-runtime.ts
@@ -1,0 +1,5 @@
+// Import-map shim: exposes react/jsx-runtime as ESM named exports.
+// See the comment in ./react.ts for why explicit destructuring is required.
+import * as JSXRuntime from 'react/jsx-runtime';
+
+export const { jsx, jsxs, Fragment } = JSXRuntime;

--- a/ui/apps/everest/src/plugin-runtime/react-jsx-runtime.ts
+++ b/ui/apps/everest/src/plugin-runtime/react-jsx-runtime.ts
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Import-map shim: exposes react/jsx-runtime as ESM named exports.
 // See the comment in ./react.ts for why explicit destructuring is required.
 import * as JSXRuntime from 'react/jsx-runtime';

--- a/ui/apps/everest/src/plugin-runtime/react-router-dom.ts
+++ b/ui/apps/everest/src/plugin-runtime/react-router-dom.ts
@@ -1,0 +1,1 @@
+export * from 'react-router-dom';

--- a/ui/apps/everest/src/plugin-runtime/react-router-dom.ts
+++ b/ui/apps/everest/src/plugin-runtime/react-router-dom.ts
@@ -1,1 +1,15 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from 'react-router-dom';

--- a/ui/apps/everest/src/plugin-runtime/react.ts
+++ b/ui/apps/everest/src/plugin-runtime/react.ts
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Import-map shim: exposes React as ESM named exports to plugin bundles.
 //
 // `react` is a CommonJS module. Rollup wraps it, but `export * from 'react'`
@@ -12,7 +26,6 @@
 // rebuild the host. Keep this list in sync with React 18's public API.
 import React from 'react';
 
-// eslint-disable-next-line import/no-default-export
 export default React;
 
 // Hooks

--- a/ui/apps/everest/src/plugin-runtime/react.ts
+++ b/ui/apps/everest/src/plugin-runtime/react.ts
@@ -1,0 +1,56 @@
+// Import-map shim: exposes React as ESM named exports to plugin bundles.
+//
+// `react` is a CommonJS module. Rollup wraps it, but `export * from 'react'`
+// does not propagate the named exports across the CJS boundary — the emitted
+// chunk ends up with only synthetic wrappers, so plugin bundles that do
+// `import { useCallback } from 'react'` fail with
+// "does not provide an export named 'useCallback'". Destructuring the default
+// namespace at module top-level produces real ESM named exports Rollup can
+// see, at the cost of listing React's public API here explicitly.
+//
+// If a plugin needs a React export that isn't listed below, add it here and
+// rebuild the host. Keep this list in sync with React 18's public API.
+import React from 'react';
+
+// eslint-disable-next-line import/no-default-export
+export default React;
+
+// Hooks
+export const {
+  useCallback,
+  useContext,
+  useDebugValue,
+  useDeferredValue,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useInsertionEffect,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  useTransition,
+} = React;
+
+// Top-level API + component primitives
+export const {
+  Children,
+  Component,
+  Fragment,
+  Profiler,
+  PureComponent,
+  StrictMode,
+  Suspense,
+  cloneElement,
+  createContext,
+  createElement,
+  createRef,
+  forwardRef,
+  isValidElement,
+  lazy,
+  memo,
+  startTransition,
+  version,
+} = React;

--- a/ui/apps/everest/tsconfig.json
+++ b/ui/apps/everest/tsconfig.json
@@ -29,5 +29,6 @@
       "@generated/api-types": ["../../../api/index.ts"]
     }
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "exclude": ["./src/plugin-runtime"]
 }

--- a/ui/apps/everest/vite-plugins/plugin-runtime-import-map.ts
+++ b/ui/apps/everest/vite-plugins/plugin-runtime-import-map.ts
@@ -55,9 +55,7 @@ export function pluginRuntimeImportMap(): Plugin {
         typeof existingInput === 'string'
           ? { main: existingInput }
           : Array.isArray(existingInput)
-            ? Object.fromEntries(
-                existingInput.map((f, i) => [`entry-${i}`, f])
-              )
+            ? Object.fromEntries(existingInput.map((f, i) => [`entry-${i}`, f]))
             : ((existingInput as Record<string, string> | undefined) ?? {
                 main: path.resolve(process.cwd(), 'index.html'),
               });

--- a/ui/apps/everest/vite-plugins/plugin-runtime-import-map.ts
+++ b/ui/apps/everest/vite-plugins/plugin-runtime-import-map.ts
@@ -1,0 +1,145 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import type { Plugin, ResolvedConfig } from 'vite';
+
+// Bare specifier → shim file basename (relative to src/plugin-runtime/, no extension).
+// The set is intentionally frozen: adding a new singleton is a breaking change
+// to the plugin runtime contract because plugin bundles are built against it.
+const SPECIFIERS: ReadonlyArray<readonly [string, string]> = [
+  ['react', 'react'],
+  ['react-dom', 'react-dom'],
+  ['react-dom/client', 'react-dom-client'],
+  ['react/jsx-runtime', 'react-jsx-runtime'],
+  ['react/jsx-dev-runtime', 'react-jsx-dev-runtime'],
+  ['@mui/material', 'mui-material'],
+  ['@mui/material/styles', 'mui-material-styles'],
+  ['@mui/icons-material', 'mui-icons-material'],
+  ['@mui/x-date-pickers', 'mui-x-date-pickers'],
+  ['@emotion/react', 'emotion-react'],
+  ['@emotion/styled', 'emotion-styled'],
+  ['@emotion/cache', 'emotion-cache'],
+  ['react-router-dom', 'react-router-dom'],
+  ['@openeverest/plugin-sdk', 'plugin-sdk'],
+];
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SHIM_DIR = path.resolve(__dirname, '../src/plugin-runtime');
+
+const shimAbs = (basename: string) => path.join(SHIM_DIR, `${basename}.ts`);
+const shimRelUrl = (basename: string) => `/src/plugin-runtime/${basename}.ts`;
+
+export function pluginRuntimeImportMap(): Plugin {
+  let resolvedConfig: ResolvedConfig;
+
+  return {
+    name: 'openeverest:plugin-runtime-import-map',
+
+    config(userCfg) {
+      const existingInput = userCfg.build?.rollupOptions?.input;
+      const baseInput: Record<string, string> =
+        typeof existingInput === 'string'
+          ? { main: existingInput }
+          : Array.isArray(existingInput)
+            ? Object.fromEntries(
+                existingInput.map((f, i) => [`entry-${i}`, f])
+              )
+            : ((existingInput as Record<string, string> | undefined) ?? {
+                main: path.resolve(process.cwd(), 'index.html'),
+              });
+
+      const shimInputs: Record<string, string> = {};
+      for (const [, basename] of SPECIFIERS) {
+        shimInputs[`plugin-runtime-${basename}`] = shimAbs(basename);
+      }
+
+      return {
+        build: {
+          manifest: true,
+          rollupOptions: {
+            input: { ...baseInput, ...shimInputs },
+            // In app-mode builds Rollup defaults to `'exports-only'`, which
+            // tree-shakes away any exported binding no other module in the
+            // graph imports. That kills the shims — plugin bundles are
+            // *external* consumers loaded at runtime through the browser
+            // import map, so Rollup can't see the imports at build time.
+            // `'strict'` preserves the declared exports verbatim.
+            preserveEntrySignatures: 'strict',
+          },
+        },
+      };
+    },
+
+    configResolved(c) {
+      resolvedConfig = c;
+    },
+
+    transformIndexHtml: {
+      order: 'post',
+      handler(html, ctx) {
+        const imports: Record<string, string> = {};
+
+        // Dev: Vite dev server serves .ts source files transformed on-the-fly.
+        // The shim files re-export from the underlying package, which Vite has
+        // already pre-bundled via optimizeDeps, so plugin and host share it.
+        if (ctx.server) {
+          for (const [spec, basename] of SPECIFIERS) {
+            imports[spec] = shimRelUrl(basename);
+          }
+        } else {
+          // Build: look up each shim's emitted chunk from the OutputBundle.
+          const bundle = ctx.bundle;
+          if (!bundle) return html;
+
+          const norm = (p: string) => path.resolve(p);
+          const targetById = new Map<string, string>();
+          for (const [spec, basename] of SPECIFIERS) {
+            targetById.set(norm(shimAbs(basename)), spec);
+          }
+
+          for (const chunk of Object.values(bundle)) {
+            if (chunk.type !== 'chunk') continue;
+            const facadeId = chunk.facadeModuleId;
+            if (!facadeId) continue;
+            const spec = targetById.get(norm(facadeId));
+            if (!spec) continue;
+            const base = resolvedConfig?.base ?? '/';
+            imports[spec] = `${base}${chunk.fileName}`;
+          }
+        }
+
+        const nonce = extractCspNonce(html);
+        const nonceAttr = nonce ? ` nonce="${nonce}"` : '';
+        const script =
+          `    <script type="importmap"${nonceAttr}>\n` +
+          `${JSON.stringify({ imports }, null, 2)
+            .split('\n')
+            .map((line) => '      ' + line)
+            .join('\n')}\n` +
+          `    </script>`;
+        return html.replace('</head>', `${script}\n  </head>`);
+      },
+    },
+  };
+}
+
+function extractCspNonce(html: string): string | null {
+  const match = html.match(
+    /<meta\s+name=["']csp-nonce["']\s+content=["']([^"']*)["']/i
+  );
+  return match?.[1] ?? null;
+}

--- a/ui/apps/everest/vite.config.ts
+++ b/ui/apps/everest/vite.config.ts
@@ -16,10 +16,15 @@ import react from '@vitejs/plugin-react-swc';
 import * as path from 'path';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
+import { pluginRuntimeImportMap } from './vite-plugins/plugin-runtime-import-map';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [tsconfigPaths({ root: '.' }), react()],
+  plugins: [
+    tsconfigPaths({ root: '.' }),
+    react(),
+    pluginRuntimeImportMap(),
+  ],
   server: {
     watch: {
       ignored: path.resolve(__dirname, '.e2e/**/*.*'),

--- a/ui/apps/everest/vite.config.ts
+++ b/ui/apps/everest/vite.config.ts
@@ -20,11 +20,7 @@ import { pluginRuntimeImportMap } from './vite-plugins/plugin-runtime-import-map
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    tsconfigPaths({ root: '.' }),
-    react(),
-    pluginRuntimeImportMap(),
-  ],
+  plugins: [tsconfigPaths({ root: '.' }), react(), pluginRuntimeImportMap()],
   server: {
     watch: {
       ignored: path.resolve(__dirname, '.e2e/**/*.*'),

--- a/ui/packages/plugin-sdk/src/types.ts
+++ b/ui/packages/plugin-sdk/src/types.ts
@@ -236,8 +236,18 @@ export interface InstanceEditFormSectionProps {
 /** The API object provided to a plugin's register() function by the host. */
 export interface PluginApi {
   /**
-   * The host's React instance. Plugins MUST use this instead of importing
-   * their own React to avoid duplicate-React issues with hooks.
+   * The host's React instance.
+   *
+   * @deprecated Since v0.2. Plugins should use a native `import React from 'react'`
+   * (or named imports like `import { useEffect } from 'react'`). The host exposes
+   * `react`, `react-dom`, `@mui/material`, `@emotion/react`, `@emotion/styled`,
+   * `react-router-dom`, and `@openeverest/plugin-sdk` as singletons via a browser
+   * import map, so bare-specifier imports in a plugin bundle resolve to the same
+   * module instance the host itself uses. This keeps React context (theme,
+   * router, auth, etc.) shared across the boundary.
+   *
+   * This field remains for backwards compatibility with plugins built against
+   * v0.1 of the SDK and will be removed in v1.0.
    */
   React: typeof import("react");
 


### PR DESCRIPTION
Generic plugins are quite flexible. Users can use their own design schema. But if we want plugin to feel natural, the design should feel aligned with OpenEverest webui itself.

In this PR we expose various design artifacts that plugins can use. That way plugin developers do not need to re-invent  the weel and try to match the design.

We actually thought about bringing the design schema into each plugin itself, but it was cumbersome and made it really hard for plugin developers to get to the proper design match.  
At the same time we allow the flexibility for plugin developers to come up with their own design and styles. 

Signed-off-by: Sergey Pronin <sp@solanica.io>