### PR TITLE
fix: arm64 server image ships amd64 binaries (release-2.0)

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -182,6 +182,16 @@ jobs:
             CGO_ENABLED=0 GOOS=linux GOARCH=${{ matrix.arch }} make release
           fi
 
+      - name: Everest - verify binary architecture
+        run: |
+          for bin in ./bin/everest ./bin/manager; do
+            got_arch=$(go version -m "$bin" | grep -o 'GOARCH=[a-z0-9]*' | head -1 | cut -d= -f2)
+            if [[ "$got_arch" != "${{ matrix.arch }}" ]]; then
+              echo "::error::$bin was built for '$got_arch', expected '${{ matrix.arch }}'"
+              exit 1
+            fi
+          done
+
       - name: Everest - setup docker build metadata
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         id: everest_meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,6 +427,16 @@ jobs:
             CGO_ENABLED=0 GOOS=linux GOARCH=${{ matrix.arch }} make release
           fi
 
+      - name: Everest - verify binary architecture
+        run: |
+          for bin in ./bin/everest ./bin/manager; do
+            got_arch=$(go version -m "$bin" | grep -o 'GOARCH=[a-z0-9]*' | head -1 | cut -d= -f2)
+            if [[ "$got_arch" != "${{ matrix.arch }}" ]]; then
+              echo "::error::$bin was built for '$got_arch', expected '${{ matrix.arch }}'"
+              exit 1
+            fi
+          done
+
       - name: Everest - setup docker build metadata
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         id: everest_meta

--- a/Makefile
+++ b/Makefile
@@ -141,9 +141,11 @@ charts:        ## Install Helm dependency charts for Everest CLI.
 
 ##@ Build
 export GOPRIVATE = github.com/percona,github.com/percona-platform,github.com/Percona-Lab
-export GOOS = $(shell go env GOHOSTOS)
+# GOOS and GOARCH default to the host but may be overridden from the
+# environment (e.g. GOARCH=arm64 make release) for cross-compilation.
+export GOOS ?= $(shell go env GOHOSTOS)
 export CGO_ENABLED = 0
-export GOARCH = $(shell go env GOHOSTARCH)
+export GOARCH ?= $(shell go env GOHOSTARCH)
 
 # Everest API server
 SERVER_LD_FLAGS = -X 'github.com/openeverest/openeverest/v2/pkg/version.Version=$(RELEASE_VERSION)' \
@@ -154,10 +156,11 @@ SERVER_BUILD_TAGS =
 SERVER_GC_FLAGS =
 
 # Helper target to build Everest API server binary.
-# CGO_ENABLED, GOOS and GOARCH are set explicitly because Everest API server is running inside a container only.
+# GOOS is forced to linux because the Everest API server only runs inside a
+# container. GOARCH is taken from the environment (defaulting to the host
+# arch) so release builds can produce a binary per target architecture.
 .PHONY: build-server
 build-server-helper: GOOS = linux
-build-server-helper: GOARCH = amd64
 build-server-helper: $(LOCALBIN)
 # We need to ensure that /public/dist/index.html exists before building Everest
 # API server because it's embedded into the binary and missing file will cause
@@ -232,9 +235,11 @@ CONTROLLER_BUILD_TAGS =
 CONTROLLER_GC_FLAGS =
 
 # Helper target to build the Everest controller manager binary.
+# GOOS is forced to linux because the controller only runs inside a container.
+# GOARCH is taken from the environment (defaulting to the host arch) so
+# release builds can produce a binary per target architecture.
 .PHONY: build-controller-helper
 build-controller-helper: GOOS = linux
-build-controller-helper: GOARCH = amd64
 build-controller-helper: $(LOCALBIN)
 	$(info Building Everest controller manager for $(GOOS)/$(GOARCH) with CGO_ENABLED=$(CGO_ENABLED))
 	go build -v $(CONTROLLER_BUILD_TAGS) $(CONTROLLER_GC_FLAGS) -ldflags "$(CONTROLLER_LD_FLAGS)" -o $(LOCALBIN)/manager ./cmd/controller


### PR DESCRIPTION
Same fix as #2605, applied to `release-2.0`. Part of #2603.

### Problem

The arm64 variant of `ghcr.io/openeverest/openeverest` contains x86-64 binaries, crashing on arm64 hosts with `exec /everest-api: exec format error`.

### Root cause

The release workflows pass the target arch as an environment variable (`GOARCH=${{ matrix.arch }} make release`), but GNU Make file assignments override environment variables. The Makefile globally assigned `export GOARCH = $(shell go env GOHOSTARCH)` and hardcoded `build-server-helper: GOARCH = amd64` — and on this branch also `build-controller-helper: GOARCH = amd64` — so both `bin/everest` and `bin/manager` (which also ships in the server image here) were **always compiled for amd64**, even in the arm64 release job running on a native arm runner. The Dockerfile then copied those prebuilt amd64 binaries into the image tagged `linux/arm64`, and `imagetools create` merged it into a multi-arch manifest whose arm64 variant carries x86-64 payloads.

The `everestctl` image and CLI release binaries are not affected (they set GOOS/GOARCH via `TARGETARCH` build args / shell prefixes).

### Fix

- **Makefile:** make `GOOS`/`GOARCH` overridable from the environment (`?=`) and drop the hardcoded `GOARCH = amd64` on `build-server-helper` and `build-controller-helper` (`GOOS` stays forced to `linux` since these only run in containers).
- **release.yml / release-v2.yml:** add a guard step after the binary build that fails the job if `bin/everest`'s or `bin/manager`'s embedded `GOARCH` doesn't match `matrix.arch`, so this class of silent breakage can't ship again.