### PR TITLE
fix: everestctl SIGSEGV resolving OCI chart dependencies

### DIFF
--- a/pkg/cli/helm/installer.go
+++ b/pkg/cli/helm/installer.go
@@ -35,6 +35,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -360,10 +361,17 @@ func everestctlCacheDir() (string, error) {
 
 // Runs `helm dependency update` in the chart directory.
 func buildChartDeps(chartDir string) error {
+	registryClient, err := registry.NewClient(
+		registry.ClientOptCredentialsFile(settings.RegistryConfig),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create registry client: %w", err)
+	}
 	man := &downloader.Manager{
 		Out:              io.Discard,
 		ChartPath:        chartDir,
 		Getters:          getter.All(settings),
+		RegistryClient:   registryClient,
 		RepositoryConfig: settings.RepositoryConfig,
 		RepositoryCache:  settings.RepositoryCache,
 	}


### PR DESCRIPTION
### Problem

After the recent [helm chart upgrade](https://github.com/openeverest/openeverest/commit/608db8fd44126b3746b74c4ef997dc7c64175615), API and CLI test CI jobs fail: `everestctl install` crashes with a nil pointer dereference in `helm.sh/helm/v3/pkg/registry.(*Client).Tags` while building the dev chart's dependencies (e.g. on #2606).

### Root cause

The everest chart now [declares an OCI dependency](https://github.com/openeverest/helm-charts/pull/72) — `plugin-hub` from `oci://ghcr.io/openeverest/charts`. When everestctl installs from a chart directory, `buildChartDeps` runs helm's dependency update (`downloader.Manager.Update()`), whose resolver must list tags on the OCI registry to resolve the `0.1.*` version wildcard. The `downloader.Manager` was created without a `RegistryClient`, so helm invoked `Tags()` on a nil `*registry.Client` → SIGSEGV. HTTP repo dependencies never hit this code path, which is why it only surfaced now.

### Fix

Create a `registry.Client` (backed by the standard helm registry config, so `helm registry login` credentials are honored) and set it on the `downloader.Manager` in `buildChartDeps`.