### PR TITLE
Add --wait flag to instance create

### DIFF
--- a/commands/instance/create.go
+++ b/commands/instance/create.go
@@ -133,30 +133,34 @@ func createRun(cmd *cobra.Command, _ []string) { //nolint:revive
 		os.Exit(exitFailed)
 	}
 
-	if err := validateWaitFlags(cmd); err != nil {
+	if err := validateWaitFlags(cmd, createOpts); err != nil {
 		output.PrintError(err, logger.GetLogger(), createCfg.Pretty)
 		os.Exit(exitFailed)
 	}
 
 	ctx := cmd.Context()
+	stop := func() {}
 	if createOpts.Wait {
 		// Ctrl-C cancels only the wait; the instance keeps provisioning.
-		var stop context.CancelFunc
-		ctx, stop = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-		defer stop()
+		var cancel context.CancelFunc
+		ctx, cancel = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+		stop = cancel
 	}
 
 	ic := instancecli.NewInstanceCreator(*createCfg, logger.GetLogger())
-	os.Exit(createExitCode(ic.Run(ctx, *createOpts, cfgPath)))
+	code := createExitCode(ic.Run(ctx, *createOpts, cfgPath), createOpts, createCfg.Pretty)
+	// Release the signal handler before os.Exit (which skips defers).
+	stop()
+	os.Exit(code)
 }
 
 // validateWaitFlags rejects --timeout without --wait and non-positive timeouts.
 // (cobra's MarkFlagsRequiredTogether would wrongly reject a bare --wait.)
