### PR TITLE
Ctl everestctl backup class list

### DIFF
--- a/commands/backupclass.go
+++ b/commands/backupclass.go
@@ -1,0 +1,36 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package commands ...
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openeverest/openeverest/v2/commands/backupclass"
+)
+
+var backupClassCmd = &cobra.Command{
+	Use:     "backup-class <command> [flags]",
+	Aliases: []string{"backupclass", "bc"},
+	Short:   "Manage Everest backup classes",
+	Long:    "Manage Everest backup classes",
+	RunE:    func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+}
+
+func init() {
+	rootCmd.AddCommand(backupClassCmd)
+	backupClassCmd.AddCommand(backupclass.GetListCmd())
+}

--- a/commands/backupclass/list.go
+++ b/commands/backupclass/list.go
@@ -1,0 +1,85 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package backupclass holds commands for backup class management.
+package backupclass
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli"
+	backupclasscli "github.com/openeverest/openeverest/v2/pkg/cli/backupclass"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+	"github.com/openeverest/openeverest/v2/pkg/logger"
+	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+var (
+	listCmd = &cobra.Command{
+		Use:     "list [flags]",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		Short:   "List backup classes",
+		Long: `List BackupClass resources via the Everest API.
+
+Displays a table with NAME, PROVIDER, EXECUTION MODE, and AGE. Details such
+as job specs, config schemas, and UI hints remain available via --json / --verbose.`,
+		Example: `  # List all backup classes
+  everestctl backup-class list
+
+  # Using aliases
+  everestctl bc ls
+
+  # JSON output for scripting
+  everestctl backup-class list --json | jq '.[].metadata.name'
+
+  # Specific cluster and context
+  everestctl backup-class list --cluster staging --context staging-ctx`,
+		PreRun: listPreRun,
+		Run:    listRun,
+	}
+	listCfg  = &backupclasscli.Config{}
+	listOpts = &backupclasscli.ListOptions{}
+)
+
+func init() {
+	listCmd.Flags().StringVar(&listOpts.Cluster, cli.FlagBackupClassCluster, "main", "Cluster name")
+	listCmd.Flags().StringVar(&listOpts.Context, cli.FlagBackupClassContext, "", "Context to use (default: current context)")
+}
+
+func listPreRun(cmd *cobra.Command, _ []string) {
+	listCfg.Pretty = !cmd.Flag(cli.FlagVerbose).Changed && !cmd.Flag(cli.FlagJSON).Changed
+}
+
+func listRun(cmd *cobra.Command, _ []string) {
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		output.PrintError(err, logger.GetLogger(), listCfg.Pretty)
+		os.Exit(1)
+	}
+
+	runner := backupclasscli.NewListRunner(*listCfg, logger.GetLogger())
+	if err := runner.Run(cmd.Context(), *listOpts, cfgPath); err != nil {
+		output.PrintError(err, logger.GetLogger(), listCfg.Pretty)
+		os.Exit(1)
+	}
+}
+
+// GetListCmd returns the list command.
+func GetListCmd() *cobra.Command {
+	return listCmd
+}

--- a/pkg/cli/backupclass/list.go
+++ b/pkg/cli/backupclass/list.go
@@ -1,0 +1,167 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package backupclass provides CLI business logic for backup class management.
+package backupclass
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/rodaine/table"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/duration"
+
+	"github.com/openeverest/openeverest/v2/client"
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+)
+
+// Config holds the shared configuration for backup class CLI runners.
+type Config struct {
+	Pretty bool
+}
+
+// ListOptions holds the inputs for the list command.
+type ListOptions struct {
+	Cluster string
+	Context string
+}
+
+// ListRunner lists backup classes via the Everest API.
+type ListRunner struct {
+	config Config
+	l      *zap.SugaredLogger
+}
+
+// NewListRunner creates a new ListRunner.
+func NewListRunner(cfg Config, l *zap.SugaredLogger) *ListRunner {
+	bl := &ListRunner{config: cfg, l: l.With("component", "backup-class-list")}
+	if cfg.Pretty {
+		bl.l = zap.NewNop().Sugar()
+	}
+	return bl
+}
+
+// Run fetches backup classes and prints them to stdout, either as a table (pretty mode)
+// or as raw JSON.
+func (bl *ListRunner) Run(ctx context.Context, opts ListOptions, cfgPath string) error {
+	c, err := authcli.NewAPIClient(authcli.Config{Pretty: bl.config.Pretty}, bl.l.Desugar().Sugar(), cfgPath, opts.Context)
+	if err != nil {
+		return err
+	}
+
+	backupClasses, err := bl.listBackupClasses(ctx, c, opts.Cluster)
+	if err != nil {
+		return err
+	}
+
+	sort.Slice(backupClasses, func(i, j int) bool {
+		return backupClassName(&backupClasses[i]) < backupClassName(&backupClasses[j])
+	})
+
+	var buf bytes.Buffer
+	bl.render(&buf, backupClasses)
+	fmt.Fprint(os.Stdout, buf.String())
+	return nil
+}
+
+func (bl *ListRunner) listBackupClasses(ctx context.Context, c *client.ClientWithResponses, cluster string) ([]client.BackupClass, error) {
+	resp, err := c.ListBackupClassesWithResponse(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list backup classes: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response listing backup classes: %s", resp.Status())
+	}
+	if resp.JSON200.Items == nil {
+		return nil, nil
+	}
+	return *resp.JSON200.Items, nil
+}
+
+func (bl *ListRunner) render(w io.Writer, backupClasses []client.BackupClass) {
+	if !bl.config.Pretty {
+		_ = json.NewEncoder(w).Encode(backupClasses) //nolint:errchkjson
+		return
+	}
+	printBackupClassTable(w, backupClasses)
+}
+
+func printBackupClassTable(w io.Writer, backupClasses []client.BackupClass) {
+	tbl := table.New("NAME", "PROVIDER", "EXECUTION MODE", "AGE").WithWriter(w)
+	for i := range backupClasses {
+		bc := &backupClasses[i]
+		tbl.AddRow(
+			backupClassName(bc),
+			backupClassProvider(bc),
+			backupClassExecutionMode(bc),
+			backupClassAge(bc),
+		)
+	}
+	tbl.Print()
+}
+
+func backupClassName(bc *client.BackupClass) string {
+	return metadataStringField(bc, "name")
+}
+
+func backupClassProvider(bc *client.BackupClass) string {
+	if bc.Spec.SupportedProviders == nil || len(*bc.Spec.SupportedProviders) == 0 {
+		return "-"
+	}
+	return strings.Join(*bc.Spec.SupportedProviders, ",")
+}
+
+func backupClassExecutionMode(bc *client.BackupClass) string {
+	if bc.Spec.ExecutionMode == "" {
+		return "-"
+	}
+	return string(bc.Spec.ExecutionMode)
+}
+
+func backupClassAge(bc *client.BackupClass) string {
+	ts := metadataStringField(bc, "creationTimestamp")
+	if ts == "-" {
+		return "-"
+	}
+	created, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return "-"
+	}
+	return duration.ShortHumanDuration(time.Since(created))
+}
+
+func metadataStringField(bc *client.BackupClass, key string) string {
+	if bc.Metadata == nil {
+		return "-"
+	}
+	v, ok := (*bc.Metadata)[key]
+	if !ok {
+		return "-"
+	}
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return "-"
+	}
+	return s
+}

