### PR TITLE
chore: handle ignored errors on defer resp.Body.Close()/Sync() (#2109)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,8 +38,16 @@ const (
 
 func main() {
 	logger := logger.MustInitLogger(true, "everest")
-	defer logger.Sync() //nolint:errcheck
 	l := logger.Sugar()
+	// Capture logger/l by value at defer-registration time so this syncs the
+	// originally initialized logger, even though both are reassigned below.
+	// Sync() commonly returns EINVAL on stdout/stderr/pipes; the warn-log on
+	// shutdown here is intentional and expected.
+	defer func(logger *zap.Logger, l *zap.SugaredLogger) {
+		if err := logger.Sync(); err != nil {
+			l.Warnf("failed to sync logger: %s", err)
+		}
+	}(logger, l)
 
 	// This is required because controller-runtime requires a logger
 	// to be set within 30 seconds of the program initialization.

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -67,7 +67,11 @@ func (e *EverestServer) report(ctx context.Context, baseURL string, data Telemet
 		e.l.Error(errors.Join(err, errors.New("failed to send telemetry request")))
 		return err
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			e.l.Warnf("failed to close telemetry response body: %s", err)
+		}
+	}()
 	if resp.StatusCode != http.StatusOK {
 		e.l.Info("Telemetry service responded with http status ", resp.StatusCode)
 	}

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+
+	"github.com/percona/everest/pkg/logger"
 )
 
 // ProviderConfig contains the configuration of an OIDC provider.
@@ -67,7 +69,13 @@ func NewProviderConfig(ctx context.Context, issuer string) (ProviderConfig, erro
 	if err != nil {
 		return ProviderConfig{}, err
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer func() {
+		// NewProviderConfig has no scoped logger available (no receiver/ctx/param logger),
+		// so the package-global accessor is used here deliberately.
+		if err := resp.Body.Close(); err != nil {
+			logger.GetLogger().Warnf("failed to close OIDC provider config response body: %s", err)
+		}
+	}()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/version_service/client.go
+++ b/pkg/version_service/client.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	everestv1alpha1 "github.com/percona/everest-operator/api/everest/v1alpha1"
+	"github.com/percona/everest/pkg/logger"
 )
 
 const (
@@ -90,7 +91,13 @@ func (c *versionServiceClient) GetSupportedEngineVersions(ctx context.Context, o
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not retrieve version response"))
 	}
-	defer res.Body.Close() //nolint:errcheck
+	defer func() {
+		// versionServiceClient has no logger field and this method has no scoped
+		// logger available, so the package-global accessor is used here deliberately.
+		if err := res.Body.Close(); err != nil {
+			logger.GetLogger().Warnf("failed to close version response body: %s", err)
+		}
+	}()
 
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("invalid response from version service endpoint http %d", res.StatusCode)
@@ -151,7 +158,13 @@ func (c *versionServiceClient) GetEverestMetadata(ctx context.Context) (*percona
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not retrieve Everest metadata"))
 	}
-	defer res.Body.Close() //nolint:errcheck
+	defer func() {
+		// versionServiceClient has no logger field and this method has no scoped
+		// logger available, so the package-global accessor is used here deliberately.
+		if err := res.Body.Close(); err != nil {
+			logger.GetLogger().Warnf("failed to close Everest metadata response body: %s", err)
+		}
+	}()
 
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("invalid response from Everest metadata endpoint http %d", res.StatusCode)


### PR DESCRIPTION
Closes #2109.

Replaces the `//nolint:errcheck` suppressions on `defer resp.Body.Close()` / `logger.Sync()` with deferred closures that check and log the error at warn level.

**Files**
- `cmd/main.go` — `logger.Sync()` warn-logged; the closure captures `logger`/`l` by value at defer-registration time so it syncs the originally initialized logger. Note: `Sync()` commonly returns `EINVAL` on stdout/stderr/pipes, so the shutdown warning is expected/by-design.
- `internal/server/telemetry.go` — `resp.Body.Close()` via the injected receiver logger (`e.l`).
- `pkg/oidc/oidc.go` — `resp.Body.Close()` via the package logger (`NewProviderConfig` has no receiver/ctx/param logger in scope; documented inline).
- `pkg/version_service/client.go` — `res.Body.Close()` (x2) via the package logger (`versionServiceClient` has no logger field; documented inline).

**Verification**
- `go build ./...`, `go vet`, and `go test` (`./cmd`, `./pkg/oidc`, `./pkg/version_service`, `./internal/server`) all pass.
- `golangci-lint run ./cmd ./pkg/oidc ./pkg/version_service` reports 0 issues.

Scoped intentionally to the errcheck fix — threading a logger through the `oidc`/`version_service` call chains would be a signature-changing refactor across multiple callers and is left out of this chore.