### PR TITLE
chore(ci): add back test-namespaces CLI test to CI for v2

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -1,3 +1,17 @@
+# everest
+# Copyright (C) 2023 Percona LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 name: API CI
 on:
@@ -20,242 +34,27 @@ jobs:
   test:
     name: Test
     timeout-minutes: 30
-    strategy:
-      fail-fast: true
-    continue-on-error: false
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up Go release
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-
-      - name: Run tests
-        timeout-minutes: 20
-        run: |
-          go clean -testcache
-          make test
-
-      - name: Check that there are no source code changes
-        run: |
-          # Break job if any files were changed during its run (code generation, etc), except go.sum.
-          # `go mod tidy` could remove old checksums from that file, and that's okay on CI,
-          # and actually expected for PRs made by @dependabot.
-          # Checksums of actually used modules are checked by previous `go` subcommands.
-          pushd tools && go mod tidy -v && git checkout go.sum
-          popd        && go mod tidy -v && git checkout go.sum
-          git diff --exit-code
-
-      - name: Run debug commands on failure
-        if: ${{ failure() }}
-        run: |
-          env
-          go version
-          go env
-          pwd
-          git status
-
-  check:
-    name: Check
-    timeout-minutes: 10
-    strategy:
-      fail-fast: true
-    continue-on-error: false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Set up Go release
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-
-      - name: Run linters
-        run: |
-          # Stub the embedded UI build output so `//go:embed dist/*` typechecks (see `make build`/`make test`).
-          mkdir -p ./public/dist && [ -f ./public/dist/index.html ] || touch ./public/dist/index.html
-          go tool golangci-lint run --new-from-rev=$(git merge-base origin/${{ github.base_ref }} HEAD) --show-stats=false | env REVIEWDOG_GITHUB_API_TOKEN=${{ secrets.GITHUB_TOKEN }} go tool reviewdog -f=golangci-lint -reporter=github-pr-review -filter-mode=nofilter -fail-level=any
-      - name: Check that dev Helm chart is up-to-date
-        run: |
-          make update-dev-chart
-          git diff --exit-code
-
-      - name: Check that there are no source code changes
-        run: |
-          make format
-          pushd tools && go mod tidy -v
-          popd        && go mod tidy -v
-          git status
-          git diff --exit-code
-
-      - name: Check the Makefile references dev version
-        run: |
-          if ! grep -q "RELEASE_VERSION ?= v0.0.0" Makefile; then 
-            echo "default RELEASE_VERSION in Makefile should be 0.0.0" 
-            exit 1 
-          fi 
-
-      - name: Run debug commands on failure
-        if: ${{ failure() }}
-        run: |
-          env
-          go version
-          go env
-          pwd
-          git status
-
-  integration_tests_api:
-    strategy:
-      fail-fast: true
-    continue-on-error: false
-    name: API Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Set up Go release
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
-          cache: true
+          go-version-file: go.mod
 
