### PR TITLE
fix(server): add panic recovery middleware to prevent server crash on handler panic (#2544)

### DIFF
--- a/internal/server/everest.go
+++ b/internal/server/everest.go
@@ -111,6 +111,7 @@ func NewEverestServer(ctx context.Context, c *config.EverestConfig, l *zap.Sugar
 	}
 
 	echoServer := echo.New()
+	echoServer.Use(echomiddleware.Recover())
 	echoServer.Use(echomiddleware.RateLimiter(echomiddleware.NewRateLimiterMemoryStore(rate.Limit(c.APIRequestsRateLimit))))
 	middleware, store := sessionRateLimiter(c.CreateSessionRateLimit)
 	echoServer.Use(middleware)

--- a/internal/server/middlewares_test.go
+++ b/internal/server/middlewares_test.go
@@ -24,11 +24,13 @@ package server
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
 
 	"github.com/labstack/echo/v4"
+	echomiddleware "github.com/labstack/echo/v4/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -39,6 +41,29 @@ import (
 	everestv1alpha1 "github.com/percona/everest-operator/api/everest/v1alpha1"
 	"github.com/percona/everest/pkg/kubernetes"
 )
+
+// TestPanicRecoveryMiddleware ensures that a handler panic is caught and
+// converted into an HTTP 500 response, instead of crashing the process.
+// See issue #2544. This mirrors the echomiddleware.Recover() registration
+// done in NewEverestServer without needing to stand up a full EverestServer
+// (which requires a live Kubernetes cluster, OIDC provider, session manager, etc).
+func TestPanicRecoveryMiddleware(t *testing.T) {
+	t.Parallel()
+
+	echoServer := echo.New()
+	echoServer.Use(echomiddleware.Recover())
+	echoServer.GET("/panic", func(echo.Context) error {
+		panic("test panic")
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/panic", nil)
+	rec := httptest.NewRecorder()
+
+	require.NotPanics(t, func() {
+		echoServer.ServeHTTP(rec, req)
+	})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
 
 func TestShouldAllowRequestDuringEngineUpgrade(t *testing.T) {
 	lockedAt := time.Now().Format(time.RFC3339)


### PR DESCRIPTION
Closes #2544.

`NewEverestServer` configures several Echo middlewares (RateLimiter, requestLogger, RemoveTrailingSlash, OAPI validator, JWT, blocklist) but omits `echomiddleware.Recover()`. A handler panic kills the entire server process instead of being caught and returned as a 500.

**Fix:** Adds `echoServer.Use(echomiddleware.Recover())` as the first global middleware after `echo.New()`, before RateLimiter — so it catches panics from all subsequent handlers and middlewares.

**Files:**
- `internal/server/everest.go` — one line added (Recover middleware registration).
- `internal/server/middlewares_test.go` — new test proving a panicking handler returns 500 instead of crashing the process. Standalone Echo instance (avoids Kubernetes/OIDC/session deps).

**Verification:** `go build ./...`, `go vet`, `go test ./internal/server/...`, `golangci-lint run ./internal/server` — all pass, 0 issues.