### PR TITLE
Fix init container resource counting in GetConsumedCPUAndMemory

### DIFF
--- a/pkg/kubernetes/container.go
+++ b/pkg/kubernetes/container.go
@@ -15,8 +15,6 @@
 package kubernetes
 
 import (
-	"encoding/json"
-
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -32,21 +30,20 @@ const (
 	ContainerStateTerminated ContainerState = "terminated"
 )
 
-// IsContainerInState returns true if container is in give state, otherwise false.
-func IsContainerInState(containerStatuses []corev1.ContainerStatus, state ContainerState) bool {
-	containerState := make(map[string]any)
+// IsContainerInState returns true if the named container is in the given state.
+func IsContainerInState(containerStatuses []corev1.ContainerStatus, name string, state ContainerState) bool {
 	for _, status := range containerStatuses {
-		data, err := json.Marshal(status.State)
-		if err != nil {
-			return false
+		if status.Name != name {
+			continue
 		}
 
-		if err := json.Unmarshal(data, &containerState); err != nil {
+		switch state {
+		case ContainerStateWaiting:
+			return status.State.Waiting != nil
+		case ContainerStateTerminated:
+			return status.State.Terminated != nil
+		default:
 			return false
-		}
-
-		if _, ok := containerState[string(state)]; ok {
-			return true
 		}
 	}
 

--- a/pkg/kubernetes/container_test.go
+++ b/pkg/kubernetes/container_test.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestIsContainerInState(t *testing.T) {
+	t.Parallel()
+
+	statuses := []corev1.ContainerStatus{
+		{
+			Name: "init-a",
+			State: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{},
+			},
+		},
+		{
+			Name: "init-b",
+			State: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{},
+			},
+		},
+		{
+			Name: "init-c",
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{},
+			},
+		},
+	}
+
+	assert.True(t, IsContainerInState(statuses, "init-a", ContainerStateTerminated))
+	assert.False(t, IsContainerInState(statuses, "init-b", ContainerStateTerminated))
+	assert.False(t, IsContainerInState(statuses, "init-missing", ContainerStateTerminated))
+	assert.True(t, IsContainerInState(statuses, "init-c", ContainerStateWaiting))
+	assert.False(t, IsContainerInState(statuses, "init-a", ContainerStateWaiting))
+}

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -190,7 +190,7 @@ func (k *Kubernetes) GetConsumedCPUAndMemory(ctx context.Context, namespace stri
 		nonTerminatedInitContainers := make([]corev1.Container, 0, len(ppod.Spec.InitContainers))
 		for _, container := range ppod.Spec.InitContainers {
 			if !IsContainerInState(
-				ppod.Status.InitContainerStatuses, ContainerStateTerminated,
+				ppod.Status.InitContainerStatuses, container.Name, ContainerStateTerminated,
 			) {
 				nonTerminatedInitContainers = append(nonTerminatedInitContainers, container)
 			}

--- a/pkg/kubernetes/resources_test.go
+++ b/pkg/kubernetes/resources_test.go
@@ -17,12 +17,17 @@
 package kubernetes
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetEKSVolumeCount(t *testing.T) {
@@ -89,6 +94,57 @@ func TestGetEKSVolumeCount(t *testing.T) {
 	}
 }
 
+func TestGetConsumedCPUAndMemoryCountsRunningInitContainers(t *testing.T) {
+	t.Parallel()
+
+	initB := containerWithCPURequest("init-b", "200m")
+	initB.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "db-pod",
+			Namespace: "everest",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				containerWithCPURequest("init-a", "100m"),
+				initB,
+			},
+			Containers: []corev1.Container{
+				containerWithCPURequest("app", "500m"),
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "init-a",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{},
+					},
+				},
+				{
+					Name: "init-b",
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+	}
+
+	mockClient := fakeclient.NewClientBuilder().
+		WithScheme(CreateScheme()).
+		WithObjects(pod).
+		Build()
+	k := NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
+
+	cpuMillis, memoryBytes, err := k.GetConsumedCPUAndMemory(context.Background(), "everest")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(700), cpuMillis)
+	assert.Equal(t, uint64(0), memoryBytes)
+}
+
 func eksNode(instanceType string, diskPressure corev1.ConditionStatus) corev1.Node {
 	return corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -103,6 +159,17 @@ func eksNode(instanceType string, diskPressure corev1.ConditionStatus) corev1.No
 					Type:   corev1.NodeDiskPressure,
 					Status: diskPressure,
 				},
+			},
+		},
+	}
+}
+
+func containerWithCPURequest(name, cpu string) corev1.Container {
+	return corev1.Container{
+		Name: name,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse(cpu),
 			},
 		},
 	}


### PR DESCRIPTION


## Summary

Fixes incorrect cluster resource calculation when a Running pod has a terminated regular init container together with a still-running native sidecar (`initContainers[].restartPolicy: Always`).

`GetConsumedCPUAndMemory` used `IsContainerInState` on the full init container status list, which returned true if **any** init container had terminated. That dropped every init container request once the first regular init finished, so the sidecar's CPU/memory requests were missing from consumed resources. Because `available = capacity - consumed`, that undercount inflated reported cluster headroom.

## Changes

* Update `IsContainerInState` to check a named container instead of any container in the list
* Replace the JSON state round trip with direct `Waiting` / `Terminated` nil checks
* Count non-terminated init containers (including native sidecars) in `GetConsumedCPUAndMemory`
* Add unit tests for the helper and a sidecar regression fixture

## Test Plan

* [x] `go test -race ./pkg/kubernetes/... -run 'TestIsContainerInState|TestGetConsumedCPUAndMemory' -v`
* [x] `go test -race ./pkg/kubernetes/...`
* [x] `make copyright-check` on changed files

Fixes #2720