--- a/pkg/cli/backupclass/list_test.go
+++ b/pkg/cli/backupclass/list_test.go
@@ -1,0 +1,178 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupclass
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+)
+
+// testBackupClass mirrors just the JSON shape the list runner reads off of
+// client.BackupClass, so tests can build fixtures without the generated
+// type's large anonymous Spec struct.
+type testBackupClass struct {
+	Metadata map[string]any `json:"metadata"`
+	Spec     struct {
+		ExecutionMode      string   `json:"executionMode"`
+		SupportedProviders []string `json:"supportedProviders,omitempty"`
+	} `json:"spec"`
+}
+
+func newTestBackupClass(name, executionMode string, providers ...string) testBackupClass {
+	tbc := testBackupClass{
+		Metadata: map[string]any{
+			"name":              name,
+			"creationTimestamp": time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
+	tbc.Spec.ExecutionMode = executionMode
+	tbc.Spec.SupportedProviders = providers
+	return tbc
+}
+
+// newTestConfig returns a config with a single context pointing at serverURL.
+func newTestConfig(serverURL string) *config.Config {
+	host := serverURL[len("http://"):]
+	srvName := host
+	userName := "admin@" + srvName
+	return &config.Config{
+		APIVersion:     "config.openeverest.io/v1alpha1",
+		Kind:           "ClientConfig",
+		CurrentContext: userName,
+		Contexts: []config.NamedContext{
+			{Name: userName, Context: config.Context{Server: srvName, User: userName}},
+		},
+		Servers: []config.NamedServer{
+			{Name: srvName, Server: config.Server{URL: serverURL}},
+		},
+		Users: []config.NamedUser{
+			{Name: userName, User: config.User{
+				AccessToken:  "test-token",
+				RefreshToken: "rt-test",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}},
+		},
+	}
+}
+
+func TestBackupClassList_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	items := []testBackupClass{
+		newTestBackupClass("pg-job-backup", "Job", "postgresql"),
+		newTestBackupClass("psmdb-managed-backup", "ProviderManaged", "percona-server-mongodb"),
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main"}, cfgPath)
+	require.NoError(t, err)
+}
+
+func TestBackupClassList_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []testBackupClass{}})
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main"}, cfgPath)
+	require.NoError(t, err)
+}
+
+func TestBackupClassList_ServerError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main"}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected response")
+}
+
+func TestBackupClassList_NoActiveContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		APIVersion: "config.openeverest.io/v1alpha1",
+		Kind:       "ClientConfig",
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main"}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active context")
+}
+
+func TestBackupClassList_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	items := []testBackupClass{newTestBackupClass("pg-job-backup", "Job", "postgresql")}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	// Pretty=false → JSON path
+	runner := NewListRunner(Config{Pretty: false}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main"}, cfgPath)
+	require.NoError(t, err)
+}

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -124,6 +124,13 @@ const (
 	// FlagProviderContext overrides the active context for this command.
 	FlagProviderContext = "context"
 
+	// `backup-class` flags.
+
+	// FlagBackupClassCluster is the name of the cluster flag.
+	FlagBackupClassCluster = "cluster"
+	// FlagBackupClassContext overrides the active context for this command.
+	FlagBackupClassContext = "context"
+
 	// settings flags.
 
 	// FlagOIDCIssuerURL is the name of the issuer-url flag.


### PR DESCRIPTION
Lists BackupClass resources via the Everest API with NAME, PROVIDER (SupportedProviders), EXECUTION MODE, and AGE columns. Supports --json/--verbose for raw output, --cluster/--context selection, the `backup-class`/`backupclass`/`bc` command group, and the `list`/`ls` aliases, following provider list conventions.