-func validateWaitFlags(cmd *cobra.Command) error {
-	if cmd.Flags().Changed(cli.FlagInstanceTimeout) && !createOpts.Wait {
+func validateWaitFlags(cmd *cobra.Command, opts *instancecli.CreateOptions) error {
+	if cmd.Flags().Changed(cli.FlagInstanceTimeout) && !opts.Wait {
 		return errors.New("--timeout is only valid together with --wait")
 	}
-	if createOpts.Wait && createOpts.Timeout <= 0 {
+	if opts.Wait && opts.Timeout <= 0 {
 		return errors.New("--timeout must be a positive duration (use e.g. --timeout 10m)")
 	}
 	return nil
@@ -164,25 +168,25 @@ func validateWaitFlags(cmd *cobra.Command) error {
 
 // createExitCode maps the create/wait result to an exit code and prints the
 // matching message. See the exit* constants for the contract.
-func createExitCode(err error) int {
+func createExitCode(err error, opts *instancecli.CreateOptions, pretty bool) int {
 	switch {
 	case err == nil:
 		return 0
 	case errors.Is(err, context.Canceled):
 		_, _ = fmt.Fprint(os.Stderr, output.Warn(
 			"wait cancelled; instance %q is still provisioning — check with 'everestctl instance status'",
-			createOpts.Name,
+			opts.Name,
 		))
 		return exitCanceled
 	case errors.Is(err, wait.ErrTimeout):
 		output.PrintError(
-			fmt.Errorf("timed out after %s waiting for instance %q to become ready; it is still provisioning", createOpts.Timeout, createOpts.Name),
-			logger.GetLogger(), createCfg.Pretty,
+			fmt.Errorf("timed out after %s waiting for instance %q to become ready; it is still provisioning", opts.Timeout, opts.Name),
+			logger.GetLogger(), pretty,
 		)
 		return exitTimeout
 	default:
 		// *wait.FailedError (Failed phase / deleted mid-wait) and everything else.
-		output.PrintError(err, logger.GetLogger(), createCfg.Pretty)
+		output.PrintError(err, logger.GetLogger(), pretty)
 		return exitFailed
 	}
 }

--- a/commands/instance/create.go
+++ b/commands/instance/create.go
@@ -17,15 +17,35 @@
 package instance
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/openeverest/openeverest/v2/pkg/cli"
 	"github.com/openeverest/openeverest/v2/pkg/cli/config"
 	instancecli "github.com/openeverest/openeverest/v2/pkg/cli/instance"
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
 	"github.com/openeverest/openeverest/v2/pkg/logger"
 	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+// Exit codes for `instance create`, chosen so CI scripts can tell the failure
+// modes apart without scraping stderr:
+//
+//	0   success
+//	1   the instance reached the Failed phase (or any other error)
+//	124 the --wait timeout elapsed (matches timeout(1))
+//	130 the wait was cancelled with Ctrl-C (128 + SIGINT)
+const (
+	exitFailed   = 1
+	exitTimeout  = 124
+	exitCanceled = 130
 )
 
 var (
@@ -69,7 +89,14 @@ to override any Instance spec field using dot-notation paths rooted at the spec
 
   # Explicit version and topology
   everestctl instance create --name my-mongo --namespace everest --provider percona-server-mongodb \
-    --version 8.0.12 --topology sharded`,
+    --version 8.0.12 --topology sharded
+
+  # Block until the instance is ready (Ctrl-C only stops waiting; the instance keeps provisioning)
+  everestctl instance create --name my-mongo --namespace everest --provider percona-server-mongodb --wait
+
+  # Bounded wait for CI, then grab the phase
+  everestctl instance create --name my-mongo --namespace everest --provider percona-server-mongodb \
+    --wait --timeout 15m --json | jq '.status.phase'`,
 		PreRun: createPreRun,
 		Run:    createRun,
 	}
@@ -88,6 +115,8 @@ func init() {
 	createCmd.Flags().StringVar(&createOpts.Context, cli.FlagInstanceContext, "", "Context to use (default: current context)")
 	createCmd.Flags().StringVarP(&createOpts.ValuesFile, cli.FlagInstanceFile, "f", "", "Path to a YAML file with component overrides (--set takes precedence)")
 	createCmd.Flags().StringArrayVar(&createOpts.Set, cli.FlagInstanceSet, nil, "Set a spec field: --set components.engine.replicas=3 or --set backup.enabled=true (repeatable)")
+	createCmd.Flags().BoolVar(&createOpts.Wait, cli.FlagInstanceWait, false, "Block until the instance reaches the Ready phase; exit non-zero if it fails or times out")
+	createCmd.Flags().DurationVar(&createOpts.Timeout, cli.FlagInstanceTimeout, 10*time.Minute, "Maximum time to wait (only valid with --wait); must be positive")
 
 	_ = createCmd.MarkFlagRequired(cli.FlagInstanceName)
 	_ = createCmd.MarkFlagRequired(cli.FlagInstanceNamespace)
@@ -101,13 +130,60 @@ func createRun(cmd *cobra.Command, _ []string) { //nolint:revive
 	cfgPath, err := config.DefaultPath()
 	if err != nil {
 		output.PrintError(err, logger.GetLogger(), createCfg.Pretty)
-		os.Exit(1)
+		os.Exit(exitFailed)
+	}
+
+	if err := validateWaitFlags(cmd); err != nil {
+		output.PrintError(err, logger.GetLogger(), createCfg.Pretty)
+		os.Exit(exitFailed)
+	}
+
+	ctx := cmd.Context()
+	if createOpts.Wait {
+		// Ctrl-C cancels only the wait; the instance keeps provisioning.
+		var stop context.CancelFunc
+		ctx, stop = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+		defer stop()
 	}
 
 	ic := instancecli.NewInstanceCreator(*createCfg, logger.GetLogger())
-	if err := ic.Run(cmd.Context(), *createOpts, cfgPath); err != nil {
+	os.Exit(createExitCode(ic.Run(ctx, *createOpts, cfgPath)))
+}
+
+// validateWaitFlags rejects --timeout without --wait and non-positive timeouts.
+// (cobra's MarkFlagsRequiredTogether would wrongly reject a bare --wait.)
+func validateWaitFlags(cmd *cobra.Command) error {
+	if cmd.Flags().Changed(cli.FlagInstanceTimeout) && !createOpts.Wait {
+		return errors.New("--timeout is only valid together with --wait")
+	}
+	if createOpts.Wait && createOpts.Timeout <= 0 {
+		return errors.New("--timeout must be a positive duration (use e.g. --timeout 10m)")
+	}
+	return nil
+}
+
+// createExitCode maps the create/wait result to an exit code and prints the
+// matching message. See the exit* constants for the contract.
+func createExitCode(err error) int {
+	switch {
+	case err == nil:
+		return 0
+	case errors.Is(err, context.Canceled):
+		_, _ = fmt.Fprint(os.Stderr, output.Warn(
+			"wait cancelled; instance %q is still provisioning — check with 'everestctl instance status'",
+			createOpts.Name,
+		))
+		return exitCanceled
+	case errors.Is(err, wait.ErrTimeout):
+		output.PrintError(
+			fmt.Errorf("timed out after %s waiting for instance %q to become ready; it is still provisioning", createOpts.Timeout, createOpts.Name),
+			logger.GetLogger(), createCfg.Pretty,
+		)
+		return exitTimeout
+	default:
+		// *wait.FailedError (Failed phase / deleted mid-wait) and everything else.
 		output.PrintError(err, logger.GetLogger(), createCfg.Pretty)
-		os.Exit(1)
+		return exitFailed
 	}
 }
 

--- a/commands/instance/create.go
+++ b/commands/instance/create.go
@@ -173,10 +173,10 @@ func createExitCode(err error, opts *instancecli.CreateOptions, pretty bool) int
 	case err == nil:
 		return 0
 	case errors.Is(err, context.Canceled):
-		_, _ = fmt.Fprint(os.Stderr, output.Warn(
-			"wait cancelled; instance %q is still provisioning — check with 'everestctl instance status'",
-			opts.Name,
-		))
+		output.PrintWarn(
+			fmt.Sprintf("wait cancelled; instance %q is still provisioning — check with 'everestctl instance status'", opts.Name),
+			logger.GetLogger(), pretty,
+		)
 		return exitCanceled
 	case errors.Is(err, wait.ErrTimeout):
 		output.PrintError(

--- a/commands/instance/create_test.go
+++ b/commands/instance/create_test.go
@@ -20,15 +20,21 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/openeverest/openeverest/v2/pkg/cli"
+	instancecli "github.com/openeverest/openeverest/v2/pkg/cli/instance"
 	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
 )
 
 func TestCreateExitCode(t *testing.T) {
-	// Not parallel: createExitCode reads/prints via package-level createOpts.
-	createOpts.Name = "my-db"
+	t.Parallel()
+
+	opts := &instancecli.CreateOptions{Name: "my-db", Timeout: time.Minute}
 
 	tests := []struct {
 		name string
@@ -44,38 +50,44 @@ func TestCreateExitCode(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, createExitCode(tc.err))
+			t.Parallel()
+			assert.Equal(t, tc.want, createExitCode(tc.err, opts, true))
 		})
 	}
 }
 
 func TestValidateWaitFlags(t *testing.T) {
-	// Not parallel: mutates the shared createCmd flag state and createOpts.
-	reset := func(wait bool, timeoutChanged bool) {
-		createOpts.Wait = wait
-		createOpts.Timeout = 10_000_000_000 // 10s, positive
-		_ = createCmd.Flags().Set("timeout", "10s")
-		if !timeoutChanged {
-			// Reset the flag's Changed bit to model "user didn't pass --timeout".
-			createCmd.Flags().Lookup("timeout").Changed = false
-		}
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		wait           bool
+		timeout        time.Duration
+		timeoutChanged bool   // whether --timeout was explicitly passed
+		wantErr        string // substring; empty means no error expected
+	}{
+		{"timeout without wait", false, 10 * time.Second, true, "only valid together with --wait"},
+		{"wait with non-positive timeout", true, 0, false, "positive duration"},
+		{"wait with default timeout", true, 10 * time.Minute, false, ""},
 	}
 
-	t.Run("timeout without wait errors", func(t *testing.T) {
-		reset(false, true)
-		err := validateWaitFlags(createCmd)
-		assert.ErrorContains(t, err, "only valid together with --wait")
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	t.Run("wait with non-positive timeout errors", func(t *testing.T) {
-		reset(true, false)
-		createOpts.Timeout = 0
-		err := validateWaitFlags(createCmd)
-		assert.ErrorContains(t, err, "positive duration")
-	})
+			cmd := &cobra.Command{}
+			cmd.Flags().Duration(cli.FlagInstanceTimeout, 10*time.Minute, "")
+			if tc.timeoutChanged {
+				require.NoError(t, cmd.Flags().Set(cli.FlagInstanceTimeout, "10s"))
+			}
+			opts := &instancecli.CreateOptions{Wait: tc.wait, Timeout: tc.timeout}
 
-	t.Run("wait with default timeout is fine", func(t *testing.T) {
-		reset(true, false)
-		assert.NoError(t, validateWaitFlags(createCmd))
-	})
+			err := validateWaitFlags(cmd, opts)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tc.wantErr)
+		})
+	}
 }

--- a/commands/instance/create_test.go
+++ b/commands/instance/create_test.go
@@ -1,0 +1,81 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
+)
+
+func TestCreateExitCode(t *testing.T) {
+	// Not parallel: createExitCode reads/prints via package-level createOpts.
+	createOpts.Name = "my-db"
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"success", nil, 0},
+		{"failed phase", &wait.FailedError{Message: "entered the Failed phase"}, exitFailed},
+		{"generic error", errors.New("boom"), exitFailed},
+		{"timeout", fmt.Errorf("wrap: %w", wait.ErrTimeout), exitTimeout},
+		{"cancelled", fmt.Errorf("wrap: %w", context.Canceled), exitCanceled},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, createExitCode(tc.err))
+		})
+	}
+}
+
+func TestValidateWaitFlags(t *testing.T) {
+	// Not parallel: mutates the shared createCmd flag state and createOpts.
+	reset := func(wait bool, timeoutChanged bool) {
+		createOpts.Wait = wait
+		createOpts.Timeout = 10_000_000_000 // 10s, positive
+		_ = createCmd.Flags().Set("timeout", "10s")
+		if !timeoutChanged {
+			// Reset the flag's Changed bit to model "user didn't pass --timeout".
+			createCmd.Flags().Lookup("timeout").Changed = false
+		}
+	}
+
+	t.Run("timeout without wait errors", func(t *testing.T) {
+		reset(false, true)
+		err := validateWaitFlags(createCmd)
+		assert.ErrorContains(t, err, "only valid together with --wait")
+	})
+
+	t.Run("wait with non-positive timeout errors", func(t *testing.T) {
+		reset(true, false)
+		createOpts.Timeout = 0
+		err := validateWaitFlags(createCmd)
+		assert.ErrorContains(t, err, "positive duration")
+	})
+
+	t.Run("wait with default timeout is fine", func(t *testing.T) {
+		reset(true, false)
+		assert.NoError(t, validateWaitFlags(createCmd))
+	})
+}

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -118,6 +118,10 @@ const (
 	FlagInstanceInterval = "interval"
 	// FlagInstanceAllNamespaces lists instances across all namespaces.
 	FlagInstanceAllNamespaces = "all-namespaces"
+	// FlagInstanceWait blocks create until the instance reaches the Ready phase.
+	FlagInstanceWait = "wait"
+	// FlagInstanceTimeout bounds --wait; only valid together with --wait.
+	FlagInstanceTimeout = "timeout"
 
 	// `provider` flags.
 

--- a/pkg/cli/instance/create.go
+++ b/pkg/cli/instance/create.go
@@ -192,6 +192,10 @@ func (ic *InstanceCreator) emitCreated(created *client.Instance, opts CreateOpti
 		_, _ = fmt.Fprint(os.Stdout, output.Success("Instance %q created in namespace %q", opts.Name, opts.Namespace))
 		return nil
 	}
+	// A 200/201 with an unparseable body would otherwise emit empty stdout.
+	if created == nil {
+		return fmt.Errorf("instance %q was created but the server returned an unreadable response body", opts.Name)
+	}
 	return writeInstanceJSON(created)
 }
 
