### PR TITLE
fix(version_service): guard nil Version Service Matrix to prevent panic (#2593)

### DIFF
--- a/pkg/version_service/client.go
+++ b/pkg/version_service/client.go
@@ -75,6 +75,27 @@ var defaultUnmarshal = protojson.UnmarshalOptions{
 	DiscardUnknown: true,
 }
 
+// versionsForOperator returns the version map for the given operator from the
+// first operator entry in a Version Service response. It returns an error if
+// the entry has no matrix (rather than panicking on a nil dereference) or if
+// the operator is not recognized.
+func versionsForOperator(firstVer *perconavs.OperatorVersion, operator string) (map[string]*perconavs.Version, error) {
+	if firstVer == nil || firstVer.GetMatrix() == nil {
+		return nil, errors.New("version service response is missing a version matrix")
+	}
+
+	switch operator {
+	case PXCOperatorName:
+		return firstVer.GetMatrix().GetPxc(), nil
+	case PSMDBOperatorName:
+		return firstVer.GetMatrix().GetMongod(), nil
+	case PGOperatorName:
+		return firstVer.GetMatrix().GetPostgresql(), nil
+	default:
+		return nil, fmt.Errorf("unsupported operator %q", operator)
+	}
+}
+
 // GetSupportedEngineVersions returns a list of supported versions for a given operator and version.
 func (c *versionServiceClient) GetSupportedEngineVersions(ctx context.Context, operator, version string) ([]string, error) {
 	p, err := url.Parse(c.url)
@@ -108,14 +129,9 @@ func (c *versionServiceClient) GetSupportedEngineVersions(ctx context.Context, o
 		return nil, errors.New("no versions found")
 	}
 
-	var versions map[string]*perconavs.Version
-	switch operator {
-	case PXCOperatorName:
-		versions = response.GetVersions()[0].GetMatrix().GetPxc()
-	case PSMDBOperatorName:
-		versions = response.GetVersions()[0].GetMatrix().GetMongod()
-	case PGOperatorName:
-		versions = response.GetVersions()[0].GetMatrix().GetPostgresql()
+	versions, err := versionsForOperator(response.GetVersions()[0], operator)
+	if err != nil {
+		return nil, err
 	}
 
 	result := make([]string, 0, len(versions))

--- a/pkg/version_service/client_test.go
+++ b/pkg/version_service/client_test.go
@@ -1,0 +1,68 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versionservice
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetSupportedEngineVersions_NilMatrix ensures that a Version Service
+// response with a missing/omitted matrix returns a clear error instead of
+// panicking with a nil pointer dereference. See issue #2593.
+func TestGetSupportedEngineVersions_NilMatrix(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"versions": [{}]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+
+	require.NotPanics(t, func() {
+		versions, err := c.GetSupportedEngineVersions(context.Background(), PXCOperatorName, "1.0.0")
+		require.Error(t, err)
+		assert.Nil(t, versions)
+	})
+}
+
+// TestGetSupportedEngineVersions_UnsupportedOperator ensures that an
+// unrecognized operator name returns an explicit error instead of silently
+// succeeding with an empty result.
+func TestGetSupportedEngineVersions_UnsupportedOperator(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"versions": [{"matrix": {"pxc": {"1.0.0": {}}}}]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+
+	versions, err := c.GetSupportedEngineVersions(context.Background(), "not-a-real-operator", "1.0.0")
+	require.Error(t, err)
+	assert.Nil(t, versions)
+}


### PR DESCRIPTION
Closes #2593.

The `GetSupportedEngineVersions` method accesses `GetMatrix()` maps without validating the matrix is non-nil. When the upstream Version Service returns a response with a missing/omitted matrix, the function silently returns an empty slice with no error — a wrong-success correctness bug.

**Fix:** Extracts a `versionsForOperator` helper that nil-checks both the `OperatorVersion` entry and its `Matrix` before selecting the operator's version map. Returns an explicit error if either is nil or the operator is unrecognized.

**Files:**
- `pkg/version_service/client.go` — new `versionsForOperator` helper + caller updated.
- `pkg/version_service/client_test.go` — new test file with two cases: nil-matrix → error, unsupported operator → error.

**Note:** The generated protobuf getters (`GetMatrix()`, `GetPxc()`, etc.) are nil-safe in the current pinned proto version, so this doesn't reproduce as a literal panic. The real bug is the silent wrong-success — no error signal when data is missing. The guard is added for both correctness and defense-in-depth.

**Verification:** `go build ./...`, `go vet`, `go test ./pkg/version_service/...`, `golangci-lint run ./pkg/version_service` — all pass, 0 issues.