### PR TITLE
Fix dynamic select default option resolution (#2566)

### DIFF
--- a/ui/apps/everest/src/components/ui-generator/ui-component/utils/select-component-handler.tsx
+++ b/ui/apps/everest/src/components/ui-generator/ui-component/utils/select-component-handler.tsx
@@ -18,6 +18,7 @@ import {
   FieldType,
   Component,
   SelectFieldParams,
+  SelectOptionsItem,
 } from '../../ui-generator.types';
 import { Provider } from 'shared-types/api.types';
 import { getValueByPath } from './get-value-by-path';
@@ -31,7 +32,7 @@ export const isSelectComponent = (item: Component): item is SelectComponent => {
 export const resolveSelectOptions = (
   selectParams: SelectFieldParams,
   providerObject?: Provider
-): { label: string; value: string }[] => {
+): SelectOptionsItem[] => {
   if ('options' in selectParams && selectParams.options) {
     return selectParams.options;
   }
@@ -46,7 +47,7 @@ export const resolveSelectOptions = (
     const rawData = getValueByPath(providerObject, optionsPath);
 
     if (Array.isArray(rawData)) {
-      const { labelPath, valuePath } = optionsPathConfig;
+      const { labelPath, valuePath, defaultPath } = optionsPathConfig;
       return rawData.map((item) => ({
         label: String(
           getValueByPath(item as Record<string, unknown>, labelPath) ?? ''
@@ -54,6 +55,11 @@ export const resolveSelectOptions = (
         value: String(
           getValueByPath(item as Record<string, unknown>, valuePath) ?? ''
         ),
+        isDefault: defaultPath
+          ? Boolean(
+              getValueByPath(item as Record<string, unknown>, defaultPath)
+            )
+          : false,
       }));
     }
   }

--- a/ui/apps/everest/src/components/ui-generator/ui-component/utils/tests/select-component-handler.test.tsx
+++ b/ui/apps/everest/src/components/ui-generator/ui-component/utils/tests/select-component-handler.test.tsx
@@ -47,20 +47,21 @@ describe('select-component-handler utils', () => {
         optionsPathConfig: {
           labelPath: 'version',
           valuePath: 'version',
+          defaultPath: 'default',
         },
       },
       {
         spec: {
           availableVersions: {
-            engine: [{ version: '8.0' }, { version: '8.1' }],
+            engine: [{ version: '8.0' }, { version: '8.1', default: true }],
           },
         },
       } as never
     );
 
     expect(options).toEqual([
-      { label: '8.0', value: '8.0' },
-      { label: '8.1', value: '8.1' },
+      { label: '8.0', value: '8.0', isDefault: false,},
+      { label: '8.1', value: '8.1', isDefault: true, },
     ]);
   });
 

--- a/ui/apps/everest/src/components/ui-generator/ui-generator.types.ts
+++ b/ui/apps/everest/src/components/ui-generator/ui-generator.types.ts
@@ -82,7 +82,7 @@ export interface NumberFieldParams extends CommonFieldParams {
   placeholder?: string;
 }
 
-type SelectOptionsItem = { label: string; value: string };
+export type SelectOptionsItem = { label: string; value: string; isDefault?: boolean };
 
 type SelectFieldParamsBase = CommonFieldParams & {
   multiple?: boolean;
@@ -99,7 +99,7 @@ export type SelectFieldParams =
     })
   | (SelectFieldParamsBase & {
       optionsPath: string;
-      optionsPathConfig: { labelPath: string; valuePath: string };
+      optionsPathConfig: { labelPath: string; valuePath: string; defaultPath?: string };
       options?: never;
     });
 

--- a/ui/apps/everest/src/components/ui-generator/utils/preprocess/preprocess-schema.ts
+++ b/ui/apps/everest/src/components/ui-generator/utils/preprocess/preprocess-schema.ts
@@ -89,10 +89,12 @@ const preprocessComponent = (
       ) as SelectFieldParams;
 
     // Only set defaultValue from resolved options if not already specified in schema
+    const defaultOption = options.find((option) => option.isDefault);
+    
     const defaultValue =
       baseParams.defaultValue !== undefined
         ? baseParams.defaultValue
-        : options[0].value;
+        : defaultOption?.value ?? options[0].value;
 
     return {
       ...normalizedComponent,


### PR DESCRIPTION
## Summary

Fixes #2566 by preserving provider-defined default values for dynamically populated select fields while maintaining the existing fallback behavior.

## Changes

- Add optional `defaultPath` to `optionsPathConfig`
- Preserve provider-defined default information while resolving dynamic select options
- Prefer the provider-defined default option before falling back to the first option
- Preserve existing behavior when `fieldParams.defaultValue` is explicitly provided
- Update unit tests

## Testing

- [x] Updated unit tests
- [x] Targeted unit tests pass
- [x] Lint passes
- [x] Copyright check passes