@@ -222,18 +226,17 @@ func (ic *InstanceCreator) waitForInstance(
 		}
 	}
 
-	err := wait.Until(ctx, poll, instanceCondition, wait.Options{
+	if err := wait.Until(ctx, poll, instanceCondition, wait.Options{
 		Timeout:  opts.Timeout,
 		OnUpdate: onUpdate,
-	})
+		OnRetry:  func(err error) { ic.l.Warnf("%v — retrying", err) },
+	}); err != nil {
+		return err
+	}
 
 	final := latest
 	if final == nil {
 		final = created
-	}
-
-	if err != nil {
-		return err
 	}
 
 	if ic.config.Pretty {

--- a/pkg/cli/instance/create.go
+++ b/pkg/cli/instance/create.go
@@ -26,12 +26,14 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
 	"github.com/openeverest/openeverest/v2/client"
 	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
 	"github.com/openeverest/openeverest/v2/pkg/output"
 )
 
@@ -47,9 +49,11 @@ type CreateOptions struct {
 	Cluster    string
 	Version    string
 	Topology   string
-	Context    string   // overrides the active context when set
-	ValuesFile string   // path to a YAML values file with spec-level overrides (optional)
-	Set        []string // dot-notation overrides e.g. "components.engine.replicas=3"; takes precedence over ValuesFile
+	Context    string        // overrides the active context when set
+	ValuesFile string        // path to a YAML values file with spec-level overrides (optional)
+	Set        []string      // dot-notation overrides e.g. "components.engine.replicas=3"; takes precedence over ValuesFile
+	Wait       bool          // block until the instance reaches the Ready phase
+	Timeout    time.Duration // bounds --wait; must be positive
 }
 
 type InstanceCreator struct {
@@ -168,10 +172,87 @@ func (ic *InstanceCreator) Run(ctx context.Context, opts CreateOptions, cfgPath 
 	}
 
 	ic.l.Infof("created instance %q in namespace %q", opts.Name, opts.Namespace)
-	if ic.config.Pretty {
-		_, _ = fmt.Fprint(os.Stdout, output.Success("Instance %q created in namespace %q", opts.Name, opts.Namespace))
+
+	// The API returns the accepted Instance as JSON201 (or JSON200).
+	created := resp.JSON201
+	if created == nil {
+		created = resp.JSON200
 	}
 
+	if !opts.Wait {
+		return ic.emitCreated(created, opts)
+	}
+	return ic.waitForInstance(ctx, c, created, opts)
+}
+
+// emitCreated reports a non-waiting create: a success line in pretty mode, or
+// the created instance in JSON mode (so `create --json` is parseable either way).
+func (ic *InstanceCreator) emitCreated(created *client.Instance, opts CreateOptions) error {
+	if ic.config.Pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Success("Instance %q created in namespace %q", opts.Name, opts.Namespace))
+		return nil
+	}
+	return writeInstanceJSON(created)
+}
+
+// waitForInstance blocks until the instance reaches a terminal phase. Pretty
+// mode streams progress then the final status; JSON mode emits one final object.
+func (ic *InstanceCreator) waitForInstance(
+	ctx context.Context,
+	c *client.ClientWithResponses,
+	created *client.Instance,
+	opts CreateOptions,
+) error {
+	// Keep the latest instance seen, for the final output.
+	var latest *client.Instance
+	basePoll := newInstancePoll(c, opts.Cluster, opts.Namespace, opts.Name)
+	poll := func(ctx context.Context) (*client.Instance, error) {
+		inst, err := basePoll(ctx)
+		if err == nil {
+			latest = inst
+		}
+		return inst, err
+	}
+
+	var onUpdate func(string)
+	if ic.config.Pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Info("Instance %q created; waiting for it to become ready...", opts.Name))
+		onUpdate = func(msg string) {
+			_, _ = fmt.Fprintf(os.Stdout, "  %s\n", msg)
+		}
+	}
+
+	err := wait.Until(ctx, poll, instanceCondition, wait.Options{
+		Timeout:  opts.Timeout,
+		OnUpdate: onUpdate,
+	})
+
+	final := latest
+	if final == nil {
+		final = created
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if ic.config.Pretty {
+		var buf bytes.Buffer
+		printInstanceStatus(&buf, final, opts.Namespace)
+		_, _ = fmt.Fprint(os.Stdout, buf.String())
+		_, _ = fmt.Fprint(os.Stdout, output.Success("Instance %q is ready", opts.Name))
+		return nil
+	}
+	return writeInstanceJSON(final)
+}
+
+func writeInstanceJSON(inst *client.Instance) error {
+	if inst == nil {
+		return nil
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(inst); err != nil {
+		return fmt.Errorf("failed to encode instance: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/cli/instance/create_test.go
+++ b/pkg/cli/instance/create_test.go
@@ -471,6 +471,14 @@ func newRunServer(t *testing.T, providerHandler, createHandler http.HandlerFunc)
 	return httptest.NewServer(mux)
 }
 
+// respondCreated writes a minimal 201 instance body, as the real API does; the
+// non-wait JSON path needs a parseable body to emit.
+func respondCreated(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_, _ = w.Write([]byte(`{"metadata":{"name":"my-db"}}`))
+}
+
 func psmdbProvider() *client.Provider {
 	return buildProvider("psmdb", []struct {
 		name      string
@@ -489,7 +497,7 @@ func TestRun_HappyPath(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(psmdbProvider())
 	}
 	createHandler := func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusCreated)
+		respondCreated(w)
 	}
 
 	srv := newRunServer(t, provHandler, createHandler)
@@ -642,7 +650,7 @@ func TestRun_ContextFlag(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(psmdbProvider())
 	}
 	createHandler := func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusCreated)
+		respondCreated(w)
 	}
 
 	srv := newRunServer(t, provHandler, createHandler)
@@ -883,7 +891,7 @@ func TestRun_WithPreset_Payloads(t *testing.T) {
 				func(w http.ResponseWriter, r *http.Request) {
 					got, readErr = io.ReadAll(r.Body)
 					assert.NoError(t, readErr)
-					w.WriteHeader(http.StatusCreated)
+					respondCreated(w)
 				},
 				okPresetHandler,
 			)
@@ -988,7 +996,7 @@ func TestRun_WithPreset_ResolvePassesNamespace(t *testing.T) {
 
 	var capturedURL string
 	srv := newRunServerWithPreset(t, okProviderHandler,
-		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusCreated) },
+		func(w http.ResponseWriter, _ *http.Request) { respondCreated(w) },
 		func(w http.ResponseWriter, r *http.Request) {
 			capturedURL = r.URL.String()
 			okPresetHandler(w, r)

--- a/pkg/cli/instance/wait.go
+++ b/pkg/cli/instance/wait.go
@@ -17,11 +17,13 @@ package instance
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/openeverest/openeverest/v2/client"
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
 	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
 )
 
@@ -47,8 +49,10 @@ func instanceCondition(inst *client.Instance) (wait.Outcome, string) {
 	}
 }
 
-// newInstancePoll returns a PollFunc for the instance. A 404 is a terminal
-// error (the resource is gone), matching `instance status --watch`.
+// newInstancePoll returns a PollFunc for the instance, mirroring the error
+// handling of `instance status --watch`: transient fetch failures and
+// unexpected statuses are retried (wait.RetryableError), while a 404 (deleted), a
+// 401 (credentials rejected), and a failed token refresh are terminal.
 func newInstancePoll(
 	c *client.ClientWithResponses,
 	cluster, namespace, name string,
@@ -56,18 +60,24 @@ func newInstancePoll(
 	return func(ctx context.Context) (*client.Instance, error) {
 		resp, err := c.GetInstanceWithResponse(ctx, cluster, namespace, name)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch instance %q: %w", name, err)
+			// A failed token refresh is terminal; other fetch errors are transient.
+			if errors.Is(err, authcli.ErrTokenRefresh) {
+				return nil, fmt.Errorf("failed to fetch instance %q: %w", name, err)
+			}
+			return nil, &wait.RetryableError{Err: fmt.Errorf("failed to fetch instance %q: %w", name, err)}
 		}
 		switch resp.StatusCode() {
 		case http.StatusOK:
 			if resp.JSON200 == nil {
-				return nil, fmt.Errorf("empty response body fetching instance %q", name)
+				return nil, &wait.RetryableError{Err: fmt.Errorf("empty response body fetching instance %q", name)}
 			}
 			return resp.JSON200, nil
 		case http.StatusNotFound:
 			return nil, fmt.Errorf("instance %q was deleted while waiting", name)
+		case http.StatusUnauthorized:
+			return nil, fmt.Errorf("server rejected credentials — run 'everestctl auth login' again")
 		default:
-			return nil, fmt.Errorf("unexpected response fetching instance %q: %s", name, resp.Status())
+			return nil, &wait.RetryableError{Err: fmt.Errorf("unexpected response fetching instance %q: %s", name, resp.Status())}
 		}
 	}
 }

--- a/pkg/cli/instance/wait.go
+++ b/pkg/cli/instance/wait.go
@@ -1,0 +1,122 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
+)
+
+// instanceCondition classifies an Instance: Ready -> Succeeded,
+// Failed/Terminating -> Failed, anything else (incl. Suspended) -> Pending.
+func instanceCondition(inst *client.Instance) (wait.Outcome, string) {
+	phase := instancePhase(inst)
+	switch phase {
+	case string(client.InstanceStatusPhaseReady):
+		return wait.Succeeded, progressMessage(inst, phase)
+	case string(client.InstanceStatusPhaseFailed):
+		msg := instanceStatusMessage(inst)
+		if msg == "" {
+			msg = "instance entered the Failed phase"
+		} else {
+			msg = "instance entered the Failed phase: " + msg
+		}
+		return wait.Failed, msg
+	case string(client.InstanceStatusPhaseTerminating):
+		return wait.Failed, "instance is being deleted"
+	default:
+		return wait.Pending, progressMessage(inst, phase)
+	}
+}
+
+// newInstancePoll returns a PollFunc for the instance. A 404 is a terminal
+// error (the resource is gone), matching `instance status --watch`.
+func newInstancePoll(
+	c *client.ClientWithResponses,
+	cluster, namespace, name string,
+) wait.PollFunc[*client.Instance] {
+	return func(ctx context.Context) (*client.Instance, error) {
+		resp, err := c.GetInstanceWithResponse(ctx, cluster, namespace, name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch instance %q: %w", name, err)
+		}
+		switch resp.StatusCode() {
+		case http.StatusOK:
+			if resp.JSON200 == nil {
+				return nil, fmt.Errorf("empty response body fetching instance %q", name)
+			}
+			return resp.JSON200, nil
+		case http.StatusNotFound:
+			return nil, fmt.Errorf("instance %q was deleted while waiting", name)
+		default:
+			return nil, fmt.Errorf("unexpected response fetching instance %q: %s", name, resp.Status())
+		}
+	}
+}
+
+func instancePhase(inst *client.Instance) string {
+	if inst == nil || inst.Status == nil || inst.Status.Phase == nil {
+		return ""
+	}
+	return string(*inst.Status.Phase)
+}
+
+func instanceStatusMessage(inst *client.Instance) string {
+	if inst == nil || inst.Status == nil || inst.Status.Message == nil {
+		return ""
+	}
+	return strings.TrimSpace(*inst.Status.Message)
+}
+
+// progressMessage renders a one-line phase + component summary, e.g.
+// "Provisioning (engine 1/3 ready)".
+func progressMessage(inst *client.Instance, phase string) string {
+	if phase == "" {
+		phase = "-"
+	}
+	comps := componentSummary(inst)
+	if comps == "" {
+		return phase
+	}
+	return fmt.Sprintf("%s (%s)", phase, comps)
+}
+
+func componentSummary(inst *client.Instance) string {
+	if inst == nil || inst.Status == nil || inst.Status.Components == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(*inst.Status.Components))
+	for _, comp := range *inst.Status.Components {
+		state := "-"
+		if comp.State != nil {
+			state = *comp.State
+		}
+		var ready, total int32
+		if comp.Ready != nil {
+			ready = *comp.Ready
+		}
+		if comp.Total != nil {
+			total = *comp.Total
+		}
+		parts = append(parts, fmt.Sprintf("%s %d/%d ready", state, ready, total))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/pkg/cli/instance/wait_test.go
+++ b/pkg/cli/instance/wait_test.go
@@ -1,0 +1,274 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
+)
+
+// instFromJSON builds a client.Instance from a JSON literal — far more readable
+// than the generated anonymous Status struct.
+func instFromJSON(t *testing.T, body string) *client.Instance {
+	t.Helper()
+	var inst client.Instance
+	require.NoError(t, json.Unmarshal([]byte(body), &inst))
+	return &inst
+}
+
+// ---- instanceCondition ------------------------------------------------------
+
+func TestInstanceCondition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		body        string
+		wantOutcome wait.Outcome
+		wantMsgHas  string
+	}{
+		{
+			name:        "ready is success",
+			body:        `{"status":{"phase":"Ready"}}`,
+			wantOutcome: wait.Succeeded,
+			wantMsgHas:  "Ready",
+		},
+		{
+			name:        "failed is terminal failure with message",
+			body:        `{"status":{"phase":"Failed","message":"engine crashloop"}}`,
+			wantOutcome: wait.Failed,
+			wantMsgHas:  "engine crashloop",
+		},
+		{
+			name:        "failed without message still fails",
+			body:        `{"status":{"phase":"Failed"}}`,
+			wantOutcome: wait.Failed,
+			wantMsgHas:  "Failed phase",
+		},
+		{
+			name:        "terminating is failure",
+			body:        `{"status":{"phase":"Terminating"}}`,
+			wantOutcome: wait.Failed,
+			wantMsgHas:  "being deleted",
+		},
+		{
+			name:        "provisioning keeps waiting",
+			body:        `{"status":{"phase":"Provisioning"}}`,
+			wantOutcome: wait.Pending,
+			wantMsgHas:  "Provisioning",
+		},
+		{
+			name:        "suspended is treated as pending, not failure",
+			body:        `{"status":{"phase":"Suspended"}}`,
+			wantOutcome: wait.Pending,
+			wantMsgHas:  "Suspended",
+		},
+		{
+			name:        "missing status is pending",
+			body:        `{"metadata":{"name":"x"}}`,
+			wantOutcome: wait.Pending,
+			wantMsgHas:  "-",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			outcome, msg := instanceCondition(instFromJSON(t, tc.body))
+			assert.Equal(t, tc.wantOutcome, outcome)
+			assert.Contains(t, msg, tc.wantMsgHas)
+		})
+	}
+}
+
+func TestProgressMessage_WithComponents(t *testing.T) {
+	t.Parallel()
+
+	inst := instFromJSON(t, `{"status":{"phase":"Provisioning","components":[
+		{"state":"initializing","ready":1,"total":3}
+	]}}`)
+	_, msg := instanceCondition(inst)
+	assert.Equal(t, "Provisioning (initializing 1/3 ready)", msg)
+}
+
+// ---- Run --wait integration -------------------------------------------------
+
+// waitServer serves the provider fetch, POST create, and GET polls. getPhases
+// are returned in order on successive GETs (last repeats); getStatus != 200
+// makes GETs return that status instead (e.g. 404).
+func waitServer(t *testing.T, getStatus int, getPhases ...string) *httptest.Server {
+	t.Helper()
+	var gets int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/providers/psmdb", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(psmdbProvider())
+	})
+	mux.HandleFunc("/v1/clusters/main/namespaces/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"metadata":{"name":"my-db"},"status":{"phase":"Pending"}}`))
+			return
+		}
+		if getStatus != http.StatusOK {
+			w.WriteHeader(getStatus)
+			return
+		}
+		i := int(atomic.AddInt32(&gets, 1)) - 1
+		if i >= len(getPhases) {
+			i = len(getPhases) - 1
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"metadata":{"name":"my-db"},"status":{"phase":%q}}`, getPhases[i])))
+	})
+	return httptest.NewServer(mux)
+}
+
+func runWaitCreate(t *testing.T, srv *httptest.Server, cfg Config, timeout time.Duration) error {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	ic := NewInstanceCreator(cfg, zap.NewNop().Sugar())
+	return ic.Run(context.Background(), CreateOptions{
+		Name:      "my-db",
+		Namespace: "everest",
+		Provider:  "psmdb",
+		Cluster:   "main",
+		Wait:      true,
+		Timeout:   timeout,
+	}, cfgPath)
+}
+
+func TestRunWait(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		getStatus int      // status returned by GET polls; non-200 short-circuits phases
+		getPhases []string // phases returned in order (last repeats)
+		timeout   time.Duration
+		wantErr   func(t *testing.T, err error)
+	}{
+		{
+			name:      "succeeds when ready",
+			getStatus: http.StatusOK,
+			getPhases: []string{"Ready"},
+			timeout:   time.Minute,
+			wantErr:   func(t *testing.T, err error) { assert.NoError(t, err) },
+		},
+		{
+			name:      "failed phase returns FailedError",
+			getStatus: http.StatusOK,
+			getPhases: []string{"Failed"},
+			timeout:   time.Minute,
+			wantErr: func(t *testing.T, err error) {
+				var fe *wait.FailedError
+				require.ErrorAs(t, err, &fe)
+				assert.Contains(t, fe.Error(), "Failed phase")
+			},
+		},
+		{
+			name:      "deleted mid-wait is terminal",
+			getStatus: http.StatusNotFound,
+			timeout:   time.Minute,
+			wantErr: func(t *testing.T, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "was deleted")
+			},
+		},
+		{
+			name:      "times out when never terminal",
+			getStatus: http.StatusOK,
+			getPhases: []string{"Provisioning"},
+			timeout:   40 * time.Millisecond,
+			wantErr:   func(t *testing.T, err error) { require.ErrorIs(t, err, wait.ErrTimeout) },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := waitServer(t, tc.getStatus, tc.getPhases...)
+			defer srv.Close()
+			tc.wantErr(t, runWaitCreate(t, srv, Config{Pretty: true}, tc.timeout))
+		})
+	}
+}
+
+// ---- create --json output contract ------------------------------------------
+
+// captureStdout returns what fn writes to os.Stdout. Not parallel-safe
+// (os.Stdout is global), so callers must not use t.Parallel.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func TestRun_JSONEmitsCreatedInstanceWithoutWait(t *testing.T) {
+	// Not parallel: captures global os.Stdout.
+	srv := waitServer(t, http.StatusOK, "Pending")
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	out := captureStdout(t, func() {
+		ic := NewInstanceCreator(Config{Pretty: false}, zap.NewNop().Sugar())
+		err := ic.Run(context.Background(), CreateOptions{
+			Name:      "my-db",
+			Namespace: "everest",
+			Provider:  "psmdb",
+			Cluster:   "main",
+		}, cfgPath)
+		require.NoError(t, err)
+	})
+
+	// The created instance object must be emitted (not empty), so the contract
+	// is stable whether or not --wait is passed.
+	var got client.Instance
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	require.NotNil(t, got.Metadata)
+	assert.Equal(t, "my-db", (*got.Metadata)["name"])
+}

--- a/pkg/cli/instance/wait_test.go
+++ b/pkg/cli/instance/wait_test.go
@@ -127,7 +127,7 @@ func TestProgressMessage_WithComponents(t *testing.T) {
 // makes GETs return that status instead (e.g. 404).
 func waitServer(t *testing.T, getStatus int, getPhases ...string) *httptest.Server {
 	t.Helper()
-	var gets int32
+	var gets atomic.Int32
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/clusters/main/providers/psmdb", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -144,13 +144,13 @@ func waitServer(t *testing.T, getStatus int, getPhases ...string) *httptest.Serv
 			w.WriteHeader(getStatus)
 			return
 		}
-		i := int(atomic.AddInt32(&gets, 1)) - 1
+		i := int(gets.Add(1)) - 1
 		if i >= len(getPhases) {
 			i = len(getPhases) - 1
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"metadata":{"name":"my-db"},"status":{"phase":%q}}`, getPhases[i])))
+		_, _ = w.Write(fmt.Appendf(nil, `{"metadata":{"name":"my-db"},"status":{"phase":%q}}`, getPhases[i]))
 	})
 	return httptest.NewServer(mux)
 }
