### PR TITLE
feat(ui): convert memory resource units from GB to Gi

### DIFF
--- a/ui/apps/everest/src/components/cluster-form/resources/constants.ts
+++ b/ui/apps/everest/src/components/cluster-form/resources/constants.ts
@@ -64,9 +64,9 @@ export const matchFieldsValueToResourceSize = (
     return ResourceSize.custom;
   }
 
-  const memory = memoryParser(extractedMemory.toString(), 'G');
+  const memory = memoryParser(extractedMemory.toString(), 'Gi');
   const res = Object.values(sizes).findIndex((item) => {
-    const sizeParsedMemory = memoryParser(item.memory.toString(), 'G');
+    const sizeParsedMemory = memoryParser(item.memory.toString(), 'Gi');
     return (
       cpuParser(item.cpu.toString()) === cpuParser(extractedCpu.toString()) &&
       sizeParsedMemory.value === memory.value

--- a/ui/apps/everest/src/components/cluster-form/resources/resource-requests-section/resource-requests-section.tsx
+++ b/ui/apps/everest/src/components/cluster-form/resources/resource-requests-section/resource-requests-section.tsx
@@ -101,8 +101,8 @@ const ResourceRequestsSection = ({
               unitPlural={unitPlural}
               name={memoryInputName}
               label="Memory request"
-              helperText={Messages.requestCeiling(memoryLimit, 'GB')}
-              endSuffix="GB"
+              helperText={Messages.requestCeiling(memoryLimit, 'Gi')}
+              endSuffix="Gi"
               numberOfUnits={intNumberOfUnits}
               disableTopMargin
             />

--- a/ui/apps/everest/src/components/cluster-form/resources/resources-toggles/resources-toggles.tsx
+++ b/ui/apps/everest/src/components/cluster-form/resources/resources-toggles/resources-toggles.tsx
@@ -273,11 +273,11 @@ const ResourcesToggles = ({
           label="MEMORY limit"
           helperText={checkResourceText(
             resourcesInfo?.available?.memoryBytes,
-            'GB',
+            'Gi',
             'memory',
             memoryCapacityExceeded
           )}
-          endSuffix="GB"
+          endSuffix="Gi"
           numberOfUnits={intNumberOfUnits}
         />
 

--- a/ui/apps/everest/src/hooks/api/db-cluster/useCreateDbCluster.ts
+++ b/ui/apps/everest/src/hooks/api/db-cluster/useCreateDbCluster.ts
@@ -102,11 +102,11 @@ const formValuesToPayloadMapping = (
         resources: {
           limits: {
             cpu: `${dbPayload.cpu}`,
-            memory: `${dbPayload.memory}G`,
+            memory: `${dbPayload.memory}Gi`,
           },
           requests: {
             cpu: `${dbPayload.cpuRequests ?? dbPayload.cpu}`,
-            memory: `${dbPayload.memoryRequests ?? dbPayload.memory}G`,
+            memory: `${dbPayload.memoryRequests ?? dbPayload.memory}Gi`,
           },
         },
         storage: {

--- a/ui/apps/everest/src/hooks/api/db-cluster/utils.test.ts
+++ b/ui/apps/everest/src/hooks/api/db-cluster/utils.test.ts
@@ -29,8 +29,8 @@ describe('getProxySpec', () => {
       false
     );
 
-    expect(proxy.resources?.limits).toEqual({ cpu: '1', memory: '2G' });
-    expect(proxy.resources?.requests).toEqual({ cpu: '1', memory: '2G' });
+    expect(proxy.resources?.limits).toEqual({ cpu: '1', memory: '2Gi' });
+    expect(proxy.resources?.requests).toEqual({ cpu: '1', memory: '2Gi' });
   });
 
   it('uses explicit request values when provided', () => {
@@ -46,8 +46,8 @@ describe('getProxySpec', () => {
       2
     );
 
-    expect(proxy.resources?.limits).toEqual({ cpu: '2', memory: '4G' });
-    expect(proxy.resources?.requests).toEqual({ cpu: '1', memory: '2G' });
+    expect(proxy.resources?.limits).toEqual({ cpu: '2', memory: '4Gi' });
+    expect(proxy.resources?.requests).toEqual({ cpu: '1', memory: '2Gi' });
   });
 
   it('omits requests when omitRequests is true', () => {
@@ -68,7 +68,7 @@ describe('getProxySpec', () => {
       true
     );
 
-    expect(proxy.resources?.limits).toEqual({ cpu: '1', memory: '2G' });
+    expect(proxy.resources?.limits).toEqual({ cpu: '1', memory: '2Gi' });
     expect(proxy.resources?.requests).toBeUndefined();
   });
 

--- a/ui/apps/everest/src/hooks/api/db-cluster/utils.ts
+++ b/ui/apps/everest/src/hooks/api/db-cluster/utils.ts
@@ -81,14 +81,14 @@ export const getProxySpec = (
     resources: {
       limits: {
         cpu: `${cpu}`,
-        memory: `${memory}G`,
+        memory: `${memory}Gi`,
       },
       ...(omitRequests
         ? {}
         : {
             requests: {
               cpu: `${cpuRequests ?? cpu}`,
-              memory: `${memoryRequests ?? memory}G`,
+              memory: `${memoryRequests ?? memory}Gi`,
             },
           }),
     },

--- a/ui/apps/everest/src/pages/database-form/database-form.utils.ts
+++ b/ui/apps/everest/src/pages/database-form/database-form.utils.ts
@@ -148,13 +148,13 @@ export const DbClusterPayloadToFormValues = (
   );
   const nodeMemoryLimit = memoryParser(
     extractResourceMemoryValue(engineResources).toString(),
-    'G'
+    'Gi'
   ).value;
   const proxyCpuLimit = proxyResources
     ? cpuParser(extractResourceCpuValue(proxyResources).toString())
     : 0;
   const proxyMemoryLimit = proxyResources
-    ? memoryParser(extractResourceMemoryValue(proxyResources).toString(), 'G')
+    ? memoryParser(extractResourceMemoryValue(proxyResources).toString(), 'Gi')
         .value
     : 0;
 
@@ -171,7 +171,7 @@ export const DbClusterPayloadToFormValues = (
       : undefined;
   const nodeMemoryRequest =
     rawNodeMemoryRequest !== undefined
-      ? memoryParser(rawNodeMemoryRequest.toString(), 'G').value
+      ? memoryParser(rawNodeMemoryRequest.toString(), 'Gi').value
       : undefined;
   const proxyCpuRequest =
     rawProxyCpuRequest !== undefined
@@ -179,7 +179,7 @@ export const DbClusterPayloadToFormValues = (
       : undefined;
   const proxyMemoryRequest =
     rawProxyMemoryRequest !== undefined
-      ? memoryParser(rawProxyMemoryRequest.toString(), 'G').value
+      ? memoryParser(rawProxyMemoryRequest.toString(), 'Gi').value
       : undefined;
 
   // Requests are "synced" with limits when they are absent or identical to the

--- a/ui/apps/everest/src/pages/database-form/database-preview/database-preview.test.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-preview/database-preview.test.tsx
@@ -122,7 +122,7 @@ describe('DatabasePreview', () => {
     expect(within(nodesTable).getByText('3 nodes:')).toBeInTheDocument();
     expect(
       within(nodesTable).getByTestId('nodes-resources-table-limits-line')
-    ).toHaveTextContent('Limits & Requests: CPU: 3.00 CPU; Memory: 6.00 GB');
+    ).toHaveTextContent('Limits & Requests: CPU: 3.00 CPU; Memory: 6.00 Gi');
     expect(within(nodesTable).getByText('Disk: 90.00 Gi')).toBeInTheDocument();
     expect(
       within(nodesTable).getByTestId('nodes-resources-table-sync-icon')

--- a/ui/apps/everest/src/pages/database-form/database-preview/sections/resources-section/resources-section.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-preview/sections/resources-section/resources-section.tsx
@@ -95,10 +95,10 @@ export const ResourcesPreviewSection = ({
     },
     {
       label: 'Memory',
-      limit: formatResourceValue(parsedMemory, 'GB', nodesShardMultiplier),
+      limit: formatResourceValue(parsedMemory, 'Gi', nodesShardMultiplier),
       request: formatResourceValue(
         parsedMemoryRequests,
-        'GB',
+        'Gi',
         nodesShardMultiplier
       ),
     },
@@ -117,8 +117,8 @@ export const ResourcesPreviewSection = ({
     },
     {
       label: 'Memory',
-      limit: formatResourceValue(parsedProxyMemory, 'GB'),
-      request: formatResourceValue(parsedProxyMemoryRequests, 'GB'),
+      limit: formatResourceValue(parsedProxyMemory, 'Gi'),
+      request: formatResourceValue(parsedProxyMemoryRequests, 'Gi'),
     },
   ];
 

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/resources-details.test.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/resources-details.test.tsx
@@ -76,7 +76,7 @@ describe('ResourcesDetails - legacy clusters', () => {
   ])(
     'shows a single value for legacy %s because requests are synced with limits',
     (_engineName, engineType) => {
-      renderCard(makeLegacyCluster(engineType, { cpu: '2', memory: '4G' }));
+      renderCard(makeLegacyCluster(engineType, { cpu: '2', memory: '4Gi' }));
 
       // Legacy clusters are treated as if limits and requests were equal, so
       // the card shows a single value (no "limit / request" slash) for every
@@ -86,7 +86,7 @@ describe('ResourcesDetails - legacy clusters', () => {
       expect(cpuRow).not.toHaveTextContent('/');
 
       const memoryRow = screen.getByTestId('memory-overview-section-row');
-      expect(memoryRow).toHaveTextContent(/4\s*GB/);
+      expect(memoryRow).toHaveTextContent(/4\s*Gi/);
       expect(memoryRow).not.toHaveTextContent('/');
     }
   );

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/resources-details.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/resources-details.tsx
@@ -100,8 +100,8 @@ export const ResourcesDetails = ({
     : true;
   const disk = dbCluster.spec.engine.storage.size;
   const parsedDiskValues = memoryParser(disk.toString());
-  const parsedMemoryValues = memoryParser(memory.toString(), 'G');
-  const parsedProxyMemoryValues = memoryParser(proxyMemory.toString(), 'G');
+  const parsedMemoryValues = memoryParser(memory.toString(), 'Gi');
+  const parsedProxyMemoryValues = memoryParser(proxyMemory.toString(), 'Gi');
   const dbType = dbEngineToDbType(dbCluster.spec.engine.type);
   const replicas = dbCluster.spec.engine.replicas.toString();
   const proxies = isProxy(dbCluster.spec.proxy)
@@ -250,13 +250,13 @@ export const ResourcesDetails = ({
                   label: Messages.fields.memory,
                   limit: getResourcesDetailedString(
                     parsedMemoryValues.value,
-                    'GB'
+                    'Gi'
                   ),
                   request:
                     memoryRequests !== undefined
                       ? getResourcesDetailedString(
-                          memoryParser(memoryRequests.toString(), 'G').value,
-                          'GB'
+                          memoryParser(memoryRequests.toString(), 'Gi').value,
+                          'Gi'
                         )
                       : undefined,
                 },
@@ -300,15 +300,15 @@ export const ResourcesDetails = ({
                     limit: getTotalResourcesDetailedString(
                       parsedProxyMemoryValues.value,
                       parseInt(proxies, 10),
-                      'GB'
+                      'Gi'
                     ),
                     request:
                       proxyMemoryRequests !== undefined
                         ? getTotalResourcesDetailedString(
-                            memoryParser(proxyMemoryRequests.toString(), 'G')
+                            memoryParser(proxyMemoryRequests.toString(), 'Gi')
                               .value,
                             parseInt(proxies, 10),
-                            'GB'
+                            'Gi'
                           )
                         : undefined,
                   },
@@ -335,20 +335,20 @@ export const ResourcesDetails = ({
               : cpuParser((cpuRequests ?? cpu).toString() || '0'),
             disk: parsedDiskValues.value,
             diskUnit: parsedDiskValues.originalUnit,
-            memory: memoryParser(memory.toString(), 'G').value,
+            memory: memoryParser(memory.toString(), 'Gi').value,
             memoryRequests: nodeRequestsSynced
-              ? memoryParser(memory.toString(), 'G').value
-              : memoryParser((memoryRequests ?? memory).toString(), 'G').value,
+              ? memoryParser(memory.toString(), 'Gi').value
+              : memoryParser((memoryRequests ?? memory).toString(), 'Gi').value,
             proxyCpu: cpuParser(proxyCpu.toString() || '0'),
             proxyCpuRequests: proxyRequestsSynced
               ? cpuParser(proxyCpu.toString() || '0')
               : cpuParser((proxyCpuRequests ?? proxyCpu).toString() || '0'),
-            proxyMemory: memoryParser(proxyMemory.toString(), 'G').value,
+            proxyMemory: memoryParser(proxyMemory.toString(), 'Gi').value,
             proxyMemoryRequests: proxyRequestsSynced
-              ? memoryParser(proxyMemory.toString(), 'G').value
+              ? memoryParser(proxyMemory.toString(), 'Gi').value
               : memoryParser(
                   (proxyMemoryRequests ?? proxyMemory).toString(),
-                  'G'
+                  'Gi'
                 ).value,
             [DbWizardFormFields.nodeRequestsSynced]: nodeRequestsSynced,
             [DbWizardFormFields.proxyRequestsSynced]: proxyRequestsSynced,

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/resources/resources-edit-modal.test.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/resources/resources-edit-modal.test.tsx
@@ -25,7 +25,7 @@ describe('ResourcesEditModal', () => {
             proxyCpu: 1,
             proxyMemory: 1,
             diskUnit: 'Gi',
-            memoryUnit: 'GB',
+            memoryUnit: 'Gi',
             resourceSizePerNode: ResourceSize.custom,
             resourceSizePerProxy: ResourceSize.custom,
           }}
@@ -68,7 +68,7 @@ describe('ResourcesEditModal', () => {
             proxyCpu: 1,
             proxyMemory: 1,
             diskUnit: 'Gi',
-            memoryUnit: 'GB',
+            memoryUnit: 'Gi',
             resourceSizePerNode: ResourceSize.custom,
             resourceSizePerProxy: ResourceSize.custom,
           }}
@@ -107,7 +107,7 @@ describe('ResourcesEditModal', () => {
             proxyCpu: 1,
             proxyMemory: 1,
             diskUnit: 'Gi',
-            memoryUnit: 'GB',
+            memoryUnit: 'Gi',
             resourceSizePerNode: ResourceSize.custom,
             resourceSizePerProxy: ResourceSize.custom,
           }}
@@ -151,7 +151,7 @@ describe('ResourcesEditModal', () => {
             proxyCpu: 1,
             proxyMemory: 1,
             diskUnit: 'Gi',
-            memoryUnit: 'GB',
+            memoryUnit: 'Gi',
             resourceSizePerNode: ResourceSize.custom,
             resourceSizePerProxy: ResourceSize.custom,
           }}
@@ -192,7 +192,7 @@ describe('ResourcesEditModal', () => {
             proxyCpu: 1,
             proxyMemory: 1,
             diskUnit: 'Gi',
-            memoryUnit: 'GB',
+            memoryUnit: 'Gi',
             resourceSizePerNode: ResourceSize.custom,
             resourceSizePerProxy: ResourceSize.custom,
           }}

--- a/ui/apps/everest/src/utils/db.test.ts
+++ b/ui/apps/everest/src/utils/db.test.ts
@@ -649,7 +649,7 @@ describe('changeDbClusterResources', () => {
         proxy: {
           type: 'haproxy',
           replicas: 1,
-          resources: { cpu: '1', memory: '2G' },
+          resources: { cpu: '1', memory: '2Gi' },
           expose: { type: 'internal' },
         },
       },
@@ -669,7 +669,7 @@ describe('changeDbClusterResources', () => {
   it('omits engine requests for a legacy cluster when requests stay synced', () => {
     const cluster = makeCluster(DbEngineType.PSMDB, {
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
 
     const result = changeDbClusterResources(cluster, {
@@ -680,7 +680,7 @@ describe('changeDbClusterResources', () => {
 
     expect(result.spec.engine.resources?.limits).toEqual({
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
     expect(result.spec.engine.resources?.requests).toBeUndefined();
   });
@@ -688,7 +688,7 @@ describe('changeDbClusterResources', () => {
   it('keeps limits only for a legacy cluster when the user toggles requests back to synced after prefilling them', () => {
     const cluster = makeCluster(DbEngineType.PSMDB, {
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
 
     // Simulates the user turning the sync toggle off (fields get prefilled with
@@ -706,7 +706,7 @@ describe('changeDbClusterResources', () => {
 
     expect(result.spec.engine.resources?.limits).toEqual({
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
     expect(result.spec.engine.resources?.requests).toBeUndefined();
   });
@@ -714,7 +714,7 @@ describe('changeDbClusterResources', () => {
   it('writes engine requests for a legacy cluster when requests are desynced', () => {
     const cluster = makeCluster(DbEngineType.PSMDB, {
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
 
     const result = changeDbClusterResources(cluster, {
@@ -727,14 +727,14 @@ describe('changeDbClusterResources', () => {
 
     expect(result.spec.engine.resources?.requests).toEqual({
       cpu: '1',
-      memory: '2G',
+      memory: '2Gi',
     });
   });
 
   it('writes engine requests for a non-legacy cluster even when synced', () => {
     const cluster = makeCluster(DbEngineType.PSMDB, {
-      limits: { cpu: '2', memory: '4G' },
-      requests: { cpu: '2', memory: '4G' },
+      limits: { cpu: '2', memory: '4Gi' },
+      requests: { cpu: '2', memory: '4Gi' },
     });
 
     const result = changeDbClusterResources(cluster, {
@@ -745,7 +745,7 @@ describe('changeDbClusterResources', () => {
 
     expect(result.spec.engine.resources?.requests).toEqual({
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
   });
 
@@ -756,7 +756,7 @@ describe('changeDbClusterResources', () => {
     const cluster = makeCluster(DbEngineType.PSMDB, {
       cpu: '0',
       memory: '0',
-      limits: { cpu: '2', memory: '4G' },
+      limits: { cpu: '2', memory: '4Gi' },
     });
 
     const result = changeDbClusterResources(cluster, {
@@ -767,7 +767,7 @@ describe('changeDbClusterResources', () => {
 
     expect(result.spec.engine.resources?.limits).toEqual({
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
     expect(result.spec.engine.resources?.requests).toBeUndefined();
   });
@@ -775,7 +775,7 @@ describe('changeDbClusterResources', () => {
   it('omits proxy requests for a legacy proxy when requests stay synced', () => {
     const cluster = makeCluster(DbEngineType.POSTGRESQL, {
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
 
     const result = changeDbClusterResources(cluster, {
@@ -789,20 +789,20 @@ describe('changeDbClusterResources', () => {
     });
 
     const proxy = result.spec.proxy as Proxy;
-    expect(proxy.resources?.limits).toEqual({ cpu: '1', memory: '2G' });
+    expect(proxy.resources?.limits).toEqual({ cpu: '1', memory: '2Gi' });
     expect(proxy.resources?.requests).toBeUndefined();
   });
 
   it('keeps limits only when re-saving a limits-only proxy while synced', () => {
     const cluster = makeCluster(DbEngineType.POSTGRESQL, {
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
     // The proxy was already saved with limits only (no explicit requests).
     (cluster.spec.proxy as Proxy).resources = {
       cpu: '0',
       memory: '0',
-      limits: { cpu: '1', memory: '2G' },
+      limits: { cpu: '1', memory: '2Gi' },
     } as Proxy['resources'];
 
     const result = changeDbClusterResources(cluster, {
@@ -814,14 +814,14 @@ describe('changeDbClusterResources', () => {
     });
 
     const proxy = result.spec.proxy as Proxy;
-    expect(proxy.resources?.limits).toEqual({ cpu: '1', memory: '2G' });
+    expect(proxy.resources?.limits).toEqual({ cpu: '1', memory: '2Gi' });
     expect(proxy.resources?.requests).toBeUndefined();
   });
 
   it('writes proxy requests for a legacy proxy when requests are desynced', () => {
     const cluster = makeCluster(DbEngineType.PXC, {
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
 
     const result = changeDbClusterResources(cluster, {
@@ -833,18 +833,18 @@ describe('changeDbClusterResources', () => {
     });
 
     const proxy = result.spec.proxy as Proxy;
-    expect(proxy.resources?.requests).toEqual({ cpu: '1', memory: '2G' });
+    expect(proxy.resources?.requests).toEqual({ cpu: '1', memory: '2Gi' });
   });
 
   it('writes proxy requests for a non-legacy proxy even when synced', () => {
     const cluster = makeCluster(DbEngineType.PXC, {
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
     // Promote the proxy to the new format so it is no longer legacy.
     (cluster.spec.proxy as Proxy).resources = {
-      limits: { cpu: '1', memory: '2G' },
-      requests: { cpu: '1', memory: '2G' },
+      limits: { cpu: '1', memory: '2Gi' },
+      requests: { cpu: '1', memory: '2Gi' },
     };
 
     const result = changeDbClusterResources(cluster, {
@@ -854,7 +854,7 @@ describe('changeDbClusterResources', () => {
     });
 
     const proxy = result.spec.proxy as Proxy;
-    expect(proxy.resources?.requests).toEqual({ cpu: '1', memory: '2G' });
+    expect(proxy.resources?.requests).toEqual({ cpu: '1', memory: '2Gi' });
   });
 
   it('always writes engine requests for a legacy PXC cluster even when synced', () => {
@@ -863,7 +863,7 @@ describe('changeDbClusterResources', () => {
     // effective resource configuration intact.
     const cluster = makeCluster(DbEngineType.PXC, {
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
 
     const result = changeDbClusterResources(cluster, {
@@ -874,18 +874,18 @@ describe('changeDbClusterResources', () => {
 
     expect(result.spec.engine.resources?.limits).toEqual({
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
     expect(result.spec.engine.resources?.requests).toEqual({
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
   });
 
   it('always writes proxy requests for a legacy PXC proxy even when synced', () => {
     const cluster = makeCluster(DbEngineType.PXC, {
       cpu: '2',
-      memory: '4G',
+      memory: '4Gi',
     });
 
     const result = changeDbClusterResources(cluster, {
@@ -895,7 +895,7 @@ describe('changeDbClusterResources', () => {
     });
 
     const proxy = result.spec.proxy as Proxy;
-    expect(proxy.resources?.limits).toEqual({ cpu: '1', memory: '2G' });
-    expect(proxy.resources?.requests).toEqual({ cpu: '1', memory: '2G' });
+    expect(proxy.resources?.limits).toEqual({ cpu: '1', memory: '2Gi' });
+    expect(proxy.resources?.requests).toEqual({ cpu: '1', memory: '2Gi' });
   });
 });

--- a/ui/apps/everest/src/utils/db.tsx
+++ b/ui/apps/everest/src/utils/db.tsx
@@ -892,14 +892,14 @@ export const changeDbClusterResources = (
         resources: {
           limits: {
             cpu: `${newResources.cpu}`,
-            memory: `${newResources.memory}G`,
+            memory: `${newResources.memory}Gi`,
           },
           ...(omitEngineRequests
             ? {}
             : {
                 requests: {
                   cpu: `${newResources.cpuRequests ?? newResources.cpu}`,
-                  memory: `${newResources.memoryRequests ?? newResources.memory}G`,
+                  memory: `${newResources.memoryRequests ?? newResources.memory}Gi`,
                 },
               }),
         },

--- a/ui/apps/everest/src/utils/k8ResourceParser/index.ts
+++ b/ui/apps/everest/src/utils/k8ResourceParser/index.ts
@@ -146,7 +146,7 @@ export const areResourceRequestsSynced = (resources?: Resources): boolean => {
   const cpuLimit = cpuParser(extractResourceCpuValue(resources).toString());
   const memoryLimit = memoryParser(
     extractResourceMemoryValue(resources).toString(),
-    'G'
+    'Gi'
   ).value;
 
   const rawCpuRequest = extractResourceCpuRequestValue(resources);
@@ -159,7 +159,7 @@ export const areResourceRequestsSynced = (resources?: Resources): boolean => {
   const memorySynced =
     rawMemoryRequest === undefined ||
     Math.abs(
-      memoryParser(rawMemoryRequest.toString(), 'G').value - memoryLimit
+      memoryParser(rawMemoryRequest.toString(), 'Gi').value - memoryLimit
     ) < RESOURCE_COMPARISON_EPSILON;
 
   return cpuSynced && memorySynced;


### PR DESCRIPTION
### Description
This change updates all database and proxy memory resource fields in the UI from `GB`/`G` (decimal Gigabytes) to `Gi` (binary Gibibytes) for limits, requests, and spec serialization.

- Updates the serialization logic to write memory specifications with the `Gi` suffix.
- Changes UI labels, end-suffixes, and tooltips to display `Gi` instead of `GB`.
- Aligns resource matching and synchronization functions to use `Gi` as the target unit.
- Updates unit test suites to assert the corrected `Gi` formatting and values.
