### PR TITLE
fix: endpoint URL can be changed on an in-use backup storage

### DIFF
--- a/internal/server/handlers/validation/backup_storage.go
+++ b/internal/server/handlers/validation/backup_storage.go
@@ -334,14 +334,18 @@ func azureAccess(ctx context.Context, l *zap.SugaredLogger, accountName, account
 	return nil
 }
 
+// basicStorageParamsAreChanged reports whether an update changes any of the parameters that
+// identify the storage location itself: bucket, region and endpoint URL.
+//
+// These are the same three fields that validateDuplicateStorageByUpdate uses to decide whether
+// two storages point at the same location (see errDuplicatedBackupStorage), and the two functions
+// must stay in sync: repointing a storage that is still in use would orphan every backup already
+// written through it. Both are expressed via the shared *OrDefault helpers so that adding a field
+// to the storage identity only has to be done once.
 func basicStorageParamsAreChanged(bs *everestv1alpha1.BackupStorage, params *api.UpdateBackupStorageParams) bool {
-	if params.BucketName != nil && bs.Spec.Bucket != pointer.GetString(params.BucketName) {
-		return true
-	}
-	if params.Region != nil && bs.Spec.Region != pointer.GetString(params.Region) {
-		return true
-	}
-	return false
+	return bucketNameOrDefault(params, bs.Spec.Bucket) != bs.Spec.Bucket ||
+		regionOrDefault(params, bs.Spec.Region) != bs.Spec.Region ||
+		urlOrDefault(params, bs.Spec.EndpointURL) != bs.Spec.EndpointURL
 }
 
 func (h *validateHandler) validateUpdateBackupStorageRequest(

--- a/internal/server/handlers/validation/backup_storage_test.go
+++ b/internal/server/handlers/validation/backup_storage_test.go
@@ -388,3 +388,108 @@ func TestValidate_DeleteBackupStorage(t *testing.T) {
 		})
 	}
 }
