### PR TITLE
fix(version_service): prevent panic on nil matrix and handle unsupported operator

### DIFF
--- a/pkg/version_service/client.go
+++ b/pkg/version_service/client.go
@@ -108,14 +108,21 @@ func (c *versionServiceClient) GetSupportedEngineVersions(ctx context.Context, o
 		return nil, errors.New("no versions found")
 	}
 
+	firstVer := response.GetVersions()[0]
+	if firstVer == nil || firstVer.GetMatrix() == nil {
+		return nil, errors.New("no version matrix found")
+	}
+
 	var versions map[string]*perconavs.Version
 	switch operator {
 	case PXCOperatorName:
-		versions = response.GetVersions()[0].GetMatrix().GetPxc()
+		versions = firstVer.GetMatrix().GetPxc()
 	case PSMDBOperatorName:
-		versions = response.GetVersions()[0].GetMatrix().GetMongod()
+		versions = firstVer.GetMatrix().GetMongod()
 	case PGOperatorName:
-		versions = response.GetVersions()[0].GetMatrix().GetPostgresql()
+		versions = firstVer.GetMatrix().GetPostgresql()
+	default:
+		return nil, fmt.Errorf("unsupported operator: %s", operator)
 	}
 
 	result := make([]string, 0, len(versions))

--- a/pkg/version_service/client_test.go
+++ b/pkg/version_service/client_test.go
@@ -1,0 +1,70 @@
+package versionservice_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/percona/everest/pkg/version_service"
+)
+
+func TestGetSupportedEngineVersions_NilMatrix(t *testing.T) {
+	t.Parallel()
+
+	// Server returns a VersionResponse where versions slice has an entry with a nil matrix
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"versions": [{}]}`))
+	}))
+	defer ts.Close()
+
+	client := versionservice.New(ts.URL)
+	ctx := context.Background()
+
+	versions, err := client.GetSupportedEngineVersions(ctx, versionservice.PXCOperatorName, "1.0.0")
+	assert.Error(t, err)
+	assert.Nil(t, versions)
+	assert.Contains(t, err.Error(), "no version matrix found")
+}
+
+func TestGetSupportedEngineVersions_UnsupportedOperator(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"versions": [{"matrix": {"pxc": {"8.0.0": {}}}}]} `))
+	}))
+	defer ts.Close()
+
+	client := versionservice.New(ts.URL)
+	ctx := context.Background()
+
+	versions, err := client.GetSupportedEngineVersions(ctx, "invalid-operator", "1.0.0")
+	assert.Error(t, err)
+	assert.Nil(t, versions)
+	assert.Contains(t, err.Error(), "unsupported operator")
+}
+
+func TestGetSupportedEngineVersions_Success(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"versions": [{"matrix": {"pxc": {"8.0.32": {}}}}]} `))
+	}))
+	defer ts.Close()
+
+	client := versionservice.New(ts.URL)
+	ctx := context.Background()
+
+	versions, err := client.GetSupportedEngineVersions(ctx, versionservice.PXCOperatorName, "1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"8.0.32"}, versions)
+}


### PR DESCRIPTION
Added nil check for version matrix response in GetSupportedEngineVersions to prevent panic when matrix payload is empty or nil. Added explicit error handling for unsupported operators.