### PR TITLE
Add provider list subcommand to Everestctl

### DIFF
--- a/commands/provider.go
+++ b/commands/provider.go
@@ -1,0 +1,36 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package commands ...
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openeverest/openeverest/v2/commands/provider"
+)
+
+var providerCmd = &cobra.Command{
+	Use:     "provider <command> [flags]",
+	Aliases: []string{"prov"},
+	Short:   "Manage Everest providers",
+	Long:    "Manage Everest providers",
+	RunE:    func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+}
+
+func init() {
+	rootCmd.AddCommand(providerCmd)
+	providerCmd.AddCommand(provider.GetListCmd())
+}

--- a/commands/provider/list.go
+++ b/commands/provider/list.go
@@ -1,0 +1,85 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package provider holds commands for provider management.
+package provider
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+	providercli "github.com/openeverest/openeverest/v2/pkg/cli/provider"
+	"github.com/openeverest/openeverest/v2/pkg/logger"
+	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+var (
+	listCmd = &cobra.Command{
+		Use:     "list [flags]",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		Short:   "List providers",
+		Long: `List Provider resources via the Everest API.
+
+Displays a table with NAME and AGE. Details such as supported topologies,
+version catalog, and schemas remain available via --json / --verbose.`,
+		Example: `  # List installed providers
+  everestctl provider list
+
+  # Using aliases
+  everestctl prov ls
+
+  # JSON output — inspect the full version catalog
+  everestctl provider list --json | jq '.[].spec.versions'
+
+  # Specific cluster and context
+  everestctl provider list --cluster staging --context staging-ctx`,
+		PreRun: listPreRun,
+		Run:    listRun,
+	}
+	listCfg  = &providercli.Config{}
+	listOpts = &providercli.ListOptions{}
+)
+
+func init() {
+	listCmd.Flags().StringVar(&listOpts.Cluster, cli.FlagProviderCluster, "main", "Cluster name")
+	listCmd.Flags().StringVar(&listOpts.Context, cli.FlagProviderContext, "", "Context to use (default: current context)")
+}
+
+func listPreRun(cmd *cobra.Command, _ []string) {
+	listCfg.Pretty = !cmd.Flag(cli.FlagVerbose).Changed && !cmd.Flag(cli.FlagJSON).Changed
+}
+
+func listRun(cmd *cobra.Command, _ []string) {
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		output.PrintError(err, logger.GetLogger(), listCfg.Pretty)
+		os.Exit(1)
+	}
+
+	runner := providercli.NewListRunner(*listCfg, logger.GetLogger())
+	if err := runner.Run(cmd.Context(), *listOpts, cfgPath); err != nil {
+		output.PrintError(err, logger.GetLogger(), listCfg.Pretty)
+		os.Exit(1)
+	}
+}
+
+// GetListCmd returns the list command.
+func GetListCmd() *cobra.Command {
+	return listCmd
+}

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -115,6 +115,13 @@ const (
 	// FlagInstanceInterval sets the poll interval for --watch.
 	FlagInstanceInterval = "interval"
 
+	// `provider` flags.
+
+	// FlagProviderCluster is the name of the cluster flag.
+	FlagProviderCluster = "cluster"
+	// FlagProviderContext overrides the active context for this command.
+	FlagProviderContext = "context"
+
 	// settings flags.
 
 	// FlagOIDCIssuerURL is the name of the issuer-url flag.

--- a/pkg/cli/provider/list.go
+++ b/pkg/cli/provider/list.go
@@ -1,0 +1,150 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package provider provides CLI business logic for provider management.
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/rodaine/table"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/duration"
+
+	"github.com/openeverest/openeverest/v2/client"
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+)
+
+// Config holds the shared configuration for provider CLI runners.
+type Config struct {
+	Pretty bool
+}
+
+// ListOptions holds the inputs for the list command.
+type ListOptions struct {
+	Cluster string
+	Context string
+}
+
+// ListRunner lists providers via the Everest API.
+type ListRunner struct {
+	config Config
+	l      *zap.SugaredLogger
+}
+
+// NewListRunner creates a new ListRunner.
+func NewListRunner(cfg Config, l *zap.SugaredLogger) *ListRunner {
+	pl := &ListRunner{config: cfg, l: l.With("component", "provider-list")}
+	if cfg.Pretty {
+		pl.l = zap.NewNop().Sugar()
+	}
+	return pl
+}
+
+// Run fetches providers and prints them to stdout, either as a table (pretty mode)
+// or as raw JSON.
+func (pl *ListRunner) Run(ctx context.Context, opts ListOptions, cfgPath string) error {
+	c, err := authcli.NewAPIClient(authcli.Config{Pretty: pl.config.Pretty}, pl.l.Desugar().Sugar(), cfgPath, opts.Context)
+	if err != nil {
+		return err
+	}
+
+	providers, err := pl.listProviders(ctx, c, opts.Cluster)
+	if err != nil {
+		return err
+	}
+
+	sort.Slice(providers, func(i, j int) bool {
+		return providerName(&providers[i]) < providerName(&providers[j])
+	})
+
+	var buf bytes.Buffer
+	pl.render(&buf, providers)
+	fmt.Fprint(os.Stdout, buf.String())
+	return nil
+}
+
+func (pl *ListRunner) listProviders(ctx context.Context, c *client.ClientWithResponses, cluster string) ([]client.Provider, error) {
+	resp, err := c.ListProvidersWithResponse(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list providers: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response listing providers: %s", resp.Status())
+	}
+	if resp.JSON200.Items == nil {
+		return nil, nil
+	}
+	return *resp.JSON200.Items, nil
+}
+
+func (pl *ListRunner) render(w io.Writer, providers []client.Provider) {
+	if !pl.config.Pretty {
+		_ = json.NewEncoder(w).Encode(providers) //nolint:errchkjson
+		return
+	}
+	printProviderTable(w, providers)
+}
+
+func printProviderTable(w io.Writer, providers []client.Provider) {
+	tbl := table.New("NAME", "AGE").WithWriter(w)
+	for i := range providers {
+		prov := &providers[i]
+		tbl.AddRow(
+			providerName(prov),
+			providerAge(prov),
+		)
+	}
+	tbl.Print()
+}
+
+func providerName(prov *client.Provider) string {
+	return metadataStringField(prov, "name")
+}
+
+func providerAge(prov *client.Provider) string {
+	ts := metadataStringField(prov, "creationTimestamp")
+	if ts == "-" {
+		return "-"
+	}
+	created, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return "-"
+	}
+	return duration.ShortHumanDuration(time.Since(created))
+}
+
+func metadataStringField(prov *client.Provider, key string) string {
+	if prov.Metadata == nil {
+		return "-"
+	}
+	v, ok := (*prov.Metadata)[key]
+	if !ok {
+		return "-"
+	}
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return "-"
+	}
+	return s
+}

