### PR TITLE
ci: group codeql-action sub-actions in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,6 +94,15 @@ updates:
       - "github_actions"
     target-branch: "main"
     groups:
+      # github/codeql-action/init, /autobuild and /analyze are separate
+      # dependencies to Dependabot, so it opens a PR per sub-action. Merging
+      # them independently desynchronises the versions, and CodeQL then fails
+      # every analysis with "Loaded a configuration file for version X, but
+      # running version Y". Grouping keeps them atomic. No update-types filter,
+      # so majors group too — that is when a mismatch is guaranteed to break.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
       github-actions:
         patterns:
           - "*"
@@ -236,6 +245,15 @@ updates:
       - "github_actions"
     target-branch: "release-2.0"
     groups:
+      # github/codeql-action/init, /autobuild and /analyze are separate
+      # dependencies to Dependabot, so it opens a PR per sub-action. Merging
+      # them independently desynchronises the versions, and CodeQL then fails
+      # every analysis with "Loaded a configuration file for version X, but
+      # running version Y". Grouping keeps them atomic. No update-types filter,
+      # so majors group too — that is when a mismatch is guaranteed to break.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
       github-actions-v2:
         patterns:
           - "*"


### PR DESCRIPTION
Companion to the `main` PR — identical change, so `dependabot.yml` stays byte-identical across both branches.

## What happened

Dependabot treats `github/codeql-action/init`, `/autobuild` and `/analyze` as **separate dependencies** and opens a PR per sub-action. #2704 bumped only `/analyze` on this branch:

```diff
-        uses: github/codeql-action/analyze@e46ed2cb... # v4.35.3
+        uses: github/codeql-action/analyze@e4fba868... # v4.37.3
```

That left `init` and `autobuild` on v4.35.3, and **every** CodeQL analysis failed:

```
Loaded a configuration file for version '4.35.3', but running version '4.37.3'
```

All five language jobs, not just one — `init` writes the config `analyze` reads.

It went unnoticed because `codeql.yml` filtered its triggers to `main`, so CodeQL had never run on `release-2.0` at all. #2753 both enables scanning here and repairs the mismatch; this PR stops it recurring.

## Why the existing group didn't catch it

`github-actions-v2` is scoped to `update-types: ["minor", "patch"]`, so major bumps arrive ungrouped — exactly when a mismatch is guaranteed to break, since v3 and v4 configs are incompatible.

## Change

```yaml
groups:
  codeql-action:
    patterns:
      - "github/codeql-action*"
  github-actions-v2:
    patterns: ["*"]
    update-types: ["minor", "patch"]
```

Listed before the catch-all so it wins the match; no `update-types` filter so majors stay atomic. The wildcard also covers `/upload-sarif`.

Config-only; YAML validated.
