### PR TITLE
everestctl: add restore create subcommand

### DIFF
--- a/commands/restore.go
+++ b/commands/restore.go
@@ -31,4 +31,5 @@ var restoreCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(restoreCmd)
 	restoreCmd.AddCommand(restore.GetListCmd())
+	restoreCmd.AddCommand(restore.GetCreateCmd())
 }

--- a/commands/restore/create.go
+++ b/commands/restore/create.go
@@ -1,0 +1,127 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+	restorecli "github.com/openeverest/openeverest/v2/pkg/cli/restore"
+	"github.com/openeverest/openeverest/v2/pkg/cli/waitcmd"
+	"github.com/openeverest/openeverest/v2/pkg/logger"
+	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+var (
+	createCmd = &cobra.Command{
+		Use:   "create [flags]",
+		Args:  cobra.NoArgs,
+		Short: "Restore an instance from a backup",
+		Long: `Create a Restore for an instance from an existing Backup via the Everest API.
+
+The instance, namespace, and backup flags are required. The backup must be an
+existing Backup CR in the same namespace. Only full-backup restores are
+supported; point-in-time recovery is a follow-up. When --name is omitted, the
+server generates a name from the instance name plus a random suffix
+(metadata.generateName). Use --wait to block until the restore reaches a
+terminal state (Succeeded or Failed); --timeout bounds how long --wait blocks
+for. Ctrl-C during --wait stops the CLI but leaves the restore running
+server-side.`,
+		Example: `  # Restore an instance from a backup
+  everestctl restore create --instance my-mongo --namespace everest \
+    --backup pre-upgrade
+
+  # Wait for the restore to finish, bounded for CI
+  everestctl restore create --instance my-mongo --namespace everest \
+    --backup nightly-20260727 --wait --timeout 30m
+
+  # Specific cluster and context
+  everestctl restore create --instance my-mongo --namespace everest \
+    --backup pre-upgrade --cluster staging --context staging-ctx
+
+  # Bounded wait for CI, then grab the state (Ctrl-C only stops waiting; the restore keeps running)
+  everestctl restore create --instance my-mongo --namespace everest \
+    --backup pre-upgrade --wait --timeout 15m --json | jq '.status.state'`,
+		PreRun: createPreRun,
+		Run:    createRun,
+	}
+	createCfg  = &restorecli.Config{}
+	createOpts = &restorecli.CreateOptions{}
+)
+
+func init() {
+	createCmd.Flags().StringVar(&createOpts.Instance, cli.FlagRestoreInstance, "", "Instance to restore into (required)")
+	createCmd.Flags().StringVarP(&createOpts.Namespace, cli.FlagRestoreNamespace, "n", "", "Namespace the instance is located in (required)")
+	createCmd.Flags().StringVar(&createOpts.Backup, cli.FlagRestoreBackup, "", "Backup to restore from (required)")
+	createCmd.Flags().StringVar(&createOpts.Name, cli.FlagRestoreName, "", "Restore name (default: generated from instance name)")
+	createCmd.Flags().StringVar(&createOpts.Cluster, cli.FlagRestoreCluster, "main", "Cluster name")
+	createCmd.Flags().StringVar(&createOpts.Context, cli.FlagRestoreContext, "", "Context to use (default: current context)")
+	createCmd.Flags().BoolVar(&createOpts.Wait, cli.FlagRestoreWait, false, "Block until the restore reaches a terminal state; exit non-zero if it fails or times out")
+	createCmd.Flags().DurationVar(&createOpts.Timeout, cli.FlagRestoreTimeout, 30*time.Minute, "Maximum time to wait (only valid with --wait); must be positive")
+
+	_ = createCmd.MarkFlagRequired(cli.FlagRestoreInstance)
+	_ = createCmd.MarkFlagRequired(cli.FlagRestoreNamespace)
+	_ = createCmd.MarkFlagRequired(cli.FlagRestoreBackup)
+}
+
+func createPreRun(cmd *cobra.Command, _ []string) {
+	createCfg.Pretty = !cmd.Flag(cli.FlagVerbose).Changed && !cmd.Flag(cli.FlagJSON).Changed
+}
+
+func createRun(cmd *cobra.Command, _ []string) {
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		output.PrintError(err, logger.GetLogger(), createCfg.Pretty)
+		os.Exit(waitcmd.ExitFailed)
+	}
+
+	if err := waitcmd.ValidateWaitFlags(createOpts.Wait, cmd.Flags().Changed(cli.FlagRestoreTimeout), createOpts.Timeout); err != nil {
+		output.PrintError(err, logger.GetLogger(), createCfg.Pretty)
+		os.Exit(waitcmd.ExitFailed)
+	}
+
+	ctx := cmd.Context()
+	var stop context.CancelFunc
+	if createOpts.Wait {
+		// Ctrl-C cancels only the wait; the restore keeps running server-side.
+		ctx, stop = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	}
+
+	runner := restorecli.NewCreateRunner(*createCfg, logger.GetLogger())
+	runErr := runner.Run(ctx, *createOpts, cfgPath)
+	if stop != nil {
+		stop()
+	}
+	// Name omitted from the cancel message: the runner already printed it
+	// before waiting began.
+	os.Exit(waitcmd.ExitCode(runErr, logger.GetLogger(), createCfg.Pretty,
+		"wait cancelled; the restore is still running — check with 'everestctl restore list'",
+		fmt.Sprintf("timed out after %s waiting for restore to complete", createOpts.Timeout),
+	))
+}
+
+// GetCreateCmd returns the create command.
+func GetCreateCmd() *cobra.Command {
+	return createCmd
+}

