### PR TITLE
everestctl: add --preset flag to instance create

### DIFF
--- a/commands/instance/create.go
+++ b/commands/instance/create.go
@@ -42,6 +42,13 @@ to override any Instance spec field using dot-notation paths rooted at the spec
 		Example: `  # Minimal: server defaults for all components
   everestctl instance create --name my-mongo --namespace everest --provider percona-server-mongodb
 
+  # Bootstrap from a preset (provider inferred; version/topology/components from preset)
+  everestctl instance create --name my-mongo --namespace everest --preset mongodb-production
+
+  # Preset as base, override a field on top
+  everestctl instance create --name my-mongo --namespace everest --preset mongodb-production \
+    --set components.engine.replicas=5
+
   # Override component fields via --set
   everestctl instance create --name my-mongo --namespace everest --provider percona-server-mongodb \
     --set components.engine.replicas=3 \
@@ -73,17 +80,17 @@ to override any Instance spec field using dot-notation paths rooted at the spec
 func init() {
 	createCmd.Flags().StringVar(&createOpts.Name, cli.FlagInstanceName, "", "Instance name (required)")
 	createCmd.Flags().StringVar(&createOpts.Namespace, cli.FlagInstanceNamespace, "", "Namespace to create the instance in (required)")
-	createCmd.Flags().StringVar(&createOpts.Provider, cli.FlagInstanceProvider, "", "Provider name, e.g. percona-server-mongodb, percona-xtradb-cluster (required)")
+	createCmd.Flags().StringVar(&createOpts.Provider, cli.FlagInstanceProvider, "", "Provider name, e.g. percona-server-mongodb (required unless --preset is given)")
+	createCmd.Flags().StringVar(&createOpts.Preset, cli.FlagInstancePreset, "", "InstancePreset name to bootstrap from; --provider is inferred from the preset when omitted")
 	createCmd.Flags().StringVar(&createOpts.Cluster, cli.FlagInstanceCluster, "main", "Cluster name")
-	createCmd.Flags().StringVar(&createOpts.Version, cli.FlagInstanceVersion, "", "Version bundle name (default: provider's default bundle)")
-	createCmd.Flags().StringVar(&createOpts.Topology, cli.FlagInstanceTopology, "", "Topology name (default: provider's first topology)")
+	createCmd.Flags().StringVar(&createOpts.Version, cli.FlagInstanceVersion, "", "Provider version bundle to use (default: taken from preset if --preset is given, otherwise provider's default)")
+	createCmd.Flags().StringVar(&createOpts.Topology, cli.FlagInstanceTopology, "", "Topology name; cannot be used with --preset (default: provider's first topology)")
 	createCmd.Flags().StringVar(&createOpts.Context, cli.FlagInstanceContext, "", "Context to use (default: current context)")
 	createCmd.Flags().StringVarP(&createOpts.ValuesFile, cli.FlagInstanceFile, "f", "", "Path to a YAML file with component overrides (--set takes precedence)")
 	createCmd.Flags().StringArrayVar(&createOpts.Set, cli.FlagInstanceSet, nil, "Set a spec field: --set components.engine.replicas=3 or --set backup.enabled=true (repeatable)")
 
 	_ = createCmd.MarkFlagRequired(cli.FlagInstanceName)
 	_ = createCmd.MarkFlagRequired(cli.FlagInstanceNamespace)
-	_ = createCmd.MarkFlagRequired(cli.FlagInstanceProvider)
 }
 
 func createPreRun(cmd *cobra.Command, _ []string) { //nolint:revive

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -104,6 +104,8 @@ const (
 	FlagInstanceVersion = "version"
 	// FlagInstanceTopology is the name of the topology flag.
 	FlagInstanceTopology = "topology"
+	// FlagInstancePreset is the name of the preset flag.
+	FlagInstancePreset = "preset"
 	// FlagInstanceSet is the name of the repeatable set flag for component overrides.
 	FlagInstanceSet = "set"
 	// FlagInstanceFile is the name of the values file flag for component overrides.

--- a/pkg/cli/instance/create.go
+++ b/pkg/cli/instance/create.go
@@ -43,12 +43,13 @@ type CreateOptions struct {
 	Name       string
 	Namespace  string
 	Provider   string
+	Preset     string // InstancePreset name; provider must match --provider
 	Cluster    string
 	Version    string
 	Topology   string
 	Context    string   // overrides the active context when set
-	ValuesFile string   // path to a YAML file with spec-level overrides (optional)
-	Set        []string // each entry: "specField.subfield=value" e.g. "components.engine.replicas=3" — takes precedence over ValuesFile
+	ValuesFile string   // path to a YAML values file with spec-level overrides (optional)
+	Set        []string // dot-notation overrides e.g. "components.engine.replicas=3"; takes precedence over ValuesFile
 }
 
 type InstanceCreator struct {
@@ -65,9 +66,32 @@ func NewInstanceCreator(cfg Config, l *zap.SugaredLogger) *InstanceCreator {
 }
 
 func (ic *InstanceCreator) Run(ctx context.Context, opts CreateOptions, cfgPath string) error {
+	if opts.Provider == "" && opts.Preset == "" {
+		return fmt.Errorf("--provider is required when --preset is not given")
+	}
+	if opts.Preset != "" && opts.Topology != "" {
+		return fmt.Errorf("--topology cannot be combined with --preset")
+	}
+
 	c, err := authcli.NewAPIClient(authcli.Config{Pretty: ic.config.Pretty}, ic.l.Desugar().Sugar(), cfgPath, opts.Context)
 	if err != nil {
 		return err
+	}
+
+	var (
+		presetSpecBase map[string]any
+		annotations    map[string]string
+	)
+	if opts.Preset != "" {
+		pr, err := ic.resolvePreset(ctx, c, opts.Preset, opts.Cluster, opts.Namespace)
+		if err != nil {
+			return err
+		}
+		if err := applyPresetDefaults(opts.Preset, &opts, pr); err != nil {
+			return err
+		}
+		presetSpecBase = pr.specMap
+		annotations = map[string]string{"openeverest.io/instance-preset": opts.Preset}
 	}
 
 	provResp, err := c.GetProviderWithResponse(ctx, opts.Cluster, opts.Provider)
@@ -103,12 +127,19 @@ func (ic *InstanceCreator) Run(ctx context.Context, opts CreateOptions, cfgPath 
 		}
 	}
 
+	// Merge order: preset < -f file < --set flags.
 	specOverrides, err := buildSpecOverrides(opts.ValuesFile, opts.Set)
 	if err != nil {
 		return err
 	}
+	if presetSpecBase != nil {
+		if specOverrides != nil {
+			deepMerge(presetSpecBase, specOverrides)
+		}
+		specOverrides = presetSpecBase
+	}
 
-	payload := buildPayload(opts.Name, opts.Provider, resolvedVersion, resolvedTopology, specOverrides)
+	payload := buildPayload(opts.Name, opts.Provider, resolvedVersion, resolvedTopology, specOverrides, annotations)
 
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -142,6 +173,82 @@ func (ic *InstanceCreator) Run(ctx context.Context, opts CreateOptions, cfgPath 
 	}
 
 	return nil
+}
+
+// applyPresetDefaults copies provider/version/topology from the preset into opts,
+// validating that an explicit --provider matches the preset's provider.
+func applyPresetDefaults(preset string, opts *CreateOptions, pr *presetResult) error {
+	if pr.provider != "" && opts.Provider != "" && pr.provider != opts.Provider {
+		return fmt.Errorf("--provider %q does not match preset %q provider %q", opts.Provider, preset, pr.provider)
+	}
+	if opts.Provider == "" {
+		if pr.provider == "" {
+			return fmt.Errorf("preset %q does not specify a provider; use --provider to set one", preset)
+		}
+		opts.Provider = pr.provider
+	}
+	if opts.Version == "" {
+		opts.Version = pr.version
+	}
+	if pr.topology != "" {
+		opts.Topology = pr.topology
+	}
+	return nil
+}
+
+type presetResult struct {
+	specMap  map[string]any
+	provider string
+	version  string
+	topology string
+}
+
+func (ic *InstanceCreator) resolvePreset(ctx context.Context, c *client.ClientWithResponses, preset, cluster, namespace string) (*presetResult, error) {
+	resp, err := c.ResolveInstancePresetWithResponse(
+		ctx,
+		cluster,
+		preset,
+		&client.ResolveInstancePresetParams{Namespace: namespace},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve preset %q: %w", preset, err)
+	}
+	if resp.StatusCode() == http.StatusNotFound {
+		return nil, fmt.Errorf("preset %q not found in cluster %q", preset, cluster)
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response resolving preset %q: %s", preset, resp.Status())
+	}
+
+	p := resp.JSON200
+	pr := &presetResult{}
+	if p.Spec.Provider != nil {
+		pr.provider = *p.Spec.Provider
+	}
+	if p.Spec.Version != nil {
+		pr.version = *p.Spec.Version
+	}
+	if p.Spec.Topology != nil && p.Spec.Topology.Type != nil {
+		pr.topology = *p.Spec.Topology.Type
+	}
+	specMap, err := presetSpecToMap(p)
+	if err != nil {
+		return nil, err
+	}
+	pr.specMap = specMap
+	return pr, nil
+}
+
+func presetSpecToMap(p *client.InstancePreset) (map[string]any, error) {
+	b, err := json.Marshal(p.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal preset spec: %w", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("failed to parse preset spec: %w", err)
+	}
+	return m, nil
 }
 
 func defaultVersion(prov *client.Provider) string {
@@ -264,7 +371,7 @@ func providerName(prov *client.Provider) string {
 	if prov.Metadata == nil {
 		return "<unknown>"
 	}
-	if name, ok := (*prov.Metadata)["name"]; ok {
+	if name, ok := (*prov.Metadata)[metadataKeyName]; ok {
 		if s, ok := name.(string); ok {
 			return s
 		}
@@ -393,8 +500,10 @@ func deepSet(m map[string]any, path []string, value any) error {
 	return deepSet(childMap, path[1:], value)
 }
 
+const metadataKeyName = "name"
+
 // buildPayload builds the Instance JSON payload; explicit flags win over --set/-f.
-func buildPayload(name, provider, version, topology string, specOverrides map[string]any) map[string]any {
+func buildPayload(name, provider, version, topology string, specOverrides map[string]any, annotations map[string]string) map[string]any {
 	if specOverrides == nil {
 		specOverrides = map[string]any{}
 	}
@@ -404,11 +513,21 @@ func buildPayload(name, provider, version, topology string, specOverrides map[st
 		specOverrides["version"] = version
 	}
 	if topology != "" {
-		specOverrides["topology"] = map[string]any{"type": topology}
+		// Merge type into existing topology object to preserve topology.config from preset.
+		if existing, ok := specOverrides["topology"].(map[string]any); ok {
+			existing["type"] = topology
+		} else {
+			specOverrides["topology"] = map[string]any{"type": topology}
+		}
+	}
+
+	metadata := map[string]any{metadataKeyName: name}
+	if len(annotations) > 0 {
+		metadata["annotations"] = annotations
 	}
 
 	return map[string]any{
-		"metadata": map[string]any{"name": name},
+		"metadata": metadata,
 		"spec":     specOverrides,
 	}
 }

--- a/pkg/cli/instance/create_test.go
+++ b/pkg/cli/instance/create_test.go
@@ -865,10 +865,14 @@ func TestRun_WithPreset_Payloads(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			var got []byte
+			var (
+				got     []byte
+				readErr error
+			)
 			srv := newRunServerWithPreset(t, okProviderHandler,
 				func(w http.ResponseWriter, r *http.Request) {
-					got, _ = io.ReadAll(r.Body)
+					got, readErr = io.ReadAll(r.Body)
+					assert.NoError(t, readErr)
 					w.WriteHeader(http.StatusCreated)
 				},
 				okPresetHandler,
@@ -890,10 +894,10 @@ func TestRun_WithPreset_Errors(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		desc            string
-		opts            CreateOptions
-		presetStatus    int
-		wantErrContains []string
+		desc         string
+		opts         CreateOptions
+		presetStatus int
+		wantErr      string
 	}{
 		{
 			desc: "provider mismatch",
@@ -904,8 +908,8 @@ func TestRun_WithPreset_Errors(t *testing.T) {
 				Cluster:   "main",
 				Preset:    "my-preset",
 			},
-			presetStatus:    http.StatusOK,
-			wantErrContains: []string{"postgresql", "psmdb"},
+			presetStatus: http.StatusOK,
+			wantErr:      `does not match preset`,
 		},
 		{
 			desc: "preset not found",
@@ -916,8 +920,8 @@ func TestRun_WithPreset_Errors(t *testing.T) {
 				Cluster:   "main",
 				Preset:    "missing-preset",
 			},
-			presetStatus:    http.StatusNotFound,
-			wantErrContains: []string{"missing-preset", "not found"},
+			presetStatus: http.StatusNotFound,
+			wantErr:      "missing-preset",
 		},
 		{
 			desc: "topology flag rejected with preset",
@@ -929,8 +933,8 @@ func TestRun_WithPreset_Errors(t *testing.T) {
 				Preset:    "my-preset",
 				Topology:  "replicaset",
 			},
-			presetStatus:    0,
-			wantErrContains: []string{"--topology cannot be combined with --preset"},
+			presetStatus: 0,
+			wantErr:      "--topology cannot be combined with --preset",
 		},
 		{
 			desc: "no provider and no preset",
@@ -939,8 +943,8 @@ func TestRun_WithPreset_Errors(t *testing.T) {
 				Namespace: "everest",
 				Cluster:   "main",
 			},
-			presetStatus:    0,
-			wantErrContains: []string{"--provider is required"},
+			presetStatus: 0,
+			wantErr:      "--provider is required",
 		},
 	}
 
@@ -964,11 +968,7 @@ func TestRun_WithPreset_Errors(t *testing.T) {
 			require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
 
 			ic := NewInstanceCreator(Config{}, zap.NewNop().Sugar())
-			err := ic.Run(context.Background(), tc.opts, cfgPath)
-			require.Error(t, err)
-			for _, s := range tc.wantErrContains {
-				assert.Contains(t, err.Error(), s)
-			}
+			require.ErrorContains(t, ic.Run(context.Background(), tc.opts, cfgPath), tc.wantErr)
 		})
 	}
 }
@@ -998,6 +998,5 @@ func TestRun_WithPreset_ResolvePassesNamespace(t *testing.T) {
 		Preset:    "my-preset",
 	}, cfgPath))
 
-	assert.Contains(t, capturedURL, "namespace=prod")
-	assert.Contains(t, capturedURL, "resolve")
+	assert.Contains(t, capturedURL, "/v1/clusters/main/instance-presets/my-preset/resolve?namespace=prod")
 }

--- a/pkg/cli/instance/create_test.go
+++ b/pkg/cli/instance/create_test.go
@@ -18,6 +18,7 @@ package instance
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -341,7 +342,7 @@ func TestDeepMerge_NewKey(t *testing.T) {
 
 func TestBuildPayload_BasicFields(t *testing.T) {
 	t.Parallel()
-	p := buildPayload("my-db", "psmdb", "8.0", "replicaset", nil)
+	p := buildPayload("my-db", "psmdb", "8.0", "replicaset", nil, nil)
 	spec := p["spec"].(map[string]any)
 	assert.Equal(t, "psmdb", spec["provider"])
 	assert.Equal(t, "8.0", spec["version"])
@@ -354,7 +355,7 @@ func TestBuildPayload_BasicFields(t *testing.T) {
 func TestBuildPayload_ExplicitFlagsWinOverOverrides(t *testing.T) {
 	t.Parallel()
 	overrides := map[string]any{"provider": "wrong", "version": "wrong"}
-	p := buildPayload("db", "psmdb", "8.0", "standalone", overrides)
+	p := buildPayload("db", "psmdb", "8.0", "standalone", overrides, nil)
 	spec := p["spec"].(map[string]any)
 	assert.Equal(t, "psmdb", spec["provider"])
 	assert.Equal(t, "8.0", spec["version"])
@@ -362,7 +363,7 @@ func TestBuildPayload_ExplicitFlagsWinOverOverrides(t *testing.T) {
 
 func TestBuildPayload_EmptyVersionAndTopologyOmitted(t *testing.T) {
 	t.Parallel()
-	p := buildPayload("db", "psmdb", "", "", nil)
+	p := buildPayload("db", "psmdb", "", "", nil, nil)
 	spec := p["spec"].(map[string]any)
 	_, hasVersion := spec["version"]
 	_, hasTopology := spec["topology"]
@@ -687,4 +688,316 @@ func TestRun_UnknownContext(t *testing.T) {
 	}, cfgPath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+// ---- preset Run tests -------------------------------------------------------
+
+// newRunServerWithPreset extends newRunServer to also serve the preset resolve
+// endpoint at /v1/clusters/main/instance-presets/{name}/resolve.
+func newRunServerWithPreset(t *testing.T, providerHandler, createHandler, presetHandler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/providers/psmdb", providerHandler)
+	mux.HandleFunc("/v1/clusters/main/namespaces/", createHandler)
+	mux.HandleFunc("/v1/clusters/main/instance-presets/", presetHandler)
+	return httptest.NewServer(mux)
+}
+
+// presetJSON returns a minimal InstancePreset JSON fixture for provider "psmdb"
+// with version "8.0" and topology "replicaset" (matching psmdbProvider).
+func presetJSON() []byte {
+	return []byte(`{
+		"spec": {
+			"provider": "psmdb",
+			"version": "8.0",
+			"topology": {"type": "replicaset"},
+			"components": {"engine": {"replicas": 3}}
+		}
+	}`)
+}
+
+func okPresetHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(presetJSON())
+}
+
+func okProviderHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(psmdbProvider()); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// TestRun_WithPreset_Payloads checks the full JSON payload submitted to the
+// create endpoint for various preset + override combinations.
+func TestRun_WithPreset_Payloads(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc        string
+		opts        CreateOptions
+		wantPayload string
+	}{
+		{
+			desc: "happy path: annotation stamped, version and topology from preset",
+			opts: CreateOptions{
+				Name:      "my-db",
+				Namespace: "everest",
+				Provider:  "psmdb",
+				Cluster:   "main",
+				Preset:    "my-preset",
+			},
+			wantPayload: `{
+   "metadata":{
+      "name":"my-db",
+      "annotations":{
+         "openeverest.io/instance-preset":"my-preset"
+      }
+   },
+   "spec":{
+      "provider":"psmdb",
+      "version":"8.0",
+      "topology":{
+         "type":"replicaset"
+      },
+      "components":{
+         "engine":{
+            "replicas":3
+         }
+      }
+   }
+}`,
+		},
+		{
+			desc: "set overrides preset; annotation still stamped",
+			opts: CreateOptions{
+				Name:      "my-db",
+				Namespace: "everest",
+				Provider:  "psmdb",
+				Cluster:   "main",
+				Preset:    "my-preset",
+				Set:       []string{"components.engine.replicas=5"},
+			},
+			wantPayload: `{
+   "metadata": {
+      "name": "my-db",
+      "annotations": {
+         "openeverest.io/instance-preset": "my-preset"
+      }
+   },
+   "spec": {
+      "provider": "psmdb",
+      "version": "8.0",
+      "topology": {
+         "type": "replicaset"
+      },
+      "components": {
+         "engine": {
+            "replicas": 5
+         }
+      }
+   }
+}`,
+		},
+		{
+			desc: "explicit version overrides preset version",
+			opts: CreateOptions{
+				Name:      "my-db",
+				Namespace: "everest",
+				Provider:  "psmdb",
+				Cluster:   "main",
+				Preset:    "my-preset",
+				Version:   "7.0",
+			},
+			wantPayload: `{
+   "metadata": {
+      "name": "my-db",
+      "annotations": {
+         "openeverest.io/instance-preset": "my-preset"
+      }
+   },
+   "spec": {
+      "provider": "psmdb",
+      "version": "7.0",
+      "topology": {
+         "type": "replicaset"
+      },
+      "components": {
+         "engine": {
+            "replicas": 3
+         }
+      }
+   }
+}`,
+		},
+		{
+			desc: "provider derived from preset when omitted",
+			opts: CreateOptions{
+				Name:      "my-db",
+				Namespace: "everest",
+				Cluster:   "main",
+				Preset:    "my-preset",
+			},
+			wantPayload: `{
+   "metadata": {
+      "name": "my-db",
+      "annotations": {
+         "openeverest.io/instance-preset": "my-preset"
+      }
+   },
+   "spec": {
+      "provider": "psmdb",
+      "version": "8.0",
+      "topology": {
+         "type": "replicaset"
+      },
+      "components": {
+         "engine": {
+            "replicas": 3
+         }
+      }
+   }
+}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var got []byte
+			srv := newRunServerWithPreset(t, okProviderHandler,
+				func(w http.ResponseWriter, r *http.Request) {
+					got, _ = io.ReadAll(r.Body)
+					w.WriteHeader(http.StatusCreated)
+				},
+				okPresetHandler,
+			)
+			defer srv.Close()
+
+			cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+			require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+			ic := NewInstanceCreator(Config{}, zap.NewNop().Sugar())
+			require.NoError(t, ic.Run(context.Background(), tc.opts, cfgPath))
+			assert.JSONEq(t, tc.wantPayload, string(got))
+		})
+	}
+}
+
+// TestRun_WithPreset_Errors checks that invalid preset usage returns the right errors.
+func TestRun_WithPreset_Errors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc            string
+		opts            CreateOptions
+		presetStatus    int
+		wantErrContains []string
+	}{
+		{
+			desc: "provider mismatch",
+			opts: CreateOptions{
+				Name:      "my-db",
+				Namespace: "everest",
+				Provider:  "postgresql",
+				Cluster:   "main",
+				Preset:    "my-preset",
+			},
+			presetStatus:    http.StatusOK,
+			wantErrContains: []string{"postgresql", "psmdb"},
+		},
+		{
+			desc: "preset not found",
+			opts: CreateOptions{
+				Name:      "my-db",
+				Namespace: "everest",
+				Provider:  "psmdb",
+				Cluster:   "main",
+				Preset:    "missing-preset",
+			},
+			presetStatus:    http.StatusNotFound,
+			wantErrContains: []string{"missing-preset", "not found"},
+		},
+		{
+			desc: "topology flag rejected with preset",
+			opts: CreateOptions{
+				Name:      "my-db",
+				Namespace: "everest",
+				Provider:  "psmdb",
+				Cluster:   "main",
+				Preset:    "my-preset",
+				Topology:  "replicaset",
+			},
+			presetStatus:    0,
+			wantErrContains: []string{"--topology cannot be combined with --preset"},
+		},
+		{
+			desc: "no provider and no preset",
+			opts: CreateOptions{
+				Name:      "my-db",
+				Namespace: "everest",
+				Cluster:   "main",
+			},
+			presetStatus:    0,
+			wantErrContains: []string{"--provider is required"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newRunServerWithPreset(t, okProviderHandler,
+				func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusCreated) },
+				func(w http.ResponseWriter, _ *http.Request) {
+					if tc.presetStatus != 0 && tc.presetStatus != http.StatusOK {
+						w.WriteHeader(tc.presetStatus)
+						return
+					}
+					okPresetHandler(w, nil)
+				},
+			)
+			defer srv.Close()
+
+			cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+			require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+			ic := NewInstanceCreator(Config{}, zap.NewNop().Sugar())
+			err := ic.Run(context.Background(), tc.opts, cfgPath)
+			require.Error(t, err)
+			for _, s := range tc.wantErrContains {
+				assert.Contains(t, err.Error(), s)
+			}
+		})
+	}
+}
+
+func TestRun_WithPreset_ResolvePassesNamespace(t *testing.T) {
+	t.Parallel()
+
+	var capturedURL string
+	srv := newRunServerWithPreset(t, okProviderHandler,
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusCreated) },
+		func(w http.ResponseWriter, r *http.Request) {
+			capturedURL = r.URL.String()
+			okPresetHandler(w, r)
+		},
+	)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	ic := NewInstanceCreator(Config{}, zap.NewNop().Sugar())
+	require.NoError(t, ic.Run(context.Background(), CreateOptions{
+		Name:      "my-db",
+		Namespace: "prod",
+		Provider:  "psmdb",
+		Cluster:   "main",
+		Preset:    "my-preset",
+	}, cfgPath))
+
+	assert.Contains(t, capturedURL, "namespace=prod")
+	assert.Contains(t, capturedURL, "resolve")
 }


### PR DESCRIPTION
Adds support for bootstrapping a new instance from a named InstancePreset. When --preset is given, the CLI resolves the preset via the API (passing --namespace so the server can fill in namespace-scoped defaults such as secretRef), uses the resolved spec as the base, then layers -f file and --set overrides on top in that order.

- New --preset flag on `instance create`; --provider stays required and must match the preset's provider field
- Version and topology are inherited from the preset when not supplied explicitly via --version / --topology
- Instances created from a preset are annotated with openeverest.io/instance-preset so the origin is traceable
- topology.config from the preset is preserved when --topology overrides only the type
- Unit tests covering the happy path, version/topology inheritance, --set override priority, provider mismatch, 404 not-found, namespace query param forwarding, and explicit-flag precedence 
- closes #2505 