--- a/pkg/cli/provider/list_test.go
+++ b/pkg/cli/provider/list_test.go
@@ -1,0 +1,172 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+)
+
+// testProvider mirrors just the JSON shape the list runner reads off of
+// client.Provider, so tests can build fixtures without the generated type's
+// large anonymous Spec struct.
+type testProvider struct {
+	Metadata map[string]any `json:"metadata"`
+	Spec     struct{}       `json:"spec"`
+}
+
+func newTestProvider(name string) testProvider {
+	return testProvider{
+		Metadata: map[string]any{
+			"name":              name,
+			"creationTimestamp": time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
+}
+
+// newTestConfig returns a config with a single context pointing at serverURL.
+func newTestConfig(serverURL string) *config.Config {
+	host := serverURL[len("http://"):]
+	srvName := host
+	userName := "admin@" + srvName
+	return &config.Config{
+		APIVersion:     "config.openeverest.io/v1alpha1",
+		Kind:           "ClientConfig",
+		CurrentContext: userName,
+		Contexts: []config.NamedContext{
+			{Name: userName, Context: config.Context{Server: srvName, User: userName}},
+		},
+		Servers: []config.NamedServer{
+			{Name: srvName, Server: config.Server{URL: serverURL}},
+		},
+		Users: []config.NamedUser{
+			{Name: userName, User: config.User{
+				AccessToken:  "test-token",
+				RefreshToken: "rt-test",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}},
+		},
+	}
+}
+
+func TestProviderList_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	items := []testProvider{
+		newTestProvider("postgresql"),
+		newTestProvider("percona-server-mongodb"),
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main"}, cfgPath)
+	require.NoError(t, err)
+}
+
+func TestProviderList_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []testProvider{}})
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main"}, cfgPath)
+	require.NoError(t, err)
+}
+
+func TestProviderList_ServerError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main"}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected response")
+}
+
+func TestProviderList_NoActiveContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		APIVersion: "config.openeverest.io/v1alpha1",
+		Kind:       "ClientConfig",
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main"}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active context")
+}
+
+func TestProviderList_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	items := []testProvider{newTestProvider("postgresql")}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	// Pretty=false → JSON path
+	runner := NewListRunner(Config{Pretty: false}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main"}, cfgPath)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Lists Provider resources via the Everest API with NAME and AGE columns. READY is omitted since the Provider CR status is not yet populated by any controller. Supports --json/--verbose for raw output, --cluster/--context selection, the `provider`/`prov` command group, and the `list`/`ls` aliases, following instance list conventions.
Closes #2554 