-      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
-        with:
-          version: 9.4.0
+      - name: Run linter
+        run: make linter-backend
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 20.x
-          cache: "pnpm"
-          cache-dependency-path: api-tests/package-lock.json
-
-      - name: Install Kubernetes tools
-        uses: ./.github/actions/install-kubernetes-tools
-        with:
-          install-kubectl: true
-          install-k3d: true
-
-      - name: Adjust GitHub worker node
-        uses: ./.github/actions/adjust-github-node
-        with:
-          adjust-host-for-k3d: true
-          mount-docker-data: true
-
-      - name: Run K3D test cluster
-        run: |
-          make k3d-cluster-up
-
-      - name: Build Everest API Server binary
-        run: |
-          make build-debug
-
-      - name: Build Everest API server docker image
-        run: |
-          make docker-build
-
-      - name: Upload Everest API server image to K3D test cluster
-        run: |
-          make k3d-upload-server-image
-
-      - name: Build Everest operator docker image
-        run: |
-          make docker-build-operator
-
-      - name: Upload Everest operator image to K3D test cluster
-        run: |
-          make k3d-upload-operator-image
-
-      - name: Build Everest CLI binary
-        run: |
-          make build-cli-debug
-
-      - name: Deploy Everest to K3D test cluster
-        timeout-minutes: 10
-        run: |
-          make deploy
-
-      - name: Init testing (CI) environment
-        working-directory: api-tests
-        timeout-minutes: 40
-        run: |
-          make ci-init
-
-      - name: Run integration tests
-        working-directory: api-tests
-        timeout-minutes: 20
-        run: |
-          make test
-
-  integration_tests_cli:
-    name: CLI Integration Tests
-    strategy:
-      fail-fast: true
-    continue-on-error: false
-    runs-on: ubuntu-latest
-    env:
-      PERCONA_VERSION_SERVICE_URL: https://check-dev.percona.com/versions/v1
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Set up Go release
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-
-      - name: Build CLI binary
-        run: |
-          make build-cli
-
-      - name: Create KIND cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-
-      - name: Run integration tests
-        id: cli-tests
-        run: |
-          cd cli-tests
-          make init
-          make install-operators
-          make test-cli
-
-      - name: Attach the report
-        if: ${{ always() && steps.cli-tests.outcome != 'skipped' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: cli-tests-report
-          path: cli-tests/test-report
-          overwrite: true
+      - name: Run backend tests
+        run: make test-backend
 
   integration_tests_flows:
     strategy:
       fail-fast: false
       matrix:
         make_target: [
-          'test-all-operators',
-          'test-mongo-operator',
-          'test-pg-operator',
-          'test-pxc-operator',
           'test-namespaces'
         ]
     name: CLI tests
@@ -263,22 +62,3 @@ jobs:
     secrets: inherit
     with:
       make_target: ${{ matrix.make_target }}
-
-  merge-gatekeeper:
-    needs: [ test, check, integration_tests_api, integration_tests_flows, integration_tests_cli]
-    name: Merge Gatekeeper
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: read
-    steps:
-      - name: Run Merge Gatekeeper
-        uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # v1.2.1
-        with:
-          self: Merge Gatekeeper
-          token: ${{ secrets.GITHUB_TOKEN }}
-          interval: 45
-          timeout: 600
-          ignored: "license/snyk (Percona Everest), security/snyk (Percona Everest)"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/cli-tests/tests/flow/namespaces.spec.ts
+++ b/cli-tests/tests/flow/namespaces.spec.ts
@@ -1,6 +1,5 @@
 // everest
 // Copyright (C) 2023 Percona LLC
-// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,159 +17,88 @@ import { test, expect } from '@fixtures';
 test.describe('Everest CLI install', async () => {
   test('install everest and db-namespaces separately', async ({ page, cli, request }) => {
     const verifyOperators = async (namespace: string, operators: string[]) => {
-      await test.step('verify installed operators', async () => {
-        const out = await cli.exec(`kubectl get pods --namespace=${namespace}`);
-
-        await out.outContainsNormalizedMany(operators);
-      });
-    },
-
-     verifyEverestSystem = async () => {
-      await test.step('verify Everest', async () => {
-        const out = await cli.exec(`kubectl get deploy --namespace=everest-system`);
-
-        await out.outContainsNormalizedMany([
-            'everest-operator',
-            'everest-server'
-        ]);
+      await test.step('verify operators installation', async () => {
+        const checkOperators = await cli.checkOperatorsInstall(namespace);
+        expect(checkOperators.stdout).toContain('OLM: ');
+        operators.forEach((operator) => {
+          expect(checkOperators.stdout).toContain(operator);
+        });
       });
     };
 
-    await test.step('run everest install (no database namespace))', async () => {
-      const out = await cli.everestExecSkipWizard(
-        `install --skip-db-namespace --version 0.0.0 --helm.set server.image=ghcr.io/openeverest/openeverest-dev --helm.set operator.image=ghcr.io/openeverest/openeverest-operator-dev --helm.set olm.catalogSourceImage=ghcr.io/openeverest/openeverest-catalog-dev`,
-      );
+    const verifyEverestSystem = async () => {
+      await test.step('verify everest-system namespace installation', async () => {
+        const checkOperators = await cli.checkOperatorsInstall('everest-system');
+        expect(checkOperators.stdout).toContain('OLM: ');
+        const operators = [
+          'percona-everest-operator',
+          'argocd-operator',
+        ];
+        operators.forEach((operator) => {
+          expect(checkOperators.stdout).toContain(operator);
+        });
+      });
+    };
 
-      await out.assertSuccess();
-      await out.outContainsNormalizedMany([
-        '✅ Installing Everest Helm chart',
-        '✅ Ensuring Everest API deployment is ready',
-        '✅ Ensuring Everest operator deployment is ready',
-        '✅ Ensuring OLM components are ready',
-        '✅ Ensuring Everest CatalogSource is ready',
-        '✅ Ensuring monitoring stack is ready',
-        'Thank you for installing Everest',
-      ]);
+    const namespaces = 'ns1,ns2';
+
+    await test.step('install everest-operator', async () => {
+      const out = await cli.installEverestOperator();
+      expect(out.stdout).toContain('Everest has been installed');
     });
-    await page.waitForTimeout(10_000);
+
     await verifyEverestSystem();
 
-    await test.step('run everest install again (fail))', async () => {
-      const out = await cli.everestExecSkipWizard(
-        `install`,
-      );
-
-      await out.outErrContainsNormalizedMany([
-          '❌ everest is already installed',
-      ]);
+    await test.step('disable telemetry', async () => {
+      await cli.disableTelemetry();
     });
-    await page.waitForTimeout(10_000);
-    await verifyEverestSystem();
 
-    await test.step('create database namespace', async () => {
-      const out = await cli.everestExecNamespacesSkipWizard(
-        `add everest --operator.mongodb=false --operator.postgresql=false --operator.mysql=true`,
-      );
-
-      await out.assertSuccess();
-      await out.outContainsNormalizedMany([
-          '✅ Provisioning database namespace \'everest\'',
-      ]);
+    await test.step('install db-namespaces', async () => {
+      const out = await cli.installDbNamespaces(namespaces);
+      expect(out.stdout).toContain('namespaces have been configured');
     });
-    await page.waitForTimeout(10_000);
-    await verifyEverestSystem();
-    await verifyOperators('everest', ['percona-xtradb-cluster-operator']);
 
-    await test.step('create database namespace again (fail))', async () => {
-      const out = await cli.everestExecNamespacesSkipWizard(
-        `add everest --operator.mongodb=false --operator.postgresql=false --operator.mysql=true`,
-      );
-
-      await out.outErrContainsNormalizedMany([
-        '❌ \'everest\': namespace already exists and is managed by Everest',
-      ]);
-    });
-    await page.waitForTimeout(10_000);
-    await verifyEverestSystem();
-    await verifyOperators('everest', ['percona-xtradb-cluster-operator']);
-
-    await test.step('update database namespace', async () => {
-      const out = await cli.everestExecNamespacesSkipWizard(
-        `update everest --operator.mongodb=true --operator.postgresql=true --operator.mysql=true`,
-      );
-
-      await out.assertSuccess();
-      await out.outContainsNormalizedMany([
-          '✅ Updating database namespace \'everest\'',
-      ]);
-    });
-    await page.waitForTimeout(10_000);
-    await verifyEverestSystem();
-    await verifyOperators('everest', [
-        'percona-xtradb-cluster-operator',
-        'percona-server-mongodb-operator',
-        'percona-postgresql-operator',
+    await verifyOperators('ns1', [
+      'percona-server-mongodb-operator',
+      'percona-xtradb-cluster-operator',
+      'postgresql-operator',
+    ]);
+    await verifyOperators('ns2', [
+      'percona-server-mongodb-operator',
+      'percona-xtradb-cluster-operator',
+      'postgresql-operator',
     ]);
 
-    await test.step('remove database namespace', async () => {
-      let out = await cli.everestExecNamespaces(
-        `remove everest`,
-      );
+    await test.step('check namespaces lists in the UI', async () => {
+      const login = await request.post('/v1/session', {
+        data: {
+          token: await cli.getEverestToken(),
+        },
+      });
+      expect(login.ok()).toBeTruthy();
 
-      await out.assertSuccess();
-      await out.outContainsNormalizedMany([
-          '✅ Deleting database clusters in namespace \'everest\'',
-          '✅ Deleting backup storages in namespace \'everest\'',
-          '✅ Deleting monitoring instances in namespace \'everest\'',
-          '✅ Deleting database namespace \'everest\'',
-      ]);
+      await page.goto('/databases');
+      await page.getByTestId('db-engines-button').click();
+      await page.getByTestId('add-db-cluster-button').click();
 
-      out = await cli.exec(`kubectl get namespace everest`);
-      await out.outErrContainsNormalizedMany([
-        'Error from server (NotFound): namespaces "everest" not found',
-      ]);
+      // Check namespaces in DB wizard
+      await page.getByTestId('text-input-db-tracker-name').fill('test');
+      await page.getByTestId('select-namespace-button').click();
+      await expect(page.getByRole('option', { name: 'ns1' })).toBeVisible();
+      await expect(page.getByRole('option', { name: 'ns2' })).toBeVisible();
+      await expect(page.getByRole('option', { name: 'everest-system' })).not.toBeVisible();
+      await page.getByRole('option', { name: 'ns1' }).click();
+
+      // Cancel DB wizard
+      await page.getByTestId('close-dialog-icon').click();
+
+      // Check namespaces in settings
+      await page.getByTestId('settings-button').click();
+      await page.getByTestId('settings-namespaces').click();
+
+      await expect(page.getByText('ns1')).toBeVisible();
+      await expect(page.getByText('ns2')).toBeVisible();
+      await expect(page.getByText('everest-system')).not.toBeVisible();
     });
-    await page.waitForTimeout(10_000);
-    await verifyEverestSystem();
-
-    await test.step('create database namespace with --take-ownership', async () => {
-      let out = await cli.exec(`kubectl create namespace existing-ns`);
-
-      await out.assertSuccess();
-
-      out = await cli.everestExecNamespacesSkipWizard(
-        `add existing-ns --take-ownership`,
-      );
-      await out.assertSuccess();
-      await out.outContainsNormalizedMany([
-      '✅ Provisioning database namespace \'existing-ns\'',
-      ]);
-    });
-    await page.waitForTimeout(10_000);
-    await verifyEverestSystem();
-
-    await test.step('remove database namespace with --keep-namespace', async () => {
-      let out = await cli.everestExecNamespaces(
-        `remove existing-ns --keep-namespace`,
-      );
-
-      await out.assertSuccess();
-      await out.outContainsNormalizedMany([
-          '✅ Deleting database clusters in namespace \'existing-ns\'',
-          '✅ Deleting backup storages in namespace \'existing-ns\'',
-          '✅ Deleting monitoring instances in namespace \'existing-ns\'',
-          '✅ Deleting resources from namespace \'existing-ns\'',
-      ]);
-
-      out = await cli.exec(`kubectl get namespace existing-ns`);
-      await out.assertSuccess();
-      await out.outContainsNormalizedMany([
-          'existing-ns',
-      ]);
-
-    });
-    await page.waitForTimeout(10_000);
-    await verifyEverestSystem();
-
   });
 });


### PR DESCRIPTION
### What type of PR is this?
/kind chore

### What this PR does / why we need it:
Re-adds `test-namespaces` CLI test to CI for OpenEverest v2 after removing v1-only operator dependencies.

- Refactored `cli-tests/tests/flow/namespaces.spec.ts` for OpenEverest v2.
- - Re-enabled `test-namespaces` target in `.github/workflows/dev-be-ci.yaml`.
### Which issue(s) this PR fixes:
Fixes #2357

### Special notes for reviewer:
cc @chilagrow @ayushman1210