### PR TITLE
fix: add panic recovery middleware to echo server

### DIFF
--- a/internal/server/everest.go
+++ b/internal/server/everest.go
@@ -213,6 +213,7 @@ func (e *EverestServer) initHTTPServer(ctx context.Context) error {
 	e.echo.GET("/static/*", echo.WrapHandler(staticFilesHandler), e.securityHeaders())
 
 	// Middlewares
+	e.echo.Use(echomiddleware.Recover())
 	e.echo.Use(e.requestLoggerMiddleware())
 	e.echo.Pre(echomiddleware.RemoveTrailingSlash())
 


### PR DESCRIPTION
### Description
This PR addresses Issue #2544

The OpenEverest API server relies on the Echo framework, but it was missing the `echomiddleware.Recover()` middleware in its handler chain (`internal/server/everest.go`).

While Go's standard `net/http` server does have a built-in panic recovery mechanism that prevents panics from crashing the process, it only aborts the active connection — the client receives a connection reset with **no HTTP response**, and **no error is logged** to the server logs. This makes panics in handlers effectively silent failures that are difficult to diagnose.

This PR adds the standard `Recover()` middleware to the top of the Echo middleware chain so that unhandled panics are:
- Caught at the Echo layer **before** `net/http`'s blunt recovery kicks in
- Converted into proper **HTTP 500 Internal Server Error** responses to the client
- **Logged with a full stack trace** for debugging

The server process was not at risk of crashing, but without this middleware, panicking requests were silently dropped with no observability.

### Changes Made
- Added `e.echo.Use(echomiddleware.Recover())` to `initHTTPServer` in `internal/server/everest.go`.

### Testing
- [x] Tested locally via `make test` / `go test`.
- [x] Verified middleware chain order.

### Related Issues
Fixes #2544