### PR TITLE
ci: scan release-2.0 and workflow files with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release-2.0"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ["main"]
+    branches: ["main", "release-2.0"]
   schedule:
     - cron: "0 0 * * 1"
 
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go", "javascript", "python", "typescript"]
+        language: ["actions", "go", "javascript", "python", "typescript"]
         # CodeQL supports [ $supported-codeql-languages ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun


### PR DESCRIPTION
## `release-2.0` has never been scanned by CodeQL

`codeql.yml` filters both triggers to `main`:

```yaml
on:
  push:
    branches: ["main"]
  pull_request:
    branches: ["main"]
```

The copy of this file living **on `release-2.0` carries the same filter**, so it can never fire on this branch. For `pull_request`, `branches:` matches the *base* branch, so PRs targeting `release-2.0` are excluded too.

Confirmed against the API — every CodeQL analysis in this repo is for `refs/heads/main` or a main-targeting PR:

```
$ gh api "/repos/openeverest/openeverest/code-scanning/analyses?ref=refs/heads/release-2.0" --jq 'length'
0
```

Zero analyses, ever, on the active v2 development branch.

## Changes

**1. Cover both maintained branches**

```diff
   push:
-    branches: ["main"]
+    branches: ["main", "release-2.0"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release-2.0"]
```

Each branch's copy now covers the branch it lives on. Listing both in both copies keeps the file identical across branches, so a future cherry-pick or merge can't silently revert the fix — which is how this gap arose.

**2. Analyse the workflow files themselves**

```diff
-        language: ["go", "javascript", "python", "typescript"]
+        language: ["actions", "go", "javascript", "python", "typescript"]
```

CodeQL's `actions` language finds script injection via `${{ github.event.* }}` in `run:` blocks, unsafe `pull_request_target` + PR-head-checkout combinations, and over-broad `permissions:` — the exact class of issue we've been auditing by hand. Making it self-detecting is worth more than any one fix.

`actions` is a non-compiled language, so the existing `Autobuild` step no-ops for it, as it already does for javascript/python/typescript. No structural change to the job.

## Expect findings on first run

This is the first analysis of `release-2.0`, so it will likely surface a backlog rather than come back clean. Worth triaging rather than merging and forgetting.

A matching PR against `main` carries the identical change.
