### PR TITLE
Fix provider-runtime reporting readiness before manager is ready

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.1.0
 	github.com/oapi-codegen/runtime v1.6.0
-	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260802124859-30258bdcf192
+	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260808040649-ebf9682bfe5a
 	github.com/operator-framework/api v0.45.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20260429065444-70caa52c384a
 	github.com/rodaine/table v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -847,8 +847,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260802124859-30258bdcf192 h1:dZxv7C7fgRqwENSt4zTlNFlvbv7XsW/D2rzqDw1fQEU=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260802124859-30258bdcf192/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260808040649-ebf9682bfe5a h1:B3Nj9AdAbEhmG+Q5M6mLmj7Dt8we4ll7MflWtMjlg04=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260808040649-ebf9682bfe5a/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
 github.com/operator-framework/api v0.45.0 h1:hkROwtsLH3oszp4IW+WsXEFSDgveSahHI7DKStOtrUI=
 github.com/operator-framework/api v0.45.0/go.mod h1:IQ4uuISTiIhV09oAurJSGD4KabayhY5nV6k1XmA235M=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/provider-runtime/reconciler/provider.go
+++ b/provider-runtime/reconciler/provider.go
@@ -18,11 +18,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -278,37 +281,18 @@ func (r *ProviderReconciler) setupServer(p providerAdapter) error {
 
 // Start starts the reconciler and server (blocking).
 func (r *ProviderReconciler) Start(ctx context.Context) error {
-	// Start server if configured
-	if r.server != nil {
-		r.server.SetClient(r.Client)
-		go func() {
-			if err := r.server.Start(ctx); err != nil {
-				log.FromContext(ctx).Error(err, "Server error")
-			}
-		}()
-		// Mark server as ready once manager is ready
-		r.server.SetReady(true)
+	if err := r.startServer(ctx); err != nil {
+		return err
 	}
-
 	return r.manager.Start(ctx)
 }
 
 // StartWithSignalHandler starts the reconciler and server with OS signal handling.
 func (r *ProviderReconciler) StartWithSignalHandler() error {
 	ctx := ctrl.SetupSignalHandler()
-
-	// Start server if configured
-	if r.server != nil {
-		r.server.SetClient(r.Client)
-		go func() {
-			if err := r.server.Start(ctx); err != nil {
-				log.FromContext(ctx).Error(err, "Server error")
-			}
-		}()
-		// Mark server as ready once manager is ready
-		r.server.SetReady(true)
+	if err := r.startServer(ctx); err != nil {
+		return err
 	}
-
 	return r.manager.Start(ctx)
 }
 
@@ -540,6 +524,73 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 
 	logger.Info("Reconciliation complete", "phase", in.Status.Phase)
 	return reconcile.Result{}, nil
+}
+
+// leaderElectionFree marks a Runnable as one that must run on every replica,
+// not only the elected leader: readiness is a per-pod property.
+type leaderElectionFree struct{ manager.Runnable }
+
+func (leaderElectionFree) NeedLeaderElection() bool { return false }
+
+// startServer wires the validation server into the manager lifecycle. It is a
+// no-op when no server is configured.
+//
+// Readiness is gated on the manager's caches: the server is marked ready from a
+// manager Runnable only after the informers the validation path reads (Instance
+// and Provider) have synced, so /readyz reports ready only once the cache-backed
+// client is usable. This keeps probes from routing validation traffic to the
+// server before it can serve it. Readiness is cleared again on shutdown.
+//
+// The Runnable is wrapped in leaderElectionFree so it runs on every replica, not
+// only the elected leader. Must be called before manager.Start.
+func (r *ProviderReconciler) startServer(ctx context.Context) error {
+	if r.server == nil {
+		return nil
+	}
+
+	r.server.SetClient(r.Client)
+	go func() {
+		if err := r.server.Start(ctx); err != nil {
+			log.FromContext(ctx).Error(err, "Server error")
+		}
+	}()
+
+	return r.manager.Add(leaderElectionFree{manager.RunnableFunc(func(runnableCtx context.Context) error {
+		// Report ready only once the informers the validation path reads have
+		// synced, so the cache-backed client is usable before /readyz turns
+		// green. Stay not-ready if the context is cancelled first (shutdown).
+		for _, obj := range []client.Object{&v1alpha1.Instance{}, &v1alpha1.Provider{}} {
+			if !r.waitForCacheSync(runnableCtx, obj) {
+				return nil
+			}
+		}
+		r.server.SetReady(true)
+		<-runnableCtx.Done()
+		r.server.SetReady(false)
+		return nil
+	})})
+}
+
+// waitForCacheSync blocks until the informer for obj has been built and synced,
+// returning true on success or false if ctx is cancelled first. GetInformer
+// returns an error while the API server is unreachable, so it is retried with a
+// short backoff to tolerate a transient blip at startup rather than latching
+// not-ready until the process restarts.
+func (r *ProviderReconciler) waitForCacheSync(ctx context.Context, obj client.Object) bool {
+	for {
+		informer, err := r.manager.GetCache().GetInformer(ctx, obj)
+		if err == nil {
+			return toolscache.WaitForCacheSync(ctx.Done(), informer.HasSynced)
+		}
+		// The API server can be briefly unreachable at startup; retry until it
+		// is reachable (controller-runtime logs the underlying failure) or the
+		// context is cancelled.
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(time.Second):
+		}
+	}
 }
 
 func (r *ProviderReconciler) handleDeletion(

--- a/provider-runtime/reconciler/readiness_test.go
+++ b/provider-runtime/reconciler/readiness_test.go
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
+	"github.com/openeverest/openeverest/v2/provider-runtime/server"
+)
+
+// readinessTestProvider is a no-op provider used to construct a reconciler.
+type readinessTestProvider struct{}
+
+func (p *readinessTestProvider) Name() string                       { return "readiness-test" }
+func (p *readinessTestProvider) Types() func(*runtime.Scheme) error { return nil }
+func (p *readinessTestProvider) Validate(*controller.Context) error { return nil }
+func (p *readinessTestProvider) Sync(*controller.Context) error     { return nil }
+func (p *readinessTestProvider) Cleanup(*controller.Context) error  { return nil }
+func (p *readinessTestProvider) Status(*controller.Context) (controller.Status, error) {
+	return controller.Status{}, nil
+}
+
+// unreachableKubeconfig points at a port with nothing listening, so the
+// manager's caches can never sync.
+const unreachableKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://127.0.0.1:59999
+contexts:
+- name: c
+  context:
+    cluster: c
+    user: u
+current-context: c
+users:
+- name: u
+  user: {}
+`
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close() //nolint:errcheck
+	addr, ok := l.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	return addr.Port
+}
+
+func statusCode(url string) int {
+	resp, err := http.Get(url) //nolint:noctx,gosec
+	if err != nil {
+		return -1
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	return resp.StatusCode
+}
+
+// TestServerReadinessGatedOnManager is a regression test for #2598.
+//
+// The reconciler's validation server must not report ready before the manager's
+// caches have synced (before the fix, SetReady(true) ran before manager.Start,
+// so /readyz returned 200 immediately and /validate could be called against a
+// not-yet-usable cache-backed client).
+//
+// Pointing the manager at an unreachable API server keeps its caches from ever
+// syncing, so a correctly gated /readyz must never return 200, while /healthz
+// still becomes OK because the HTTP server itself is up.
+func TestServerReadinessGatedOnManager(t *testing.T) {
+	dir := t.TempDir()
+	kc := filepath.Join(dir, "kubeconfig")
+	require.NoError(t, os.WriteFile(kc, []byte(unreachableKubeconfig), 0o600))
+	t.Setenv("KUBECONFIG", kc)
+
+	port := freePort(t)
+	ctx := t.Context()
+
+	r, err := New(ctx, &readinessTestProvider{},
+		WithServer(server.ServerConfig{Port: port}),
+		WithMetrics("0"),
+	)
+	require.NoError(t, err)
+
+	go func() { _ = r.Start(ctx) }()
+
+	base := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// The HTTP server comes up even though the manager cannot sync.
+	require.Eventually(t, func() bool {
+		return statusCode(base+"/healthz") == http.StatusOK
+	}, 3*time.Second, 20*time.Millisecond, "server did not start listening")
+
+	// Readiness must stay false for the whole observation window because the
+	// manager's caches never sync.
+	require.Never(t, func() bool {
+		return statusCode(base+"/readyz") == http.StatusOK
+	}, time.Second, 50*time.Millisecond, "/readyz reported ready before the manager was ready")
+}

--- a/provider-runtime/server/server.go
+++ b/provider-runtime/server/server.go
@@ -118,7 +118,9 @@ func NewServer(config ServerConfig, validator ValidatorFunc) *Server {
 	}
 }
 
-// SetClient sets the Kubernetes client (called by reconciler after manager is ready).
+// SetClient sets the Kubernetes client. The client is wired before the manager
+// starts; readiness (see SetReady) is what gates traffic until the manager's
+// caches have synced and the client is usable.
 func (s *Server) SetClient(c client.Client) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/provider-runtime/server/server_test.go
+++ b/provider-runtime/server/server_test.go
@@ -1,0 +1,79 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// freePort returns an available localhost TCP port.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close() //nolint:errcheck
+	addr, ok := l.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	return addr.Port
+}
+
+// statusCode issues a GET and returns the status code, or -1 if the request
+// could not be made (e.g. the listener is not up yet).
+func statusCode(url string) int {
+	resp, err := http.Get(url) //nolint:noctx,gosec
+	if err != nil {
+		return -1
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	return resp.StatusCode
+}
+
+// TestServerReadinessEndpoint verifies that /readyz reflects the readiness flag
+// set via SetReady, while /healthz is always OK once the server is listening.
+func TestServerReadinessEndpoint(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	srv := NewServer(ServerConfig{Port: port}, nil)
+
+	ctx := t.Context()
+	go func() { _ = srv.Start(ctx) }()
+
+	base := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// Wait for the listener to come up. /healthz is independent of readiness.
+	require.Eventually(t, func() bool {
+		return statusCode(base+"/healthz") == http.StatusOK
+	}, 3*time.Second, 20*time.Millisecond, "server did not start listening")
+
+	// Before SetReady(true): server is healthy but not ready.
+	assert.Equal(t, http.StatusServiceUnavailable, statusCode(base+"/readyz"))
+	assert.Equal(t, http.StatusOK, statusCode(base+"/healthz"))
+
+	// After SetReady(true): ready.
+	srv.SetReady(true)
+	assert.Equal(t, http.StatusOK, statusCode(base+"/readyz"))
+
+	// After SetReady(false): not ready again.
+	srv.SetReady(false)
+	assert.Equal(t, http.StatusServiceUnavailable, statusCode(base+"/readyz"))
+}


### PR DESCRIPTION
## What

Gates the provider-runtime validation server's readiness on the manager's caches being synced, instead of marking it ready before `manager.Start()`.

Fixes #2598.

## Why

`Start()` / `StartWithSignalHandler()` called `server.SetReady(true)` before the blocking `manager.Start(ctx)`. As a result `/readyz` returned 200 before the controller manager (and its cache-backed client) were up. A probe or automation that waits on `/readyz` and then creates an Instance could reach `/validate` before the client could serve reads, and the error surfaced as a validation denial (`allowed: false`) rather than being kept away from a not-ready endpoint.

## How

- Extracted the server startup into a single `startServer` helper, removing the duplicated block across `Start` and `StartWithSignalHandler`.
- Readiness is now set from a `manager.Runnable`. It waits for the informers the validation path reads — `Instance` and `Provider` — to sync before calling `SetReady(true)`, and clears it again on shutdown.
- The Runnable is wrapped in `leaderElectionFree` so it runs on every replica rather than only the elected leader. Readiness is a per-pod property: a plain `manager.RunnableFunc` lands in controller-runtime's leader-election group, which would leave every non-leader replica permanently not-ready — pulled out of the Service that fronts `/validate`, and unable to complete a rollout — the day a provider enables leader election.

Two notes on the approach:

- A plain `mgr.GetCache().WaitForCacheSync(ctx)` is not enough: at the time the manager starts its runnables no informer has been requested yet, so it returns `true` vacuously and readiness is not actually gated. Waiting on specific informers avoids that.
- `GetInformer` returns an error while the API server is unreachable, so it is retried with a short backoff; otherwise a transient blip at startup would leave the server not-ready until the process restarts.

Out of scope: `handleValidation` currently returns infrastructure errors as `allowed: false`. That is a separate concern and can be addressed in its own issue.

## Testing

- `provider-runtime/server/server_test.go` — `/readyz` reflects `SetReady`, `/healthz` is independent of readiness.
- `provider-runtime/reconciler/readiness_test.go` — regression test: with an unreachable API server the caches never sync, so `/readyz` never reports ready while `/healthz` does. Fails against the previous behavior and passes with this change.

`go test ./provider-runtime/...` passes, including `-race`. Copyright headers verified with `make copyright-check`.