--- a/docs/proposals/backups-restore-architecture.md
+++ b/docs/proposals/backups-restore-architecture.md
@@ -272,13 +272,17 @@ kind: Restore
 metadata:
   name: restore-from-backup-001
 spec:
-  instanceName: my-db
+  instanceRef:
+    name: my-db
   dataSource:
-    backupName: my-db-backup-2026-05-11
-    pitr: # optional, only if PITR restore
-      type: date
-      date: "2026-05-11T01:30:00Z"
-  config: {} # from UIGenerator restore section
+    type: Backup
+    backup:
+      backupRef:
+        name: my-db-backup-2026-05-11
+      pitr: # optional, only if PITR restore
+        type: date
+        date: "2026-05-11T01:30:00Z"
+  parameters: {} # from UIGenerator restore section
 status:
   state: Succeeded
 ```
@@ -360,7 +364,7 @@ Currently PSMDB provider's `SyncBackup()` ignores `Backup.spec.config`. Required
 | Function            | Current                                             | Required                                                              |
 | ------------------- | --------------------------------------------------- | --------------------------------------------------------------------- |
 | `SyncBackup()`      | Sets only `ClusterName`, `StorageName`              | Read `backup.Spec.Config` → set `psmdbBackup.Spec.Type`, compression  |
-| `SyncRestore()`     | Reads only PITR from `restore.Spec.DataSource.PITR` | Read `restore.Spec.Config` (future: selective restore params)         |
+| `SyncRestore()`     | Reads only PITR from `restore.Spec.DataSource.Backup.PITR` | Read `restore.Spec.Parameters` (future: selective restore params)         |
 | `buildBackupSpec()` | PITR = simple bool from `storage.PITR.Enabled`      | Read `storage.PITR.Config` → set `oplogSpanMin`, compression for PITR |
 | `BackupCustomSpec`  | Empty `struct{}`                                    | Not needed — config comes from Backup CR, not provider definition     |
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -163,6 +163,14 @@ const (
 	FlagRestoreCluster = "cluster"
 	// FlagRestoreContext overrides the active context for this command.
 	FlagRestoreContext = "context"
+	// FlagRestoreBackup is the name of the source Backup flag.
+	FlagRestoreBackup = "backup"
+	// FlagRestoreName is the name of the restore name flag.
+	FlagRestoreName = "name"
+	// FlagRestoreWait blocks until the restore reaches a terminal state.
+	FlagRestoreWait = "wait"
+	// FlagRestoreTimeout bounds how long --wait blocks for.
+	FlagRestoreTimeout = "timeout"
 
 	// `backup-storage` flags.
 

--- a/pkg/cli/restore/create.go
+++ b/pkg/cli/restore/create.go
@@ -128,7 +128,7 @@ func (cr *CreateRunner) emitCreated(created *client.Restore, name string) error 
 
 // waitForRestore blocks until the restore reaches a terminal state, streaming
 // progress in pretty mode. JSON mode emits one final object on success.
-func (cr *CreateRunner) waitForRestore(ctx context.Context, c *client.ClientWithResponses, created *client.Restore, opts CreateOptions,name string) error {
+func (cr *CreateRunner) waitForRestore(ctx context.Context, c *client.ClientWithResponses, created *client.Restore, opts CreateOptions, name string) error {
 	var latest *client.Restore
 	basePoll := newRestorePoll(c, opts.Cluster, opts.Namespace, name)
 	poll := func(ctx context.Context) (*client.Restore, error) {

--- a/pkg/cli/restore/create.go
+++ b/pkg/cli/restore/create.go
@@ -1,0 +1,178 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package restore provides CLI business logic for restore management.
+package restore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openeverest/openeverest/v2/client"
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
+	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+// CreateOptions holds the inputs for the create command.
+type CreateOptions struct {
+	Instance  string
+	Namespace string
+	Backup    string
+	Name      string
+	Cluster   string
+	Context   string
+	Wait      bool
+	Timeout   time.Duration
+}
+
+// CreateRunner creates a Restore via the Everest API.
+type CreateRunner struct {
+	config Config
+	l      *zap.SugaredLogger
+}
+
+// NewCreateRunner creates a new CreateRunner.
+func NewCreateRunner(cfg Config, l *zap.SugaredLogger) *CreateRunner {
+	cr := &CreateRunner{config: cfg, l: l.With("component", "restore-create")}
+	if cfg.Pretty {
+		cr.l = zap.NewNop().Sugar()
+	}
+	return cr
+}
+
+// Run creates a Restore and, with opts.Wait, blocks until it reaches a
+// terminal state.
+func (cr *CreateRunner) Run(ctx context.Context, opts CreateOptions, cfgPath string) error {
+	c, err := authcli.NewAPIClient(authcli.Config{Pretty: cr.config.Pretty}, cr.l.Desugar().Sugar(), cfgPath, opts.Context)
+	if err != nil {
+		return err
+	}
+
+	md := metav1.ObjectMeta{Namespace: opts.Namespace}
+	if opts.Name != "" {
+		md.Name = opts.Name
+	} else {
+		md.GenerateName = opts.Instance + "-"
+	}
+	restore := client.Restore{Metadata: &md}
+	restore.Spec.InstanceRef.Name = opts.Instance
+	restore.Spec.DataSource.Type = client.RestoreSpecDataSourceTypeBackup
+	restore.Spec.DataSource.Backup = &struct {
+		BackupRef struct {
+			Name string `json:"name"`
+		} `json:"backupRef"`
+		Pitr *struct {
+			Date *time.Time `json:"date,omitempty"`
+			Type any        `json:"type"`
+		} `json:"pitr,omitempty"`
+	}{}
+	restore.Spec.DataSource.Backup.BackupRef.Name = opts.Backup
+
+	resp, err := c.CreateRestoreWithResponse(ctx, opts.Cluster, opts.Namespace, restore)
+	if err != nil {
+		return fmt.Errorf("create restore request failed: %w", err)
+	}
+
+	if resp.StatusCode() != http.StatusCreated || resp.JSON201 == nil {
+		if resp.StatusCode() == http.StatusConflict {
+			return fmt.Errorf("restore %q already exists in namespace %q", opts.Name, opts.Namespace)
+		}
+		if resp.JSONDefault != nil && resp.JSONDefault.Message != nil {
+			return fmt.Errorf("server error: %s", *resp.JSONDefault.Message)
+		}
+		return fmt.Errorf("unexpected response creating restore: %s", resp.Status())
+	}
+
+	name := restoreName(resp.JSON201)
+	cr.l.Infof("created restore %q for instance %q in namespace %q", name, opts.Instance, opts.Namespace)
+
+	if !opts.Wait {
+		return cr.emitCreated(resp.JSON201, name)
+	}
+	return cr.waitForRestore(ctx, c, resp.JSON201, opts, name)
+}
+
+// emitCreated reports a non-waiting create: a success line in pretty mode, or
+// the created restore in JSON mode (so `create --json` is parseable either way).
+func (cr *CreateRunner) emitCreated(created *client.Restore, name string) error {
+	if cr.config.Pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Success("Restore %q created", name))
+		return nil
+	}
+	// A 201 with an unparseable body would otherwise emit empty stdout.
+	if created == nil {
+		return fmt.Errorf("restore %q was created but the server returned an unreadable response body", name)
+	}
+	return writeRestoreJSON(created)
+}
+
+// waitForRestore blocks until the restore reaches a terminal state, streaming
+// progress in pretty mode. JSON mode emits one final object on success.
+func (cr *CreateRunner) waitForRestore(ctx context.Context, c *client.ClientWithResponses, created *client.Restore, opts CreateOptions,name string) error {
+	var latest *client.Restore
+	basePoll := newRestorePoll(c, opts.Cluster, opts.Namespace, name)
+	poll := func(ctx context.Context) (*client.Restore, error) {
+		r, err := basePoll(ctx)
+		if err == nil {
+			latest = r
+		}
+		return r, err
+	}
+
+	var onUpdate func(string)
+	if cr.config.Pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Info("Restore %q created; waiting for it to complete...", name))
+		onUpdate = func(msg string) {
+			_, _ = fmt.Fprintf(os.Stdout, "  %s\n", msg)
+		}
+	}
+
+	if err := wait.Until(ctx, poll, restoreCondition, wait.Options{
+		Timeout:  opts.Timeout,
+		OnUpdate: onUpdate,
+		OnRetry:  func(err error) { cr.l.Warnf("%v — retrying", err) },
+	}); err != nil {
+		return err
+	}
+
+	final := latest
+	if final == nil {
+		final = created
+	}
+
+	if cr.config.Pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Success("Restore %q completed", name))
+		return nil
+	}
+	return writeRestoreJSON(final)
+}
+
+func writeRestoreJSON(r *client.Restore) error {
+	if r == nil {
+		return nil
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(r); err != nil {
+		return fmt.Errorf("failed to encode restore: %w", err)
+	}
+	return nil
+}

--- a/pkg/cli/restore/create_test.go
+++ b/pkg/cli/restore/create_test.go
@@ -1,0 +1,299 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/openeverest/openeverest/v2/client"
+)
+
+func newConfigPath(t *testing.T, serverURL string) string {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(serverURL).Save(cfgPath))
+	return cfgPath
+}
+
+// restoreWithState builds a Restore fixture via JSON (see restoreFromJSON in
+// wait_test.go), so it stays valid across Restore schema changes instead of
+// hand-spelling the generated anonymous Status struct.
+func restoreWithState(t *testing.T, name, state string) *client.Restore {
+	t.Helper()
+	statusField := ""
+	if state != "" {
+		statusField = fmt.Sprintf(`,"status":{"state":%q}`, state)
+	}
+	body := fmt.Sprintf(
+		`{"metadata":{"name":%q,"namespace":"everest"},"spec":{"instanceRef":{"name":"my-mongo"},"dataSource":{"type":"Backup","backup":{"backupRef":{"name":"pre-upgrade"}}}}%s}`,
+		name, statusField,
+	)
+	return restoreFromJSON(t, body)
+}
+
+func TestRun_HappyPath_GeneratesName(t *testing.T) {
+	t.Parallel()
+
+	var gotBody client.Restore
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores", func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(restoreWithState(t, "my-mongo-abcde", ""))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cr := NewCreateRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := cr.Run(context.Background(), CreateOptions{
+		Instance:  "my-mongo",
+		Namespace: "everest",
+		Backup:    "pre-upgrade",
+		Cluster:   "main",
+	}, newConfigPath(t, srv.URL))
+
+	require.NoError(t, err)
+	require.NotNil(t, gotBody.Metadata)
+	assert.Equal(t, "my-mongo-", gotBody.Metadata.GenerateName)
+	assert.Empty(t, gotBody.Metadata.Name)
+	assert.Equal(t, "my-mongo", gotBody.Spec.InstanceRef.Name)
+	assert.Equal(t, client.RestoreSpecDataSourceTypeBackup, gotBody.Spec.DataSource.Type)
+	require.NotNil(t, gotBody.Spec.DataSource.Backup)
+	assert.Equal(t, "pre-upgrade", gotBody.Spec.DataSource.Backup.BackupRef.Name)
+}
+
+func TestRun_ExplicitName(t *testing.T) {
+	t.Parallel()
+
+	var gotBody client.Restore
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores", func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(restoreWithState(t, "restore-from-backup", ""))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cr := NewCreateRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := cr.Run(context.Background(), CreateOptions{
+		Instance:  "my-mongo",
+		Namespace: "everest",
+		Backup:    "pre-upgrade",
+		Name:      "restore-from-backup",
+		Cluster:   "main",
+	}, newConfigPath(t, srv.URL))
+
+	require.NoError(t, err)
+	require.NotNil(t, gotBody.Metadata)
+	assert.Equal(t, "restore-from-backup", gotBody.Metadata.Name)
+}
+
+func TestRun_Conflict_ReturnsFriendlyError(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cr := NewCreateRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := cr.Run(context.Background(), CreateOptions{
+		Instance:  "my-mongo",
+		Namespace: "everest",
+		Backup:    "pre-upgrade",
+		Name:      "restore-from-backup",
+		Cluster:   "main",
+	}, newConfigPath(t, srv.URL))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `restore "restore-from-backup" already exists in namespace "everest"`)
+}
+
+func TestRun_Wait_SucceedsOnTerminalState(t *testing.T) {
+	t.Parallel()
+
+	var getCalls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(restoreWithState(t, "my-mongo-abcde", ""))
+	})
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores/my-mongo-abcde", func(w http.ResponseWriter, _ *http.Request) {
+		getCalls++
+		state := "Running"
+		if getCalls >= 2 {
+			state = "Succeeded"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(restoreWithState(t, "my-mongo-abcde", state))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cr := NewCreateRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := cr.Run(context.Background(), CreateOptions{
+		Instance:  "my-mongo",
+		Namespace: "everest",
+		Backup:    "pre-upgrade",
+		Cluster:   "main",
+		Wait:      true,
+		Timeout:   10 * time.Second,
+	}, newConfigPath(t, srv.URL))
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, getCalls, 2)
+}
+
+func TestRun_Wait_FailsOnFailedState(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(restoreWithState(t, "my-mongo-abcde", ""))
+	})
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores/my-mongo-abcde", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		r := restoreWithState(t, "my-mongo-abcde", "Failed")
+		msg := "target instance rejected the restore payload"
+		r.Status.Message = &msg
+		_ = json.NewEncoder(w).Encode(r)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cr := NewCreateRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := cr.Run(context.Background(), CreateOptions{
+		Instance:  "my-mongo",
+		Namespace: "everest",
+		Backup:    "pre-upgrade",
+		Cluster:   "main",
+		Wait:      true,
+		Timeout:   10 * time.Second,
+	}, newConfigPath(t, srv.URL))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target instance rejected the restore payload")
+}
+
+func TestRun_Wait_RetriesTransientFetchError(t *testing.T) {
+	t.Parallel()
+
+	// First poll returns 500 (transient), second returns Succeeded — the wait
+	// must retry rather than fail on the transient status.
+	var getCalls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(restoreWithState(t, "my-mongo-abcde", ""))
+	})
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores/my-mongo-abcde", func(w http.ResponseWriter, _ *http.Request) {
+		getCalls++
+		if getCalls == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(restoreWithState(t, "my-mongo-abcde", "Succeeded"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cr := NewCreateRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := cr.Run(context.Background(), CreateOptions{
+		Instance:  "my-mongo",
+		Namespace: "everest",
+		Backup:    "pre-upgrade",
+		Cluster:   "main",
+		Wait:      true,
+		Timeout:   10 * time.Second,
+	}, newConfigPath(t, srv.URL))
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, getCalls, 2)
+}
+
+func TestRun_JSONErrorsOnEmptyCreateBody(t *testing.T) {
+	t.Parallel()
+
+	// 201 with no parseable body must error rather than emit empty stdout.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cr := NewCreateRunner(Config{Pretty: false}, zap.NewNop().Sugar())
+	err := cr.Run(context.Background(), CreateOptions{
+		Instance:  "my-mongo",
+		Namespace: "everest",
+		Backup:    "pre-upgrade",
+		Cluster:   "main",
+	}, newConfigPath(t, srv.URL))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected response creating restore")
+}
+
+func TestRun_Wait_TimesOut(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(restoreWithState(t, "my-mongo-abcde", ""))
+	})
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores/my-mongo-abcde", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(restoreWithState(t, "my-mongo-abcde", "Running"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cr := NewCreateRunner(Config{Pretty: true}, zap.NewNop().Sugar())
+	err := cr.Run(context.Background(), CreateOptions{
+		Instance:  "my-mongo",
+		Namespace: "everest",
+		Backup:    "pre-upgrade",
+		Cluster:   "main",
+		Wait:      true,
+		Timeout:   3 * time.Second,
+	}, newConfigPath(t, srv.URL))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+}

--- a/pkg/cli/restore/wait.go
+++ b/pkg/cli/restore/wait.go
@@ -1,0 +1,84 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/openeverest/openeverest/v2/client"
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
+)
+
+// terminal restore states.
+const (
+	restoreStateSucceeded = "Succeeded"
+	restoreStateFailed    = "Failed"
+)
+
+// restoreCondition maps Succeeded/Failed to terminal outcomes and everything
+// else to Pending.
+func restoreCondition(r *client.Restore) (wait.Outcome, string) {
+	state := restoreState(r)
+	switch state {
+	case restoreStateSucceeded:
+		return wait.Succeeded, state
+	case restoreStateFailed:
+		return wait.Failed, restoreFailureMessage(r)
+	default:
+		return wait.Pending, state
+	}
+}
+
+// newRestorePoll returns a PollFunc for the restore.
+func newRestorePoll(
+	c *client.ClientWithResponses,
+	cluster, namespace, name string,
+) wait.PollFunc[*client.Restore] {
+	return func(ctx context.Context) (*client.Restore, error) {
+		resp, err := c.GetRestoreWithResponse(ctx, cluster, namespace, name)
+		if err != nil {
+			// A failed token refresh is terminal; other fetch errors are transient.
+			if errors.Is(err, authcli.ErrTokenRefresh) {
+				return nil, fmt.Errorf("failed to fetch restore %q: %w", name, err)
+			}
+			return nil, &wait.RetryableError{Err: fmt.Errorf("failed to fetch restore %q: %w", name, err)}
+		}
+		switch resp.StatusCode() {
+		case http.StatusOK:
+			if resp.JSON200 == nil {
+				return nil, &wait.RetryableError{Err: fmt.Errorf("empty response body fetching restore %q", name)}
+			}
+			return resp.JSON200, nil
+		case http.StatusNotFound:
+			return nil, fmt.Errorf("restore %q was deleted while waiting", name)
+		case http.StatusUnauthorized:
+			return nil, fmt.Errorf("server rejected credentials — run 'everestctl auth login' again")
+		default:
+			return nil, &wait.RetryableError{Err: fmt.Errorf("unexpected response fetching restore %q: %s", name, resp.Status())}
+		}
+	}
+}
+
+func restoreFailureMessage(r *client.Restore) string {
+	if r == nil || r.Status == nil || r.Status.Message == nil || *r.Status.Message == "" {
+		return "restore entered the Failed state"
+	}
+	return "restore entered the Failed state: " + *r.Status.Message
+}

--- a/pkg/cli/restore/wait_test.go
+++ b/pkg/cli/restore/wait_test.go
@@ -1,0 +1,191 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openeverest/openeverest/v2/client"
+	"github.com/openeverest/openeverest/v2/pkg/cli"
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
+)
+
+// restoreFromJSON builds a client.Restore from a JSON literal.
+func restoreFromJSON(t *testing.T, body string) *client.Restore {
+	t.Helper()
+	var r client.Restore
+	require.NoError(t, json.Unmarshal([]byte(body), &r))
+	return &r
+}
+
+// newTestClient builds an unauthenticated client for testing a poll/query
+// func directly, bypassing the config-and-auth-backed Run path. It still
+// normalizes the URL the same way authcli.NewAPIClient does (appending /v1),
+// so mux routes registered here match what the real client actually requests.
+func newTestClient(serverURL string) (*client.ClientWithResponses, error) {
+	return client.NewClientWithResponses(cli.NormalizeServerURL(serverURL))
+}
+
+func TestRestoreCondition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		body        string
+		wantOutcome wait.Outcome
+		wantMsgHas  string
+	}{
+		{
+			name:        "succeeded is success",
+			body:        `{"status":{"state":"Succeeded"}}`,
+			wantOutcome: wait.Succeeded,
+		},
+		{
+			name:        "failed with message",
+			body:        `{"status":{"state":"Failed","message":"target instance rejected the restore payload"}}`,
+			wantOutcome: wait.Failed,
+			wantMsgHas:  "target instance rejected the restore payload",
+		},
+		{
+			name:        "failed without message",
+			body:        `{"status":{"state":"Failed"}}`,
+			wantOutcome: wait.Failed,
+			wantMsgHas:  "entered the Failed state",
+		},
+		{
+			name:        "running is pending",
+			body:        `{"status":{"state":"Running"}}`,
+			wantOutcome: wait.Pending,
+			wantMsgHas:  "Running",
+		},
+		{
+			// Regression guard: Error is retryable, not terminal.
+			name:        "error state is pending, not failed",
+			body:        `{"status":{"state":"Error"}}`,
+			wantOutcome: wait.Pending,
+			wantMsgHas:  "Error",
+		},
+		{
+			name:        "no status is pending",
+			body:        `{}`,
+			wantOutcome: wait.Pending,
+			wantMsgHas:  "-",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			outcome, msg := restoreCondition(restoreFromJSON(t, tc.body))
+			assert.Equal(t, tc.wantOutcome, outcome)
+			if tc.wantMsgHas != "" {
+				assert.Contains(t, msg, tc.wantMsgHas)
+			}
+		})
+	}
+}
+
+func TestNewRestorePoll_DeletedMidWait(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores/gone", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c, err := newTestClient(srv.URL)
+	require.NoError(t, err)
+
+	poll := newRestorePoll(c, "main", "everest", "gone")
+	_, err = poll(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "was deleted while waiting")
+}
+
+func TestNewRestorePoll_UnauthorizedIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores/my-mongo-abcde", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c, err := newTestClient(srv.URL)
+	require.NoError(t, err)
+
+	poll := newRestorePoll(c, "main", "everest", "my-mongo-abcde")
+	_, err = poll(context.Background())
+	require.Error(t, err)
+	var re *wait.RetryableError
+	require.NotErrorAs(t, err, &re, "401 must be terminal, not retryable")
+	assert.Contains(t, err.Error(), "run 'everestctl auth login' again")
+}
+
+func TestNewRestorePoll_FailedTokenRefreshIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	// A RoundTripper simulating the auth transport's behavior when a 401
+	// triggers a token refresh that itself fails.
+	rt := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("wrap: %w", authcli.ErrTokenRefresh)
+	})
+	c, err := client.NewClientWithResponses("http://example.invalid", client.WithHTTPClient(&http.Client{Transport: rt}))
+	require.NoError(t, err)
+
+	poll := newRestorePoll(c, "main", "everest", "my-mongo-abcde")
+	_, err = poll(context.Background())
+	require.Error(t, err)
+	require.ErrorIs(t, err, authcli.ErrTokenRefresh)
+	var re *wait.RetryableError
+	require.NotErrorAs(t, err, &re, "a failed token refresh must be terminal, not retryable")
+}
+
+func TestNewRestorePoll_UnexpectedStatusIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/clusters/main/namespaces/everest/restores/my-mongo-abcde", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c, err := newTestClient(srv.URL)
+	require.NoError(t, err)
+
+	poll := newRestorePoll(c, "main", "everest", "my-mongo-abcde")
+	_, err = poll(context.Background())
+	require.Error(t, err)
+	var re *wait.RetryableError
+	require.ErrorAs(t, err, &re, "a transient 500 must be retryable, not terminal")
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }


### PR DESCRIPTION
Restores could already be triggered through the API and UI, but not from the terminal -- exactly the moment operators are most likely to need it, recovering from a shell instead of hand-crafting a Restore CR with kubectl or calling the API directly. This adds `everestctl restore create --instance --namespace --backup`, with an optional --name (falls back to metadata.generateName, same as backup create) and --wait/--timeout to block until the restore reaches a terminal state.

Mirrors backup create's CreateRunner/poll/409-conflict pattern and reuses the existing wait/waitcmd plumbing instead of growing a second copy. The one real structural difference is the payload: the source backup sits under spec.dataSource.backup.backupRef.name instead of a flat ref, since dataSource is shared with future PITR/seeding sources. PITR and restore-time parameters are deliberately left out -- #2620 calls both out of scope for a follow-up.

Built against #2652's typed ObjectMeta (restore list already migrated to it), and fixed the stale Restore CR example left in the backups-restore-architecture doc from the earlier *Ref.name refactor.

Closes #2620