### PR TITLE
ci: group codeql-action sub-actions in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,6 +94,15 @@ updates:
       - "github_actions"
     target-branch: "main"
     groups:
+      # github/codeql-action/init, /autobuild and /analyze are separate
+      # dependencies to Dependabot, so it opens a PR per sub-action. Merging
+      # them independently desynchronises the versions, and CodeQL then fails
+      # every analysis with "Loaded a configuration file for version X, but
+      # running version Y". Grouping keeps them atomic. No update-types filter,
+      # so majors group too — that is when a mismatch is guaranteed to break.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
       github-actions:
         patterns:
           - "*"
@@ -236,6 +245,15 @@ updates:
       - "github_actions"
     target-branch: "release-2.0"
     groups:
+      # github/codeql-action/init, /autobuild and /analyze are separate
+      # dependencies to Dependabot, so it opens a PR per sub-action. Merging
+      # them independently desynchronises the versions, and CodeQL then fails
+      # every analysis with "Loaded a configuration file for version X, but
+      # running version Y". Grouping keeps them atomic. No update-types filter,
+      # so majors group too — that is when a mismatch is guaranteed to break.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
       github-actions-v2:
         patterns:
           - "*"

--- a/go.mod
+++ b/go.mod
@@ -26,9 +26,9 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.1.0
 	github.com/oapi-codegen/runtime v1.6.0
-	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260706135153-83a0cdff4b7d
+	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260802112009-c90cbb874f05
 	github.com/operator-framework/api v0.45.0
-	github.com/percona/everest-operator v0.6.0-dev1.0.20260713100559-df3fbdf1ee9a
+	github.com/percona/everest-operator v0.6.0-dev1.0.20260802112029-d78a6b920f67
 	github.com/rodaine/table v1.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -810,8 +810,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260706135153-83a0cdff4b7d h1:yVwXd6ogqTJf5XyK7knHhp3rVxUD3polD7wbIUUP73Q=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260706135153-83a0cdff4b7d/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260802112009-c90cbb874f05 h1:q0L1AjUWNVbqzWJN1UGi35d887Asg2CcVquBM4m+N0A=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260802112009-c90cbb874f05/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
 github.com/operator-framework/api v0.45.0 h1:hkROwtsLH3oszp4IW+WsXEFSDgveSahHI7DKStOtrUI=
 github.com/operator-framework/api v0.45.0/go.mod h1:IQ4uuISTiIhV09oAurJSGD4KabayhY5nV6k1XmA235M=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
@@ -824,8 +824,8 @@ github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
-github.com/percona/everest-operator v0.6.0-dev1.0.20260713100559-df3fbdf1ee9a h1:mU61zRrnToMPlGHL5ddCXMeyJk9d77QZwDzj3A+m/i0=
-github.com/percona/everest-operator v0.6.0-dev1.0.20260713100559-df3fbdf1ee9a/go.mod h1:VrplSKtIxGi2S8ZYvugNLR+LctYxpd9GPyCICGKMKtc=
+github.com/percona/everest-operator v0.6.0-dev1.0.20260802112029-d78a6b920f67 h1:WNoIUED8GF7DnKTw+8dz2pDarrpeWXXZ26U1EojoL/k=
+github.com/percona/everest-operator v0.6.0-dev1.0.20260802112029-d78a6b920f67/go.mod h1:VrplSKtIxGi2S8ZYvugNLR+LctYxpd9GPyCICGKMKtc=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20251104101930-05ab6d7e1004 h1:Q/HeUxMI63ekZYY0TlnfF0Vp3WZ0mmx7gI9iBzehjeY=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20251104101930-05ab6d7e1004/go.mod h1:NYc9wcoGLNXmOHwfsaed+Ej3nxv3dUViHOcCfQneJ84=
 github.com/percona/percona-postgresql-operator/v2 v2.9.1-0.20260522133121-1f77e9d3c184 h1:5UsPFYemyDyw772RfvRMbpW8DKlcE0Gbz6vg3heUWcY=


### PR DESCRIPTION
## What happened

Dependabot treats `github/codeql-action/init`, `/autobuild` and `/analyze` as **separate dependencies** and opens a PR per sub-action:

```
#2704 [MERGED] base=release-2.0  codeql-action/analyze  4.35.3 → 4.37.3   (+1/-1)
#2629 [CLOSED] base=main         codeql-action/init     4.35.4 → 4.37.3   ← never merged
#2632 [MERGED] base=main         codeql-action/analyze  4.35.4 → 4.37.3
```

Merging `/analyze` without `/init` and `/autobuild` left `release-2.0` with mismatched versions, and **every** CodeQL analysis failed:

```
Loaded a configuration file for version '4.35.3', but running version '4.37.3'
```

Not one step — all five language jobs, because `init` writes the config that `analyze` reads.

It went unnoticed for three months because `codeql.yml` filtered its triggers to `main`, so CodeQL had never run on `release-2.0` at all (see #2753).

## Why the existing group didn't catch it

```yaml
groups:
  github-actions:
    patterns: ["*"]
    update-types: ["minor", "patch"]   # ← majors fall outside the group
```

A major bump like `3.35.2 → 4.35.3` isn't grouped, so the sub-actions arrive as independent PRs — precisely the case where a mismatch is *guaranteed* to break, since v3 and v4 configs are incompatible.

## Change

A dedicated group, listed **before** the catch-all so it wins the match, with **no** `update-types` filter so majors stay atomic:

```yaml
groups:
  codeql-action:
    patterns:
      - "github/codeql-action*"
  github-actions:
    patterns: ["*"]
    update-types: ["minor", "patch"]
```

Applied to both the `main` and `release-2.0` ecosystem entries, since they're configured separately. The wildcard also covers `/upload-sarif`, which `scorecard.yml` uses.

Config-only; YAML validated. Companion PR carries the identical change to `release-2.0`.
