### PR TITLE
ci: drop unsupported semver-major-days from github-actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -102,7 +102,6 @@ updates:
           - "patch"
     cooldown:
       default-days: 7
-      semver-major-days: 14
   - package-ecosystem: "npm"
     directory: "/api-tests"
     schedule:
@@ -245,7 +244,6 @@ updates:
           - "patch"
     cooldown:
       default-days: 7
-      semver-major-days: 14
   - package-ecosystem: "npm"
     directory: "/api-tests"
     schedule:


### PR DESCRIPTION
Follow-up to #2722, which Dependabot rejects with:

```
The property '#/updates/4/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/12/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
```

Dependabot does not classify GitHub Actions version bumps by semver level, so the `semver-*-days` cooldown keys aren't accepted for that ecosystem — only `default-days` is. This removes the key from both the v1 and v2 `github-actions` configs, keeping the 7-day `default-days`.

The `gomod` and `npm` configs are unaffected and keep `semver-major-days: 14`.

Note that until this lands the whole config is invalid, so none of the grouping from #2722 is in effect yet.