### PR TITLE
Fix EKS z1d EBS volume limit typo

### DIFF
--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -120,7 +120,7 @@ func (k *Kubernetes) getEKSVolumeCount(node corev1.Node) (uint64, error) {
 	}
 	// ... however, if the node type is one of M5, C5, R5, T3, Z1D it's 25.
 	limitedVolumesSet := map[string]struct{}{
-		"m5": {}, "c5": {}, "r5": {}, "t3": {}, "t1d": {},
+		"m5": {}, "c5": {}, "r5": {}, "t3": {}, "z1d": {},
 	}
 	if _, ok := limitedVolumesSet[typeAndSize[0]]; ok {
 		volumeLimitPerNode = 25

--- a/pkg/kubernetes/resources_test.go
+++ b/pkg/kubernetes/resources_test.go
@@ -1,0 +1,109 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetEKSVolumeCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		node       corev1.Node
+		want       uint64
+		wantErrMsg string
+	}{
+		{
+			name: "z1d uses reduced limit",
+			node: eksNode("z1d.large", corev1.ConditionFalse),
+			want: 25,
+		},
+		{
+			name: "t3 uses reduced limit",
+			node: eksNode("t3.medium", corev1.ConditionFalse),
+			want: 25,
+		},
+		{
+			name: "m5 uses reduced limit",
+			node: eksNode("m5.xlarge", corev1.ConditionFalse),
+			want: 25,
+		},
+		{
+			name: "m4 uses default limit",
+			node: eksNode("m4.large", corev1.ConditionFalse),
+			want: eksVolumeLimitPerNode,
+		},
+		{
+			name: "disk pressure returns zero",
+			node: eksNode("z1d.large", corev1.ConditionTrue),
+			want: 0,
+		},
+		{
+			name:       "missing instance type label",
+			node:       corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+			wantErrMsg: "beta.kubernetes.io/instance-type",
+		},
+		{
+			name: "invalid instance type format",
+			node: eksNode("invalid", corev1.ConditionFalse),
+			wantErrMsg: "failed to parse EKS node type",
+		},
+	}
+
+	k := &Kubernetes{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := k.getEKSVolumeCount(tt.node)
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func eksNode(instanceType string, diskPressure corev1.ConditionStatus) corev1.Node {
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+			Labels: map[string]string{
+				"beta.kubernetes.io/instance-type": instanceType,
+			},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeDiskPressure,
+					Status: diskPressure,
+				},
+			},
+		},
+	}
+}

--- a/pkg/kubernetes/resources_test.go
+++ b/pkg/kubernetes/resources_test.go
@@ -65,8 +65,8 @@ func TestGetEKSVolumeCount(t *testing.T) {
 			wantErrMsg: "beta.kubernetes.io/instance-type",
 		},
 		{
-			name: "invalid instance type format",
-			node: eksNode("invalid", corev1.ConditionFalse),
+			name:       "invalid instance type format",
+			node:       eksNode("invalid", corev1.ConditionFalse),
 			wantErrMsg: "failed to parse EKS node type",
 		},
 	}


### PR DESCRIPTION


## Summary

Fixes incorrect EBS volume limit calculation for EKS **z1d** nodes.

In `getEKSVolumeCount`, the reduced 25-volume limit map used `"t1d"` instead of `"z1d"`. Because `t1d` is not a valid AWS instance family, `z1d.*` nodes (e.g. `z1d.large`) incorrectly received the default limit of **39** instead of **25**, causing cluster resource calculations to overstate available disk capacity on EKS.

## Changes

- Replace `"t1d"` with `"z1d"` in `limitedVolumesSet` in `pkg/kubernetes/resources.go`
- Add table-driven unit tests in `pkg/kubernetes/resources_test.go` covering:
  - Reduced limit instance types (`z1d`, `t3`, `m5`) → 25
  - Default limit instance type (`m4`) → 39
  - Disk pressure → 0
  - Missing instance-type label and invalid format → error

## Related Issue

Fixes #2623 

## Test Plan

- [x] `go test -race ./pkg/kubernetes/... -run TestGetEKSVolumeCount -v`
- [x] `make copyright-check FILES="pkg/kubernetes/resources.go pkg/kubernetes/resources_test.go"`

```bash
go test -race ./pkg/kubernetes/... -run TestGetEKSVolumeCount -v
# PASS: z1d.large → 25, t3.medium → 25, m4.large → 39
```

