### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -274,10 +274,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Set up Go release
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/dev-fe-browser-tests.yaml
+++ b/.github/workflows/dev-fe-browser-tests.yaml
@@ -12,17 +12,17 @@ jobs:
       run:
         working-directory: ui
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           lfs: true
           ref: ${{ github.sha }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 9.4.0
 
       - name: Use Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20.x
           cache: "pnpm"
@@ -32,7 +32,7 @@ jobs:
         run: pnpm install
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('ui/pnpm-lock.yaml') }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload browser test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vitest-browser-reports
           path: ui/apps/everest/test-results/


### PR DESCRIPTION
## Why

Actions must now be pinned to full-length commit SHAs at the org level. A mutable tag means the action's owner — or anyone who compromises them — can change what executes in our pipelines retroactively, and unpinned workflows no longer run.

`main` is already fully pinned (19/19 workflows). This branch had drifted: `dev-be-ci.yaml` was *partially* pinned — some steps on SHAs, some on tags — and `dev-fe-browser-tests.yaml` was entirely unpinned. Both are recent additions, which is the signature of a convention that nothing enforces.

## What

Every `uses:` tag reference is replaced with the commit SHA that tag points at today, keeping the human-readable version in a trailing comment:

```diff
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
```

- **Behaviour-preserving** — same code runs, it just can't change underneath us.
- Comments use the most specific release tag pointing at that commit, matching the convention already used on `main`.
- Line-for-line; no reordering or reformatting.

7 references across 2 workflows. Generated mechanically and YAML-validated. Part of an org-wide sweep across all repositories.

## Note

`dev-fe-browser-tests.yaml` is also the one workflow on this branch with no top-level `permissions:` block, so it inherits the org default. That's now `read`, so it's not a live problem — but worth adding for the same reason as the pinning: conventions that aren't enforced drift.
