### PR TITLE
fix: arm64 server image ships an amd64 binary

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -182,6 +182,14 @@ jobs:
             CGO_ENABLED=0 GOOS=linux GOARCH=${{ matrix.arch }} make release
           fi
 
+      - name: Everest - verify binary architecture
+        run: |
+          got_arch=$(go version -m ./bin/everest | grep -o 'GOARCH=[a-z0-9]*' | head -1 | cut -d= -f2)
+          if [[ "$got_arch" != "${{ matrix.arch }}" ]]; then
+            echo "::error::bin/everest was built for '$got_arch', expected '${{ matrix.arch }}'"
+            exit 1
+          fi
+
       - name: Everest - setup docker build metadata
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         id: everest_meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,6 +499,14 @@ jobs:
             CGO_ENABLED=0 GOOS=linux GOARCH=${{ matrix.arch }} make release
           fi
 
+      - name: Everest - verify binary architecture
+        run: |
+          got_arch=$(go version -m ./bin/everest | grep -o 'GOARCH=[a-z0-9]*' | head -1 | cut -d= -f2)
+          if [[ "$got_arch" != "${{ matrix.arch }}" ]]; then
+            echo "::error::bin/everest was built for '$got_arch', expected '${{ matrix.arch }}'"
+            exit 1
+          fi
+
       - name: Everest - setup docker build metadata
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         id: everest_meta

--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,11 @@ charts:        ## Install Helm dependency charts for Everest CLI.
 
 ##@ Build
 export GOPRIVATE = github.com/percona,github.com/percona-platform,github.com/Percona-Lab
-export GOOS = $(shell go env GOHOSTOS)
+# GOOS and GOARCH default to the host but may be overridden from the
+# environment (e.g. GOARCH=arm64 make release) for cross-compilation.
+export GOOS ?= $(shell go env GOHOSTOS)
 export CGO_ENABLED = 0
-export GOARCH = $(shell go env GOHOSTARCH)
+export GOARCH ?= $(shell go env GOHOSTARCH)
 
 # Everest API server
 SERVER_LD_FLAGS = -X 'github.com/percona/everest/pkg/version.Version=$(RELEASE_VERSION)' \
@@ -108,10 +110,11 @@ SERVER_BUILD_TAGS =
 SERVER_GC_FLAGS =
 
 # Helper target to build Everest API server binary.
-# CGO_ENABLED, GOOS and GOARCH are set explicitly because Everest API server is running inside a container only.
+# GOOS is forced to linux because the Everest API server only runs inside a
+# container. GOARCH is taken from the environment (defaulting to the host
+# arch) so release builds can produce a binary per target architecture.
 .PHONY: build-server
 build-server-helper: GOOS = linux
-build-server-helper: GOARCH = amd64
 build-server-helper: $(LOCALBIN)
 # We need to ensure that /public/dist/index.html exists before building Everest
 # API server because it's embedded into the binary and missing file will cause


### PR DESCRIPTION
Fixes #2603

### Problem

The arm64 variant of `ghcr.io/openeverest/openeverest` contains an x86-64 `everest-api` binary, crashing on arm64 hosts with `exec /everest-api: exec format error`.

### Root cause

The release workflows pass the target arch as an environment variable (`GOARCH=${{ matrix.arch }} make release`), but GNU Make file assignments override environment variables. The Makefile both globally assigned `export GOARCH = $(shell go env GOHOSTARCH)` and hardcoded `build-server-helper: GOARCH = amd64`, so the server binary was **always compiled for amd64** — even in the arm64 release job running on a native arm runner (the job log even prints `Building Everest API server for linux/amd64`). The Dockerfile then copied that prebuilt amd64 binary into the image tagged `linux/arm64`, and `imagetools create` merged it into a multi-arch manifest whose arm64 variant carries an x86-64 payload.

The `everestctl` image and CLI release binaries are not affected (they set GOOS/GOARCH via `TARGETARCH` build args / shell prefixes).

### Fix

- **Makefile:** make `GOOS`/`GOARCH` overridable from the environment (`?=`) and drop the hardcoded `GOARCH = amd64` on `build-server-helper` (`GOOS` stays forced to `linux` since the server only runs in containers).
- **release.yml / release-v2.yml:** add a guard step after the binary build that fails the job if `bin/everest`'s embedded `GOARCH` doesn't match `matrix.arch`, so this class of silent breakage can't ship again.