### PR TITLE
Add backup-storage list subcommand to everestctl

### DIFF
--- a/commands/backupstorage.go
+++ b/commands/backupstorage.go
@@ -1,0 +1,36 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package commands ...
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openeverest/openeverest/v2/commands/backupstorage"
+)
+
+var backupStorageCmd = &cobra.Command{
+	Use:     "backup-storage <command> [flags]",
+	Aliases: []string{"backupstorage", "bs"},
+	Short:   "Manage Everest backup storages",
+	Long:    "Manage Everest backup storages",
+	RunE:    func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+}
+
+func init() {
+	rootCmd.AddCommand(backupStorageCmd)
+	backupStorageCmd.AddCommand(backupstorage.GetListCmd())
+}

--- a/commands/backupstorage/list.go
+++ b/commands/backupstorage/list.go
@@ -42,8 +42,8 @@ Credentials are never included in the output.`,
 		Example: `  # List backup storages in a namespace
   everestctl backup-storage list --namespace everest
 
-  # Using aliases
-  everestctl bs ls --namespace everest
+  # List across all namespaces
+  everestctl bs ls --all-namespaces
 
   # JSON output — inspect S3 details
   everestctl backup-storage list --namespace everest --json | jq '.[].spec.s3'
@@ -58,11 +58,13 @@ Credentials are never included in the output.`,
 )
 
 func init() {
-	listCmd.Flags().StringVarP(&listOpts.Namespace, cli.FlagBackupStorageNamespace, "n", "", "Namespace to list backup storages from (required)")
+	listCmd.Flags().StringVarP(&listOpts.Namespace, cli.FlagBackupStorageNamespace, "n", "", "Namespace to list backup storages from")
+	listCmd.Flags().BoolVarP(&listOpts.AllNamespaces, cli.FlagBackupStorageAllNamespaces, "A", false, "List backup storages across all namespaces")
 	listCmd.Flags().StringVar(&listOpts.Cluster, cli.FlagBackupStorageCluster, "main", "Cluster name")
 	listCmd.Flags().StringVar(&listOpts.Context, cli.FlagBackupStorageContext, "", "Context to use (default: current context)")
 
-	_ = listCmd.MarkFlagRequired(cli.FlagBackupStorageNamespace)
+	listCmd.MarkFlagsOneRequired(cli.FlagBackupStorageNamespace, cli.FlagBackupStorageAllNamespaces)
+	listCmd.MarkFlagsMutuallyExclusive(cli.FlagBackupStorageNamespace, cli.FlagBackupStorageAllNamespaces)
 }
 
 func listPreRun(cmd *cobra.Command, _ []string) {

--- a/commands/backupstorage/list.go
+++ b/commands/backupstorage/list.go
@@ -1,0 +1,89 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package backupstorage holds commands for backup storage management.
+package backupstorage
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli"
+	backupstoragecli "github.com/openeverest/openeverest/v2/pkg/cli/backupstorage"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+	"github.com/openeverest/openeverest/v2/pkg/logger"
+	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+var (
+	listCmd = &cobra.Command{
+		Use:     "list [flags]",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		Short:   "List backup storages",
+		Long: `List BackupStorage resources via the Everest API.
+
+Displays a table with NAME, NAMESPACE, TYPE, and AGE. Type-specific details
+(e.g. S3 bucket, region, endpoint) remain available via --json / --verbose.
+Credentials are never included in the output.`,
+		Example: `  # List backup storages in a namespace
+  everestctl backup-storage list --namespace everest
+
+  # Using aliases
+  everestctl bs ls --namespace everest
+
+  # JSON output — inspect S3 details
+  everestctl backup-storage list --namespace everest --json | jq '.[].spec.s3'
+
+  # Specific cluster and context
+  everestctl backup-storage list --namespace everest --cluster staging --context staging-ctx`,
+		PreRun: listPreRun,
+		Run:    listRun,
+	}
+	listCfg  = &backupstoragecli.Config{}
+	listOpts = &backupstoragecli.ListOptions{}
+)
+
+func init() {
+	listCmd.Flags().StringVarP(&listOpts.Namespace, cli.FlagBackupStorageNamespace, "n", "", "Namespace to list backup storages from (required)")
+	listCmd.Flags().StringVar(&listOpts.Cluster, cli.FlagBackupStorageCluster, "main", "Cluster name")
+	listCmd.Flags().StringVar(&listOpts.Context, cli.FlagBackupStorageContext, "", "Context to use (default: current context)")
+
+	_ = listCmd.MarkFlagRequired(cli.FlagBackupStorageNamespace)
+}
+
+func listPreRun(cmd *cobra.Command, _ []string) {
+	listCfg.Pretty = !cmd.Flag(cli.FlagVerbose).Changed && !cmd.Flag(cli.FlagJSON).Changed
+}
+
+func listRun(cmd *cobra.Command, _ []string) {
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		output.PrintError(err, logger.GetLogger(), listCfg.Pretty)
+		os.Exit(1)
+	}
+
+	runner := backupstoragecli.NewListRunner(*listCfg, logger.GetLogger())
+	if err := runner.Run(cmd.Context(), *listOpts, cfgPath); err != nil {
+		output.PrintError(err, logger.GetLogger(), listCfg.Pretty)
+		os.Exit(1)
+	}
+}
+
+// GetListCmd returns the list command.
+func GetListCmd() *cobra.Command {
+	return listCmd
+}

--- a/pkg/cli/backupstorage/list.go
+++ b/pkg/cli/backupstorage/list.go
@@ -42,9 +42,10 @@ type Config struct {
 
 // ListOptions holds the inputs for the list command.
 type ListOptions struct {
-	Namespace string
-	Cluster   string
-	Context   string
+	Namespace     string
+	AllNamespaces bool
+	Cluster       string
+	Context       string
 }
 
 // ListRunner lists backup storages via the Everest API.
@@ -71,12 +72,27 @@ func (sl *ListRunner) Run(ctx context.Context, opts ListOptions, cfgPath string)
 		return err
 	}
 
-	backupStorages, err := sl.listBackupStorages(ctx, c, opts.Cluster, opts.Namespace)
-	if err != nil {
-		return err
+	namespaces := []string{opts.Namespace}
+	if opts.AllNamespaces {
+		if namespaces, err = sl.listNamespaces(ctx, c, opts.Cluster); err != nil {
+			return err
+		}
+	}
+
+	backupStorages := make([]client.BackupStorage, 0, len(namespaces))
+	for _, ns := range namespaces {
+		items, err := sl.listBackupStorages(ctx, c, opts.Cluster, ns)
+		if err != nil {
+			return err
+		}
+		backupStorages = append(backupStorages, items...)
 	}
 
 	sort.Slice(backupStorages, func(i, j int) bool {
+		ni, nj := backupStorageNamespace(&backupStorages[i]), backupStorageNamespace(&backupStorages[j])
+		if ni != nj {
+			return ni < nj
+		}
 		return backupStorageName(&backupStorages[i]) < backupStorageName(&backupStorages[j])
 	})
 
@@ -86,15 +102,26 @@ func (sl *ListRunner) Run(ctx context.Context, opts ListOptions, cfgPath string)
 	return nil
 }
 
+func (sl *ListRunner) listNamespaces(ctx context.Context, c *client.ClientWithResponses, cluster string) ([]string, error) {
+	resp, err := c.ListNamespacesWithResponse(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list namespaces: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response listing namespaces: %s", resp.Status())
+	}
+	return *resp.JSON200, nil
+}
+
 func (sl *ListRunner) listBackupStorages(
 	ctx context.Context, c *client.ClientWithResponses, cluster, namespace string,
 ) ([]client.BackupStorage, error) {
 	resp, err := c.ListBackupStoragesWithResponse(ctx, cluster, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list backup storages: %w", err)
+		return nil, fmt.Errorf("failed to list backup storages in namespace %q: %w", namespace, err)
 	}
 	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
-		return nil, fmt.Errorf("unexpected response listing backup storages: %s", resp.Status())
+		return nil, fmt.Errorf("unexpected response listing backup storages in namespace %q: %s", namespace, resp.Status())
 	}
 	if resp.JSON200.Items == nil {
 		return nil, nil

--- a/pkg/cli/backupstorage/list.go
+++ b/pkg/cli/backupstorage/list.go
@@ -1,0 +1,167 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package backupstorage provides CLI business logic for backup storage management.
+package backupstorage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/rodaine/table"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/duration"
+
+	"github.com/openeverest/openeverest/v2/client"
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+)
+
+// Config holds the shared configuration for backup storage CLI runners.
+type Config struct {
+	Pretty bool
+}
+
+// ListOptions holds the inputs for the list command.
+type ListOptions struct {
+	Namespace string
+	Cluster   string
+	Context   string
+}
+
+// ListRunner lists backup storages via the Everest API.
+type ListRunner struct {
+	config Config
+	l      *zap.SugaredLogger
+}
+
+// NewListRunner creates a new ListRunner.
+func NewListRunner(cfg Config, l *zap.SugaredLogger) *ListRunner {
+	sl := &ListRunner{config: cfg, l: l.With("component", "backup-storage-list")}
+	if cfg.Pretty {
+		sl.l = zap.NewNop().Sugar()
+	}
+	return sl
+}
+
+// Run fetches backup storages and prints them to stdout, either as a table (pretty mode)
+// or as raw JSON. Credentials are never part of the response: the API clears write-only
+// credential fields before persisting a BackupStorage, so nothing needs to be redacted here.
+func (sl *ListRunner) Run(ctx context.Context, opts ListOptions, cfgPath string) error {
+	c, err := authcli.NewAPIClient(authcli.Config{Pretty: sl.config.Pretty}, sl.l.Desugar().Sugar(), cfgPath, opts.Context)
+	if err != nil {
+		return err
+	}
+
+	backupStorages, err := sl.listBackupStorages(ctx, c, opts.Cluster, opts.Namespace)
+	if err != nil {
+		return err
+	}
+
+	sort.Slice(backupStorages, func(i, j int) bool {
+		return backupStorageName(&backupStorages[i]) < backupStorageName(&backupStorages[j])
+	})
+
+	var buf bytes.Buffer
+	sl.render(&buf, backupStorages)
+	fmt.Fprint(os.Stdout, buf.String())
+	return nil
+}
+
+func (sl *ListRunner) listBackupStorages(
+	ctx context.Context, c *client.ClientWithResponses, cluster, namespace string,
+) ([]client.BackupStorage, error) {
+	resp, err := c.ListBackupStoragesWithResponse(ctx, cluster, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list backup storages: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response listing backup storages: %s", resp.Status())
+	}
+	if resp.JSON200.Items == nil {
+		return nil, nil
+	}
+	return *resp.JSON200.Items, nil
+}
+
+func (sl *ListRunner) render(w io.Writer, backupStorages []client.BackupStorage) {
+	if !sl.config.Pretty {
+		_ = json.NewEncoder(w).Encode(backupStorages) //nolint:errchkjson
+		return
+	}
+	printBackupStorageTable(w, backupStorages)
+}
+
+func printBackupStorageTable(w io.Writer, backupStorages []client.BackupStorage) {
+	tbl := table.New("NAME", "NAMESPACE", "TYPE", "AGE").WithWriter(w)
+	for i := range backupStorages {
+		bs := &backupStorages[i]
+		tbl.AddRow(
+			backupStorageName(bs),
+			backupStorageNamespace(bs),
+			backupStorageType(bs),
+			backupStorageAge(bs),
+		)
+	}
+	tbl.Print()
+}
+
+func backupStorageName(bs *client.BackupStorage) string {
+	return metadataStringField(bs, "name")
+}
+
+func backupStorageNamespace(bs *client.BackupStorage) string {
+	return metadataStringField(bs, "namespace")
+}
+
+func backupStorageType(bs *client.BackupStorage) string {
+	if bs.Spec.Type == "" {
+		return "-"
+	}
+	return string(bs.Spec.Type)
+}
+
+func backupStorageAge(bs *client.BackupStorage) string {
+	ts := metadataStringField(bs, "creationTimestamp")
+	if ts == "-" {
+		return "-"
+	}
+	created, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return "-"
+	}
+	return duration.ShortHumanDuration(time.Since(created))
+}
+
+func metadataStringField(bs *client.BackupStorage, key string) string {
+	if bs.Metadata == nil {
+		return "-"
+	}
+	v, ok := (*bs.Metadata)[key]
+	if !ok {
+		return "-"
+	}
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return "-"
+	}
+	return s
+}

--- a/pkg/cli/backupstorage/list_test.go
+++ b/pkg/cli/backupstorage/list_test.go
@@ -1,0 +1,188 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupstorage
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+)
+
+// testBackupStorage mirrors just the JSON shape the list runner reads off of
+// client.BackupStorage, so tests can build fixtures without the generated
+// type's large anonymous Spec struct.
+type testBackupStorage struct {
+	Metadata map[string]any `json:"metadata"`
+	Spec     struct {
+		Type string `json:"type"`
+		S3   *struct {
+			Bucket string `json:"bucket"`
+			Region string `json:"region"`
+		} `json:"s3,omitempty"`
+	} `json:"spec"`
+}
+
+func newTestBackupStorage(name, namespace, storageType string) testBackupStorage {
+	tbs := testBackupStorage{
+		Metadata: map[string]any{
+			"name":              name,
+			"namespace":         namespace,
+			"creationTimestamp": time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
+	tbs.Spec.Type = storageType
+	tbs.Spec.S3 = &struct {
+		Bucket string `json:"bucket"`
+		Region string `json:"region"`
+	}{Bucket: "my-bucket", Region: "us-east-1"}
+	return tbs
+}
+
+// newTestConfig returns a config with a single context pointing at serverURL.
+func newTestConfig(serverURL string) *config.Config {
+	host := serverURL[len("http://"):]
+	srvName := host
+	userName := "admin@" + srvName
+	return &config.Config{
+		APIVersion:     "config.openeverest.io/v1alpha1",
+		Kind:           "ClientConfig",
+		CurrentContext: userName,
+		Contexts: []config.NamedContext{
+			{Name: userName, Context: config.Context{Server: srvName, User: userName}},
+		},
+		Servers: []config.NamedServer{
+			{Name: srvName, Server: config.Server{URL: serverURL}},
+		},
+		Users: []config.NamedUser{
+			{Name: userName, User: config.User{
+				AccessToken:  "test-token",
+				RefreshToken: "rt-test",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}},
+		},
+	}
+}
+
+func TestBackupStorageList_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	items := []testBackupStorage{
+		newTestBackupStorage("s3-primary", "everest", "s3"),
+		newTestBackupStorage("s3-secondary", "everest", "s3"),
+	}
+
+	var requestPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main", Namespace: "everest"}, cfgPath)
+	require.NoError(t, err)
+	assert.Contains(t, requestPath, "/namespaces/everest/backup-storages")
+}
+
+func TestBackupStorageList_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []testBackupStorage{}})
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main", Namespace: "everest"}, cfgPath)
+	require.NoError(t, err)
+}
+
+func TestBackupStorageList_ServerError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main", Namespace: "everest"}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected response")
+}
+
+func TestBackupStorageList_NoActiveContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		APIVersion: "config.openeverest.io/v1alpha1",
+		Kind:       "ClientConfig",
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main", Namespace: "everest"}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active context")
+}
+
+func TestBackupStorageList_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	items := []testBackupStorage{newTestBackupStorage("s3-primary", "everest", "s3")}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	// Pretty=false → JSON path
+	runner := NewListRunner(Config{Pretty: false}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{Cluster: "main", Namespace: "everest"}, cfgPath)
+	require.NoError(t, err)
+}

--- a/pkg/cli/backupstorage/list_test.go
+++ b/pkg/cli/backupstorage/list_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,7 +45,7 @@ type testBackupStorage struct {
 	} `json:"spec"`
 }
 
-func newTestBackupStorage(name, namespace, storageType string) testBackupStorage {
+func newTestBackupStorage(name, namespace string) testBackupStorage {
 	tbs := testBackupStorage{
 		Metadata: map[string]any{
 			"name":              name,
@@ -52,7 +53,7 @@ func newTestBackupStorage(name, namespace, storageType string) testBackupStorage
 			"creationTimestamp": time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
 		},
 	}
-	tbs.Spec.Type = storageType
+	tbs.Spec.Type = "s3"
 	tbs.Spec.S3 = &struct {
 		Bucket string `json:"bucket"`
 		Region string `json:"region"`
@@ -89,8 +90,8 @@ func TestBackupStorageList_HappyPath(t *testing.T) {
 	t.Parallel()
 
 	items := []testBackupStorage{
-		newTestBackupStorage("s3-primary", "everest", "s3"),
-		newTestBackupStorage("s3-secondary", "everest", "s3"),
+		newTestBackupStorage("s3-primary", "everest"),
+		newTestBackupStorage("s3-secondary", "everest"),
 	}
 
 	var requestPath string
@@ -110,6 +111,45 @@ func TestBackupStorageList_HappyPath(t *testing.T) {
 	err := runner.Run(t.Context(), ListOptions{Cluster: "main", Namespace: "everest"}, cfgPath)
 	require.NoError(t, err)
 	assert.Contains(t, requestPath, "/namespaces/everest/backup-storages")
+}
+
+func TestBackupStorageList_AllNamespaces(t *testing.T) {
+	t.Parallel()
+
+	nsBackupStorages := map[string][]testBackupStorage{
+		"everest":  {newTestBackupStorage("s3-primary", "everest")},
+		"everest2": {newTestBackupStorage("s3-secondary", "everest2")},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if strings.HasSuffix(r.URL.Path, "/namespaces") {
+			_ = json.NewEncoder(w).Encode([]string{"everest", "everest2"})
+			return
+		}
+
+		for ns, items := range nsBackupStorages {
+			if strings.Contains(r.URL.Path, "/namespaces/"+ns+"/backup-storages") {
+				_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
+				return
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []testBackupStorage{}})
+	}))
+	defer srv.Close()
+
+	cfg := newTestConfig(srv.URL)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, cfg.Save(cfgPath))
+
+	runner := NewListRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := runner.Run(t.Context(), ListOptions{
+		AllNamespaces: true,
+		Cluster:       "main",
+	}, cfgPath)
+	require.NoError(t, err)
 }
 
 func TestBackupStorageList_EmptyResult(t *testing.T) {
@@ -168,7 +208,7 @@ func TestBackupStorageList_NoActiveContext(t *testing.T) {
 func TestBackupStorageList_JSONOutput(t *testing.T) {
 	t.Parallel()
 
-	items := []testBackupStorage{newTestBackupStorage("s3-primary", "everest", "s3")}
+	items := []testBackupStorage{newTestBackupStorage("s3-primary", "everest")}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -134,6 +134,8 @@ const (
 	FlagBackupStorageCluster = "cluster"
 	// FlagBackupStorageContext overrides the active context for this command.
 	FlagBackupStorageContext = "context"
+	// FlagBackupStorageAllNamespaces lists backup storages across all namespaces.
+	FlagBackupStorageAllNamespaces = "all-namespaces"
 
 	// `backup-class` flags.
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -124,6 +124,15 @@ const (
 	// FlagProviderContext overrides the active context for this command.
 	FlagProviderContext = "context"
 
+	// `backup-storage` flags.
+
+	// FlagBackupStorageNamespace is the name of the namespace flag.
+	FlagBackupStorageNamespace = "namespace"
+	// FlagBackupStorageCluster is the name of the cluster flag.
+	FlagBackupStorageCluster = "cluster"
+	// FlagBackupStorageContext overrides the active context for this command.
+	FlagBackupStorageContext = "context"
+
 	// settings flags.
 
 	// FlagOIDCIssuerURL is the name of the issuer-url flag.


### PR DESCRIPTION
Adds `everestctl backup-storage list` to view configured backup storages via the Everest API, mirroring the existing provider list pattern. Supports namespace filtering (-n/--namespace), --json output, and the backupstorage/bs and list/ls aliases. Credentials are never included in the output.
Closes #2552 