### PR TITLE
ci: drop obsolete write-access gate from FE gatekeeper

### DIFF
--- a/.github/workflows/dev-fe-gatekeeper.yaml
+++ b/.github/workflows/dev-fe-gatekeeper.yaml
@@ -94,24 +94,6 @@ jobs:
         if: matrix.action == 'build'
         run: make build
 
-  permission_checks:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get User Permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@c21884f3dda18dafc2f8b402fe807ccc9ec1aa5e # v2.4.0
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check User Permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          exit 1
-
   E2E_tests_workflow:
     uses: ./.github/workflows/dev-fe-e2e.yaml
     secrets:
@@ -121,7 +103,7 @@ jobs:
       RBAC_PASSWORD: rbac-e2e-test
 
   merge-gatekeeper:
-    needs: [CI_checks, permission_checks, E2E_tests_workflow]
+    needs: [CI_checks, E2E_tests_workflow]
     name: Merge Gatekeeper
     if: ${{ always() }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Problem

The `permission_checks` job in `dev-fe-gatekeeper.yaml` always fails for PRs from external contributors: the read-only `GITHUB_TOKEN` can't resolve their collaborator permission, so `require-result` is `false`, the job exits 1, and `merge-gatekeeper` — which lists it in `needs` — is blocked.

### Why it's safe to remove

Tracing the history, the gate no longer guards anything:

- It was added in #271 **in the same commit that switched the trigger from `pull_request` to `pull_request_target`**. With `pull_request_target`, fork PRs execute with the base repo's secret context, so a write-access gate was genuinely required.
- The workflow split (`76e6152a`) reverted the trigger to plain `pull_request`, but kept the job.
- #323 ("Remove s3 dependency") deleted the `BACKUP_LOCATION_*` S3 credentials the E2E job consumed and replaced them with a local MinIO instance.

As of today: trigger is `pull_request`, runners are GitHub-hosted `ubuntu-latest`, fork PRs get a read-only token and no repository secrets, and the only credentials passed to `dev-fe-e2e.yaml` are hardcoded test literals (`everestadmin`, `rbac-e2e-test`). GitHub's own "approve workflow runs for first-time contributors" setting already covers the runner-abuse concern.

### Changes

- Remove the `permission_checks` job.
- Drop it from `merge-gatekeeper`'s `needs`.
