### PR TITLE
fix: ignore stale RBAC permission check results

### DIFF
--- a/ui/apps/everest/src/hooks/rbac/rbac.ts
+++ b/ui/apps/everest/src/hooks/rbac/rbac.ts
@@ -94,7 +94,11 @@ export const useNamespacePermissionsForResource = (
   const queryResult = useNamespaces();
   const { data: namespaces } = queryResult;
 
+  const latestRequestIdRef = useRef(0);
+
   const checkPermissions = useCallback(async () => {
+    const requestId = ++latestRequestIdRef.current;
+
     const newPermissions: Record<RBACAction, string[]> = {
       read: [],
       update: [],
@@ -121,6 +125,10 @@ export const useNamespacePermissionsForResource = (
       }
     }
     await Promise.all(permissionsPromisesArr);
+
+    if (requestId !== latestRequestIdRef.current) {
+      return;
+    }
     setPermissions(newPermissions);
   }, [namespaces, resource, specificResource]);
 

--- a/ui/apps/everest/src/hooks/rbac/rbac.ts
+++ b/ui/apps/everest/src/hooks/rbac/rbac.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { useNamespaces } from 'hooks/api/namespaces';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   can,
@@ -34,7 +34,10 @@ export const useRBACPermissions = (
     delete: false,
   });
 
+  const latestRequestIdRef = useRef(0);
+
   const checkPermissions = useCallback(async () => {
+    const requestId = ++latestRequestIdRef.current;
     const multipleSpecificResources = Array.isArray(specificResources);
     const canRead = await (multipleSpecificResources
       ? canAll('read', resource, specificResources)
@@ -48,6 +51,11 @@ export const useRBACPermissions = (
     const canCreate = await (multipleSpecificResources
       ? canAll('create', resource, specificResources)
       : can('create', resource, specificResources));
+
+    // Discard results from a stale invocation that resolved after a newer one.
+    if (requestId !== latestRequestIdRef.current) {
+      return;
+    }
 
     setPermissions({
       read: canRead,


### PR DESCRIPTION
## SUMMARY

This PR prevents stale permission checks from overwriting newer RBAC state when multiple permission requests are in flight. It updates `useRBACPermissions` to ignore outdated async results, ensuring the UI always reflects the most recent permission evaluation.

Primarily affected module:

* `ui/apps/everest/src/hooks/rbac/rbac.ts`

## FIX

```ts
// Before
const canRead = await can(...);
setPermissions({ read: canRead, ... });

// After
const requestId = ++latestRequestIdRef.current;
const canRead = await can(...);

if (requestId !== latestRequestIdRef.current) return;

setPermissions({ read: canRead, ... });
```

