### PR TITLE
fix(oidc): add HTTP timeout for well-known config fetch

### DIFF
--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -47,6 +48,9 @@ type ProviderConfig struct {
 const (
 	// WellKnownPath is the path to the well-known OIDC configuration.
 	WellKnownPath = "/.well-known/openid-configuration"
+
+	// defaultHTTPClientTimeout bounds OIDC well-known config fetches.
+	defaultHTTPClientTimeout = 30 * time.Second
 )
 
 // ErrUnexpectedSatusCode is returned when HTTP 200 is not returned.
@@ -63,7 +67,8 @@ func NewProviderConfig(ctx context.Context, issuer string) (ProviderConfig, erro
 	if err != nil {
 		return ProviderConfig{}, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: defaultHTTPClientTimeout}
+	resp, err := client.Do(req)
 	if err != nil {
 		return ProviderConfig{}, err
 	}


### PR DESCRIPTION
## Summary
- Fixes #2257 by replacing `http.DefaultClient` with a 30s-bounded `http.Client` in `pkg/oidc/oidc.go`.
- Prevents everest-server startup from hanging when the OIDC IdP is slow or unreachable.

## Test plan
- [ ] Confirm `NewProviderConfig` uses a client with `Timeout: 30s`.
- [ ] With a reachable issuer, OIDC config fetch still succeeds.
- [ ] With an unreachable/slow issuer, the call fails within ~30s instead of hanging.