### PR TITLE
ci: skip fork-only-failing workflows outside upstream repo

### DIFF
--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   auto-update-base:
+    if: github.repository == 'openeverest/openeverest'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'openeverest/openeverest'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.repository == 'openeverest/openeverest'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- Fixes #2111 by gating `storybook.yml`, `auto-update-base.yaml`, and `dev-build.yaml` with `if: github.repository == 'openeverest/openeverest'`.
- Prevents these workflows from running on forks, where required secrets and permissions are unavailable and cause noisy CI failures.

## Test plan
- [ ] Confirm jobs are skipped when the workflow runs in a fork (`github.repository` != `openeverest/openeverest`).
- [ ] Confirm jobs still run normally on `openeverest/openeverest` (push to `main` / workflow_dispatch as applicable).