+
+func TestBasicStorageParamsAreChanged(t *testing.T) {
+	t.Parallel()
+
+	storage := func() *everestv1alpha1.BackupStorage {
+		return &everestv1alpha1.BackupStorage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "storageA",
+				Namespace: bsNamespace,
+			},
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "https://s3.example.com",
+			},
+		}
+	}
+
+	cases := []struct {
+		name       string
+		params     everestapi.UpdateBackupStorageParams
+		areChanged bool
+	}{
+		{
+			name:       "no params set",
+			params:     everestapi.UpdateBackupStorageParams{},
+			areChanged: false,
+		},
+		{
+			name:       "bucket changed",
+			params:     everestapi.UpdateBackupStorageParams{BucketName: new("bucket2")},
+			areChanged: true,
+		},
+		{
+			name:       "region changed",
+			params:     everestapi.UpdateBackupStorageParams{Region: new("region2")},
+			areChanged: true,
+		},
+		{
+			// Repointing an in-use storage at a different endpoint orphans every backup
+			// already written through it, so it must be treated like a bucket/region change.
+			name:       "url changed",
+			params:     everestapi.UpdateBackupStorageParams{Url: new("https://s3.other.example.com")},
+			areChanged: true,
+		},
+		{
+			name:       "bucket set to the same value",
+			params:     everestapi.UpdateBackupStorageParams{BucketName: new("bucket1")},
+			areChanged: false,
+		},
+		{
+			name:       "region set to the same value",
+			params:     everestapi.UpdateBackupStorageParams{Region: new("region1")},
+			areChanged: false,
+		},
+		{
+			name:       "url set to the same value",
+			params:     everestapi.UpdateBackupStorageParams{Url: new("https://s3.example.com")},
+			areChanged: false,
+		},
+		{
+			name: "all three set to the same values",
+			params: everestapi.UpdateBackupStorageParams{
+				BucketName: new("bucket1"),
+				Region:     new("region1"),
+				Url:        new("https://s3.example.com"),
+			},
+			areChanged: false,
+		},
+		{
+			name: "all three changed",
+			params: everestapi.UpdateBackupStorageParams{
+				BucketName: new("bucket2"),
+				Region:     new("region2"),
+				Url:        new("https://s3.other.example.com"),
+			},
+			areChanged: true,
+		},
+		{
+			// Non-identity params must never trip the in-use guard on their own,
+			// otherwise credentials could not be rotated on a storage that is in use.
+			name: "only non-identity params changed",
+			params: everestapi.UpdateBackupStorageParams{
+				AccessKey:      new("new-access-key"),
+				SecretKey:      new("new-secret-key"),
+				VerifyTLS:      new(false),
+				ForcePathStyle: new(true),
+				Description:    new("new description"),
+			},
+			areChanged: false,
+		},
+		{
+			name:       "url cleared to empty",
+			params:     everestapi.UpdateBackupStorageParams{Url: new("")},
+			areChanged: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.areChanged, basicStorageParamsAreChanged(storage(), &tc.params))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2665

### Problem

A backup storage that is still in use — one carrying the `everest.percona.com/in-use-protection` finalizer — can have its endpoint URL changed, even though bucket and region changes on the same storage are correctly rejected with:

```
backup storage='my-storage' in namespace='everest' is used and cannot be updated
```

Existing `DatabaseClusterBackup` objects reference the storage by name, so repointing it leaves those backups recorded against a storage that no longer points at where they actually live. New backups go to the new endpoint; restores from the older ones fail.

### Root cause

`basicStorageParamsAreChanged` checks `Bucket` and `Region` but not `EndpointURL`, so the guard in `validateUpdateBackupStorageRequest` never fires for a URL-only update.

The rest of the file already treats all three fields as the storage identity: `validateDuplicateStorageByUpdate` compares `region + bucket + url` when deciding whether two storages point at the same place, and `errDuplicatedBackupStorage` says so in its message - *"backup storage with the same url, bucket and region
already exists"*. The two functions had drifted apart, and `basicStorageParamsAreChanged` had no test references anywhere in the repo, so nothing caught it.

Only `main` is affected. On `release-2.0` the validation handler for backup storages is a set of bare proxies to `h.next`, so neither this function nor the in-use guard exists there.

### Fix

Route the check through the same three `*OrDefault` helpers that `validateDuplicateStorageByUpdate` already uses, so both functions derive storage identity from one place and cannot drift apart again:

```go
func basicStorageParamsAreChanged(bs *everestv1alpha1.BackupStorage, params *api.UpdateBackupStorageParams) bool {
	return bucketNameOrDefault(params, bs.Spec.Bucket) != bs.Spec.Bucket ||
		regionOrDefault(params, bs.Spec.Region) != bs.Spec.Region ||
		urlOrDefault(params, bs.Spec.EndpointURL) != bs.Spec.EndpointURL
}
```

The helpers return the current value when a param is `nil`, so the explicit nil checks become unnecessary rather than being dropped.

`ForcePathStyle` and `VerifyTLS` are deliberately left out - they are connection options rather than location, and including them would block credential or TLS changes on a storage that is in use.

### Tests

Added `TestBasicStorageParamsAreChanged`, table-driven in the same style as the existing `TestValidateDuplicateStorageByUpdate`. Eleven cases covering: no params set, each of bucket/region/URL changed, each set to its *same* value, all three changed, all three unchanged, URL cleared to empty, and one asserting that non-identity params (access key, secret key, `VerifyTLS`, `ForcePathStyle`, description) still do **not** trip the guard, so credential rotation on an in-use storage keeps working.

Against the previous implementation the two URL cases fail:

```
--- FAIL: TestBasicStorageParamsAreChanged/url_changed
            expected: true
            actual  : false
--- FAIL: TestBasicStorageParamsAreChanged/url_cleared_to_empty
            expected: true
            actual  : false
```

The other nine pass on both the old and new implementation, which is the check that the refactor is behaviour-preserving outside the URL case.

Verified locally: `make test` (full suite, `-race`) green, `golangci-lint` clean on the package, `make copyright-check` clean, `make format` produces no drift, and no generated files change.