@@ -186,7 +186,7 @@ func TestRunWait(t *testing.T) {
 			getStatus: http.StatusOK,
 			getPhases: []string{"Ready"},
 			timeout:   time.Minute,
-			wantErr:   func(t *testing.T, err error) { assert.NoError(t, err) },
+			wantErr:   func(t *testing.T, err error) { t.Helper(); assert.NoError(t, err) },
 		},
 		{
 			name:      "failed phase returns FailedError",
@@ -194,6 +194,7 @@ func TestRunWait(t *testing.T) {
 			getPhases: []string{"Failed"},
 			timeout:   time.Minute,
 			wantErr: func(t *testing.T, err error) {
+				t.Helper()
 				var fe *wait.FailedError
 				require.ErrorAs(t, err, &fe)
 				assert.Contains(t, fe.Error(), "Failed phase")
@@ -204,6 +205,7 @@ func TestRunWait(t *testing.T) {
 			getStatus: http.StatusNotFound,
 			timeout:   time.Minute,
 			wantErr: func(t *testing.T, err error) {
+				t.Helper()
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "was deleted")
 			},
@@ -213,7 +215,7 @@ func TestRunWait(t *testing.T) {
 			getStatus: http.StatusOK,
 			getPhases: []string{"Provisioning"},
 			timeout:   40 * time.Millisecond,
-			wantErr:   func(t *testing.T, err error) { require.ErrorIs(t, err, wait.ErrTimeout) },
+			wantErr:   func(t *testing.T, err error) { t.Helper(); require.ErrorIs(t, err, wait.ErrTimeout) },
 		},
 	}
 
@@ -246,8 +248,10 @@ func captureStdout(t *testing.T, fn func()) string {
 	return string(out)
 }
 
+// Not parallel: captures global os.Stdout.
+//
+//nolint:paralleltest // mutates global os.Stdout; must run serially
 func TestRun_JSONEmitsCreatedInstanceWithoutWait(t *testing.T) {
-	// Not parallel: captures global os.Stdout.
 	srv := waitServer(t, http.StatusOK, "Pending")
 	defer srv.Close()
 

--- a/pkg/cli/instance/wait_test.go
+++ b/pkg/cli/instance/wait_test.go
@@ -211,6 +211,20 @@ func TestRunWait(t *testing.T) {
 			},
 		},
 		{
+			// A 401 makes the auth transport attempt a token refresh; when that
+			// fails it surfaces as ErrTokenRefresh, which must be terminal (not
+			// retried until timeout).
+			name:      "failed token refresh is terminal",
+			getStatus: http.StatusUnauthorized,
+			timeout:   time.Minute,
+			wantErr: func(t *testing.T, err error) {
+				t.Helper()
+				require.Error(t, err)
+				require.NotErrorIs(t, err, wait.ErrTimeout)
+				assert.Contains(t, err.Error(), "refresh failed")
+			},
+		},
+		{
 			name:      "times out when never terminal",
 			getStatus: http.StatusOK,
 			getPhases: []string{"Provisioning"},
@@ -227,6 +241,67 @@ func TestRunWait(t *testing.T) {
 			tc.wantErr(t, runWaitCreate(t, srv, Config{Pretty: true}, tc.timeout))
 		})
 	}
+}
+
+func TestRunWait_RetriesTransientFetchError(t *testing.T) {
+	t.Parallel()
+
+	// First poll returns 500 (transient), second returns Ready — the wait must
+	// retry rather than fail on the transient status.
+	var gets atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/providers/psmdb", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(psmdbProvider())
+	})
+	mux.HandleFunc("/v1/clusters/main/namespaces/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"metadata":{"name":"my-db"},"status":{"phase":"Pending"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if gets.Add(1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"metadata":{"name":"my-db"},"status":{"phase":"Ready"}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	assert.NoError(t, runWaitCreate(t, srv, Config{Pretty: true}, time.Minute))
+}
+
+func TestRun_JSONErrorsOnEmptyCreateBody(t *testing.T) {
+	t.Parallel()
+
+	// 201 with no parseable body must error rather than emit empty stdout.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/providers/psmdb", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(psmdbProvider())
+	})
+	mux.HandleFunc("/v1/clusters/main/namespaces/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	ic := NewInstanceCreator(Config{Pretty: false}, zap.NewNop().Sugar())
+	err := ic.Run(context.Background(), CreateOptions{
+		Name:      "my-db",
+		Namespace: "everest",
+		Provider:  "psmdb",
+		Cluster:   "main",
+	}, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unreadable response body")
 }
 
 // ---- create --json output contract ------------------------------------------

--- a/pkg/cli/wait/wait.go
+++ b/pkg/cli/wait/wait.go
@@ -55,6 +55,16 @@ func (e *FailedError) Error() string {
 	return e.Message
 }
 
+// RetryableError marks a transient poll error: instead of stopping, the waiter
+// reports it via Options.OnRetry and polls again on the next tick. Terminal
+// poll errors are returned bare.
+type RetryableError struct {
+	Err error
+}
+
+func (e *RetryableError) Error() string { return e.Err.Error() }
+func (e *RetryableError) Unwrap() error { return e.Err }
+
 // Condition classifies a fetched resource. Its message is surfaced via
 // Options.OnUpdate when Pending, or becomes the FailedError text when Failed.
 type Condition[T any] func(T) (Outcome, string)
@@ -65,15 +75,20 @@ type PollFunc[T any] func(ctx context.Context) (T, error)
 
 // Options tunes the waiter.
 type Options struct {
-	// Interval between polls. Internal knob (no CLI flag); the zero value means
-	// unset and falls back to DefaultInterval, so a bad value can't be typed.
+	// Interval between polls; the zero value falls back to DefaultInterval.
 	Interval time.Duration
-	// Timeout bounds the total wait and must be positive — the command layer
-	// rejects zero/negative.
+	// Timeout bounds the total wait. Zero or negative means no timeout — poll
+	// until Succeeded/Failed, a terminal poll error, or ctx cancellation —
+	// mirroring kubectl's --timeout=0 and Interval's zero-value behaviour. (The
+	// instance-create CLI still requires a positive --timeout via its own flag
+	// validation; this is only the package's self-defending default.)
 	Timeout time.Duration
 	// OnUpdate, if set, receives the Condition message on each Pending poll.
 	// Consecutive duplicates are suppressed so output advances only on change.
 	OnUpdate func(message string)
+	// OnRetry, if set, is called with each transient (RetryableError) poll error
+	// before the waiter polls again.
+	OnRetry func(err error)
 }
 
 // Until polls until cond returns Succeeded (nil), Failed (*FailedError), poll
@@ -85,9 +100,14 @@ func Until[T any](ctx context.Context, poll PollFunc[T], cond Condition[T], opts
 		interval = DefaultInterval
 	}
 
-	// Own timeout context so deadlineErr can tell a timeout from a Ctrl-C.
-	tctx, cancel := context.WithTimeout(ctx, opts.Timeout)
-	defer cancel()
+	// Own timeout context so deadlineErr can tell a timeout from a Ctrl-C. A
+	// zero/negative Timeout means "no timeout": poll against the parent ctx.
+	tctx := ctx
+	if opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		tctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+	}
 
 	var lastMsg string
 	first := true
