### PR TITLE
ci: scan release-2.0 and workflow files with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release-2.0"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ["main"]
+    branches: ["main", "release-2.0"]
   schedule:
     - cron: "0 0 * * 1"
 
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go", "javascript", "python", "typescript"]
+        language: ["actions", "go", "javascript", "python", "typescript"]
         # CodeQL supports [ $supported-codeql-languages ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 


### PR DESCRIPTION
Companion to #2753 — the identical change on `main`, so `codeql.yml` stays byte-identical across both maintained branches.

## Why the branch filter changes here too

`main`'s copy only ever sees `main` events, so `"release-2.0"` in its filter is inert today. It's included so the file doesn't diverge between branches: this gap exists precisely *because* the `release-2.0` copy inherited `branches: ["main"]` from `main` and nobody noticed it was now wrong. Keeping the files identical means a future cherry-pick can't reintroduce it.

Full analysis of the scanning gap is in #2753 — `release-2.0` has **zero** CodeQL analyses to date.

## Changes

```diff
   push:
-    branches: ["main"]
+    branches: ["main", "release-2.0"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release-2.0"]
...
-        language: ["go", "javascript", "python", "typescript"]
+        language: ["actions", "go", "javascript", "python", "typescript"]
```

The `actions` language analyses workflow files for script injection via `${{ github.event.* }}`, unsafe `pull_request_target` patterns, and over-broad `permissions:`. `actions` is non-compiled, so `Autobuild` no-ops for it exactly as it does for javascript/python/typescript.

## Note

`main` has been scanned continuously (29 analyses), so this should mostly add `actions` findings rather than a large backlog.