@@ -106,13 +126,10 @@ func Until[T any](ctx context.Context, poll PollFunc[T], cond Condition[T], opts
 
 		inst, err := poll(tctx)
 		if err != nil {
-			// Report a cancellation/deadline as such, not a generic fetch failure.
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				if de := deadlineErr(ctx, tctx); de != nil {
-					return de
-				}
+			if done, rerr := classifyPollErr(ctx, tctx, err, opts.OnRetry); done {
+				return rerr
 			}
-			return err
+			continue
 		}
 
 		outcome, msg := cond(inst)
@@ -128,6 +145,27 @@ func Until[T any](ctx context.Context, poll PollFunc[T], cond Condition[T], opts
 			}
 		}
 	}
+}
+
+// classifyPollErr decides what to do with a poll error. It returns done=true
+// with the error to surface for a terminal failure (including a cancellation or
+// elapsed deadline), or done=false for a transient RetryableError — after
+// reporting it via onRetry — so the caller polls again.
+func classifyPollErr(parent, tctx context.Context, err error, onRetry func(error)) (bool, error) {
+	// A cancellation/deadline surfacing through poll is reported as such.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if de := deadlineErr(parent, tctx); de != nil {
+			return true, de
+		}
+	}
+	var re *RetryableError
+	if errors.As(err, &re) {
+		if onRetry != nil {
+			onRetry(re.Err)
+		}
+		return false, nil
+	}
+	return true, err
 }
 
 // deadlineErr returns context.Canceled if the parent was cancelled, ErrTimeout

--- a/pkg/cli/wait/wait.go
+++ b/pkg/cli/wait/wait.go
@@ -28,7 +28,7 @@ import (
 type Outcome int
 
 const (
-	//Resource is not in a terminal state yet; keep polling.
+	// Pending means the resource is not in a terminal state yet; keep polling.
 	Pending Outcome = iota
 	// Succeeded means the resource reached the desired terminal state.
 	Succeeded

--- a/pkg/cli/wait/wait.go
+++ b/pkg/cli/wait/wait.go
@@ -1,0 +1,145 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package wait is a resource-agnostic polling waiter shared by CLI commands
+// that block until a resource reaches a terminal state (e.g. instance create
+// --wait). Callers supply a PollFunc and a Condition.
+package wait
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Outcome is the classification a Condition assigns to one observation.
+type Outcome int
+
+const (
+	//Resource is not in a terminal state yet; keep polling.
+	Pending Outcome = iota
+	// Succeeded means the resource reached the desired terminal state.
+	Succeeded
+	// Failed means the resource reached a terminal failure state.
+	Failed
+)
+
+// DefaultInterval applies when Options.Interval is not positive.
+const DefaultInterval = 2 * time.Second
+
+// ErrTimeout is returned when the timeout elapses first. Callers map it to a
+// distinct exit code so scripts can tell a timeout apart from a real failure.
+var ErrTimeout = errors.New("timed out waiting for condition")
+
+// FailedError carries the reason a resource reached a terminal failure state.
+type FailedError struct {
+	Message string
+}
+
+func (e *FailedError) Error() string {
+	if e.Message == "" {
+		return "resource entered a failed state"
+	}
+	return e.Message
+}
+
+// Condition classifies a fetched resource. Its message is surfaced via
+// Options.OnUpdate when Pending, or becomes the FailedError text when Failed.
+type Condition[T any] func(T) (Outcome, string)
+
+// PollFunc fetches the current resource state. A non-nil error is terminal and
+// returned unchanged, so callers can stop early instead of waiting out the timeout.
+type PollFunc[T any] func(ctx context.Context) (T, error)
+
+// Options tunes the waiter.
+type Options struct {
+	// Interval between polls. Internal knob (no CLI flag); the zero value means
+	// unset and falls back to DefaultInterval, so a bad value can't be typed.
+	Interval time.Duration
+	// Timeout bounds the total wait and must be positive — the command layer
+	// rejects zero/negative.
+	Timeout time.Duration
+	// OnUpdate, if set, receives the Condition message on each Pending poll.
+	// Consecutive duplicates are suppressed so output advances only on change.
+	OnUpdate func(message string)
+}
+
+// Until polls until cond returns Succeeded (nil), Failed (*FailedError), poll
+// errors, the timeout elapses (ErrTimeout), or ctx is cancelled. It polls once
+// immediately, then on each tick.
+func Until[T any](ctx context.Context, poll PollFunc[T], cond Condition[T], opts Options) error {
+	interval := opts.Interval
+	if interval <= 0 {
+		interval = DefaultInterval
+	}
+
+	// Own timeout context so deadlineErr can tell a timeout from a Ctrl-C.
+	tctx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	defer cancel()
+
+	var lastMsg string
+	first := true
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if !first {
+			select {
+			case <-tctx.Done():
+				return deadlineErr(ctx, tctx)
+			case <-ticker.C:
+			}
+		}
+		first = false
+
+		inst, err := poll(tctx)
+		if err != nil {
+			// Report a cancellation/deadline as such, not a generic fetch failure.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				if de := deadlineErr(ctx, tctx); de != nil {
+					return de
+				}
+			}
+			return err
+		}
+
+		outcome, msg := cond(inst)
+		switch outcome {
+		case Succeeded:
+			return nil
+		case Failed:
+			return &FailedError{Message: msg}
+		case Pending:
+			if opts.OnUpdate != nil && msg != lastMsg {
+				lastMsg = msg
+				opts.OnUpdate(msg)
+			}
+		}
+	}
+}
+
+// deadlineErr returns context.Canceled if the parent was cancelled, ErrTimeout
+// if the deadline elapsed, or nil while tctx is still live.
+func deadlineErr(parent, tctx context.Context) error {
+	select {
+	case <-tctx.Done():
+		if parent.Err() != nil {
+			return parent.Err()
+		}
+		return ErrTimeout
+	default:
+		return nil
+	}
+}

--- a/pkg/cli/wait/wait_test.go
+++ b/pkg/cli/wait/wait_test.go
@@ -44,29 +44,28 @@ func phaseCond(phase string) (wait.Outcome, string) {
 func TestUntil_SucceedsImmediately(t *testing.T) {
 	t.Parallel()
 
-	var calls int32
+	var calls atomic.Int32
 	poll := func(_ context.Context) (string, error) {
-		atomic.AddInt32(&calls, 1)
+		calls.Add(1)
 		return "Ready", nil
 	}
 
-	err := wait.Until(context.Background(), poll,
-		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+	err := wait.Until(context.Background(), poll, phaseCond,
 		wait.Options{Interval: time.Millisecond, Timeout: time.Second},
 	)
 
 	require.NoError(t, err)
 	// Terminal on the very first observation — no ticker wait needed.
-	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	assert.Equal(t, int32(1), calls.Load())
 }
 
 func TestUntil_TransitionsThenSucceeds(t *testing.T) {
 	t.Parallel()
 
 	phases := []string{"Pending", "Provisioning", "Initializing", "Ready"}
-	var idx int32
+	var idx atomic.Int32
 	poll := func(_ context.Context) (string, error) {
-		i := atomic.AddInt32(&idx, 1) - 1
+		i := idx.Add(1) - 1
 		if int(i) >= len(phases) {
 			return phases[len(phases)-1], nil
 		}
@@ -74,8 +73,7 @@ func TestUntil_TransitionsThenSucceeds(t *testing.T) {
 	}
 
 	var updates []string
-	err := wait.Until(context.Background(), poll,
-		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+	err := wait.Until(context.Background(), poll, phaseCond,
 		wait.Options{
 			Interval: time.Millisecond,
 			Timeout:  2 * time.Second,
@@ -93,8 +91,7 @@ func TestUntil_FailedPhaseReturnsFailedError(t *testing.T) {
 
 	poll := func(_ context.Context) (string, error) { return "Failed", nil }
 
-	err := wait.Until(context.Background(), poll,
-		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+	err := wait.Until(context.Background(), poll, phaseCond,
 		wait.Options{Interval: time.Millisecond, Timeout: time.Second},
 	)
 
@@ -109,8 +106,7 @@ func TestUntil_TimeoutReturnsErrTimeout(t *testing.T) {
 	// Never terminal — always pending, so only the timeout can stop it.
 	poll := func(_ context.Context) (string, error) { return "Provisioning", nil }
 
-	err := wait.Until(context.Background(), poll,
-		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+	err := wait.Until(context.Background(), poll, phaseCond,
 		wait.Options{Interval: 5 * time.Millisecond, Timeout: 40 * time.Millisecond},
 	)
 
@@ -128,8 +124,7 @@ func TestUntil_ParentCancelReturnsContextCanceled(t *testing.T) {
 		cancel()
 	}()
 
-	err := wait.Until(ctx, poll,
-		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+	err := wait.Until(ctx, poll, phaseCond,
 		// Long timeout so the cancellation, not the deadline, is what stops us.
 		wait.Options{Interval: 5 * time.Millisecond, Timeout: 10 * time.Second},
 	)
@@ -142,46 +137,44 @@ func TestUntil_PollErrorIsTerminal(t *testing.T) {
 	t.Parallel()
 
 	sentinel := errors.New("instance \"my-mongo\" has been deleted")
-	var calls int32
+	var calls atomic.Int32
 	poll := func(_ context.Context) (string, error) {
-		atomic.AddInt32(&calls, 1)
+		calls.Add(1)
 		return "", sentinel
 	}
 
-	err := wait.Until(context.Background(), poll,
-		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+	err := wait.Until(context.Background(), poll, phaseCond,
 		wait.Options{Interval: time.Millisecond, Timeout: time.Second},
 	)
 
 	require.ErrorIs(t, err, sentinel)
 	// Returned on the first poll — not retried.
-	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	assert.Equal(t, int32(1), calls.Load())
 }
 
 func TestUntil_OnUpdateSuppressesDuplicates(t *testing.T) {
 	t.Parallel()
 
 	// Same pending phase repeatedly, then Ready — OnUpdate should fire once.
-	var idx int32
+	var idx atomic.Int32
 	poll := func(_ context.Context) (string, error) {
-		if atomic.AddInt32(&idx, 1) >= 4 {
+		if idx.Add(1) >= 4 {
 			return "Ready", nil
 		}
 		return "Provisioning", nil
 	}
 
-	var updates int32
-	err := wait.Until(context.Background(), poll,
-		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+	var updates atomic.Int32
+	err := wait.Until(context.Background(), poll, phaseCond,
 		wait.Options{
 			Interval: time.Millisecond,
 			Timeout:  time.Second,
-			OnUpdate: func(_ string) { atomic.AddInt32(&updates, 1) },
+			OnUpdate: func(_ string) { updates.Add(1) },
 		},
 	)
 
 	require.NoError(t, err)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&updates))
+	assert.Equal(t, int32(1), updates.Load())
 }
 
 func TestUntil_DefaultIntervalWhenUnset(t *testing.T) {
@@ -191,8 +184,7 @@ func TestUntil_DefaultIntervalWhenUnset(t *testing.T) {
 	// so this stays fast while covering the zero-interval branch.
 	poll := func(_ context.Context) (string, error) { return "Ready", nil }
 
-	err := wait.Until(context.Background(), poll,
-		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+	err := wait.Until(context.Background(), poll, phaseCond,
 		wait.Options{Timeout: time.Second},
 	)
 	require.NoError(t, err)

--- a/pkg/cli/wait/wait_test.go
+++ b/pkg/cli/wait/wait_test.go
@@ -1,0 +1,199 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wait_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
+)
+
+// phaseCond mirrors the real instance condition: Ready succeeds, Failed fails,
+// everything else pends.
+func phaseCond(phase string) (wait.Outcome, string) {
+	switch phase {
+	case "Ready":
+		return wait.Succeeded, "ready"
+	case "Failed":
+		return wait.Failed, "instance entered Failed phase"
+	default:
+		return wait.Pending, "phase: " + phase
+	}
+}
+
+func TestUntil_SucceedsImmediately(t *testing.T) {
+	t.Parallel()
+
+	var calls int32
+	poll := func(_ context.Context) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "Ready", nil
+	}
+
+	err := wait.Until(context.Background(), poll,
+		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+		wait.Options{Interval: time.Millisecond, Timeout: time.Second},
+	)
+
+	require.NoError(t, err)
+	// Terminal on the very first observation — no ticker wait needed.
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+func TestUntil_TransitionsThenSucceeds(t *testing.T) {
+	t.Parallel()
+
+	phases := []string{"Pending", "Provisioning", "Initializing", "Ready"}
+	var idx int32
+	poll := func(_ context.Context) (string, error) {
+		i := atomic.AddInt32(&idx, 1) - 1
+		if int(i) >= len(phases) {
+			return phases[len(phases)-1], nil
+		}
+		return phases[i], nil
+	}
+
+	var updates []string
+	err := wait.Until(context.Background(), poll,
+		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+		wait.Options{
+			Interval: time.Millisecond,
+			Timeout:  2 * time.Second,
+			OnUpdate: func(m string) { updates = append(updates, m) },
+		},
+	)
+
+	require.NoError(t, err)
+	// Three pending phases seen before Ready — each surfaced once, in order.
+	assert.Equal(t, []string{"phase: Pending", "phase: Provisioning", "phase: Initializing"}, updates)
+}
+
+func TestUntil_FailedPhaseReturnsFailedError(t *testing.T) {
+	t.Parallel()
+
+	poll := func(_ context.Context) (string, error) { return "Failed", nil }
+
+	err := wait.Until(context.Background(), poll,
+		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+		wait.Options{Interval: time.Millisecond, Timeout: time.Second},
+	)
+
+	var fe *wait.FailedError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, "instance entered Failed phase", fe.Message)
+}
+
+func TestUntil_TimeoutReturnsErrTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Never terminal — always pending, so only the timeout can stop it.
+	poll := func(_ context.Context) (string, error) { return "Provisioning", nil }
+
+	err := wait.Until(context.Background(), poll,
+		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+		wait.Options{Interval: 5 * time.Millisecond, Timeout: 40 * time.Millisecond},
+	)
+
+	require.ErrorIs(t, err, wait.ErrTimeout)
+}
+
+func TestUntil_ParentCancelReturnsContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	poll := func(_ context.Context) (string, error) { return "Provisioning", nil }
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	err := wait.Until(ctx, poll,
+		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+		// Long timeout so the cancellation, not the deadline, is what stops us.
+		wait.Options{Interval: 5 * time.Millisecond, Timeout: 10 * time.Second},
+	)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, wait.ErrTimeout)
+}
+
+func TestUntil_PollErrorIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("instance \"my-mongo\" has been deleted")
+	var calls int32
+	poll := func(_ context.Context) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "", sentinel
+	}
+
+	err := wait.Until(context.Background(), poll,
+		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+		wait.Options{Interval: time.Millisecond, Timeout: time.Second},
+	)
+
+	require.ErrorIs(t, err, sentinel)
+	// Returned on the first poll — not retried.
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+func TestUntil_OnUpdateSuppressesDuplicates(t *testing.T) {
+	t.Parallel()
+
+	// Same pending phase repeatedly, then Ready — OnUpdate should fire once.
+	var idx int32
+	poll := func(_ context.Context) (string, error) {
+		if atomic.AddInt32(&idx, 1) >= 4 {
+			return "Ready", nil
+		}
+		return "Provisioning", nil
+	}
+
+	var updates int32
+	err := wait.Until(context.Background(), poll,
+		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+		wait.Options{
+			Interval: time.Millisecond,
+			Timeout:  time.Second,
+			OnUpdate: func(_ string) { atomic.AddInt32(&updates, 1) },
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&updates))
+}
+
+func TestUntil_DefaultIntervalWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	// Immediate success means the (large) default interval is never waited on,
+	// so this stays fast while covering the zero-interval branch.
+	poll := func(_ context.Context) (string, error) { return "Ready", nil }
+
+	err := wait.Until(context.Background(), poll,
+		func(p string) (wait.Outcome, string) { return phaseCond(p) },
+		wait.Options{Timeout: time.Second},
+	)
+	require.NoError(t, err)
+}

--- a/pkg/cli/wait/wait_test.go
+++ b/pkg/cli/wait/wait_test.go
@@ -189,3 +189,47 @@ func TestUntil_DefaultIntervalWhenUnset(t *testing.T) {
 	)
 	require.NoError(t, err)
 }
+
+func TestUntil_RetryableIsRetriedNotTerminal(t *testing.T) {
+	t.Parallel()
+
+	// First two polls fail transiently, then Ready — the wait should keep going
+	// and report each transient error via OnRetry rather than stopping.
+	var calls atomic.Int32
+	poll := func(_ context.Context) (string, error) {
+		if calls.Add(1) < 3 {
+			return "", &wait.RetryableError{Err: errors.New("transient fetch failure")}
+		}
+		return "Ready", nil
+	}
+
+	var retries atomic.Int32
+	err := wait.Until(context.Background(), poll, phaseCond, wait.Options{
+		Interval: time.Millisecond,
+		Timeout:  time.Second,
+		OnRetry:  func(_ error) { retries.Add(1) },
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), calls.Load())
+	assert.Equal(t, int32(2), retries.Load())
+}
+
+func TestUntil_ZeroTimeoutMeansNoTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Timeout left unset (zero). A pending-then-ready poll must still succeed
+	// rather than time out immediately.
+	var calls atomic.Int32
+	poll := func(_ context.Context) (string, error) {
+		if calls.Add(1) < 2 {
+			return "Provisioning", nil
+		}
+		return "Ready", nil
+	}
+
+	err := wait.Until(context.Background(), poll, phaseCond, wait.Options{
+		Interval: time.Millisecond,
+	})
+	require.NoError(t, err)
+}

--- a/pkg/output/command.go
+++ b/pkg/output/command.go
@@ -41,6 +41,16 @@ func PrintError(err error, l *zap.SugaredLogger, prettyPrint bool) {
 	}
 }
 
+// PrintWarn formats and prints a warning, respecting pretty/JSON mode: the
+// emoji-styled line in pretty mode, the structured logger otherwise.
+func PrintWarn(msg string, l *zap.SugaredLogger, prettyPrint bool) {
+	if prettyPrint {
+		_, _ = fmt.Fprint(os.Stderr, Warn("%s", msg))
+	} else {
+		l.Warn(msg)
+	}
+}
+
 //nolint:gochecknoglobals
 var (
 	// Style is applied to the successful result.


### PR DESCRIPTION
Scripting a blocking create today means wrapping `instance status --watch` in a shell loop, which is awkward because --watch never exits on its own. This adds --wait so a create can block until the instance is actually ready.

With --wait the command polls until the instance reaches the Ready phase and exits 0, or exits non-zero if it hits the Failed phase, gets deleted, or the --timeout elapses. Exit codes are distinct so CI can tell the cases apart: 1 for a failed instance, 124 for a timeout (matching timeout(1)), and 130 when someone Ctrl-C's out. Cancelling only stops the wait -- the instance keeps provisioning server-side, and we say so on the way out.

Pretty mode streams progress a line at a time and prints the final status; --json stays quiet and emits a single instance object at the end. While here, `create --json` without --wait now emits the created object too, so the JSON contract no longer depends on whether --wait was passed.

The polling itself lives in a small reusable pkg/cli/wait helper (poll func + condition + timeout/exit-code handling) so backup create can share it later rather than growing a second copy that drifts.
closes #2580 