### PR TITLE
Ctl everestctl backup storage delete

### DIFF
--- a/commands/backupstorage.go
+++ b/commands/backupstorage.go
@@ -33,4 +33,5 @@ func init() {
 	rootCmd.AddCommand(backupStorageCmd)
 	backupStorageCmd.AddCommand(backupstorage.GetListCmd())
 	backupStorageCmd.AddCommand(backupstorage.GetCreateCmd())
+	backupStorageCmd.AddCommand(backupstorage.GetDeleteCmd())
 }

--- a/commands/backupstorage/delete.go
+++ b/commands/backupstorage/delete.go
@@ -76,7 +76,7 @@ list'/'everestctl backup list' for the namespace.`,
 
 func init() {
 	deleteCmd.Flags().StringVar(&deleteOpts.Name, cli.FlagBackupStorageName, "", "Backup storage name (required)")
-	deleteCmd.Flags().StringVar(&deleteOpts.Namespace, cli.FlagBackupStorageNamespace, "", "Namespace the backup storage is in (required)")
+	deleteCmd.Flags().StringVarP(&deleteOpts.Namespace, cli.FlagBackupStorageNamespace, "n", "", "Namespace the backup storage is in (required)")
 	deleteCmd.Flags().StringVar(&deleteOpts.Cluster, cli.FlagBackupStorageCluster, "main", "Cluster name")
 	deleteCmd.Flags().StringVar(&deleteOpts.Context, cli.FlagBackupStorageContext, "", "Context to use (default: current context)")
 	deleteCmd.Flags().BoolVarP(&deleteOpts.Yes, cli.FlagYes, "y", false, "Skip the confirmation prompt")
@@ -110,7 +110,7 @@ func deleteRun(cmd *cobra.Command, _ []string) {
 	d := backupstoragecli.NewDeleter(*deleteCfg, logger.GetLogger())
 	runErr := d.Run(cmd.Context(), *deleteOpts, cfgPath)
 	os.Exit(waitcmd.ExitCode(runErr, logger.GetLogger(), deleteCfg.Pretty,
-		fmt.Sprintf("wait cancelled; backup storage %q deletion continues in the background", deleteOpts.Name),
+		fmt.Sprintf("wait cancelled; backup storage %q deletion continues in the background — check with 'everestctl backup-storage list --namespace %s'", deleteOpts.Name, deleteOpts.Namespace),
 		fmt.Sprintf("timed out after %s waiting for backup storage %q to be deleted; deletion is still running server-side — a stuck delete is almost always an Instance or Backup that still references the storage, check 'everestctl instance list --namespace %s' / 'everestctl backup list --namespace %s'",
 			deleteOpts.Timeout, deleteOpts.Name, deleteOpts.Namespace, deleteOpts.Namespace),
 	))

--- a/commands/backupstorage/delete.go
+++ b/commands/backupstorage/delete.go
@@ -48,7 +48,14 @@ unless it was externally referenced before being adopted.
 Interactively (a terminal, no --yes), you'll be asked to confirm with y/N.
 Pass --yes/-y to skip the prompt; in a non-interactive context (no terminal,
 or --json) omitting --yes fails immediately instead of hanging on a prompt
-nobody can answer.`,
+nobody can answer.
+
+--ignore-not-found treats an already-absent backup storage as success and
+skips both the confirmation prompt and --wait entirely, since there's
+nothing to confirm or wait for. If --wait times out, the deletion is still
+running server-side, and a stuck delete is almost always an Instance or
+Backup that still references the storage, so point at 'everestctl instance
+list'/'everestctl backup list' for the namespace.`,
 		Example: `  # Delete a backup storage (prompts y/N)
   everestctl backup-storage delete --name my-s3 --namespace everest
 
@@ -56,7 +63,10 @@ nobody can answer.`,
   everestctl backup-storage delete --name my-s3 --namespace everest -y
 
   # Scripted teardown, wait until fully removed
-  everestctl backup-storage delete --name my-s3 --namespace everest --yes --wait --timeout 5m`,
+  everestctl backup-storage delete --name my-s3 --namespace everest --yes --wait --timeout 5m
+
+  # Idempotent teardown: treat "already gone" as success
+  everestctl backup-storage delete --name my-s3 --namespace everest --yes --ignore-not-found`,
 		PreRun: deletePreRun,
 		Run:    deleteRun,
 	}
@@ -70,6 +80,7 @@ func init() {
 	deleteCmd.Flags().StringVar(&deleteOpts.Cluster, cli.FlagBackupStorageCluster, "main", "Cluster name")
 	deleteCmd.Flags().StringVar(&deleteOpts.Context, cli.FlagBackupStorageContext, "", "Context to use (default: current context)")
 	deleteCmd.Flags().BoolVarP(&deleteOpts.Yes, cli.FlagYes, "y", false, "Skip the confirmation prompt")
+	deleteCmd.Flags().BoolVar(&deleteOpts.IgnoreNotFound, cli.FlagBackupStorageIgnoreNotFound, false, "Treat \"backup storage already gone\" as a successful delete instead of an error")
 	deleteCmd.Flags().BoolVar(&deleteOpts.Wait, cli.FlagBackupStorageWait, false, "Block until the backup storage is fully deleted (Ctrl-C cancels only the wait, not the deletion)")
 	deleteCmd.Flags().DurationVar(&deleteOpts.Timeout, cli.FlagBackupStorageTimeout, 5*time.Minute, "Maximum time to wait (only valid with --wait); must be positive")
 
@@ -108,7 +119,8 @@ func deleteRun(cmd *cobra.Command, _ []string) {
 	stop()
 	os.Exit(waitcmd.ExitCode(runErr, logger.GetLogger(), deleteCfg.Pretty,
 		fmt.Sprintf("wait cancelled; backup storage %q deletion continues in the background", deleteOpts.Name),
-		fmt.Sprintf("timed out after %s waiting for backup storage %q to be deleted — it may still be referenced by an Instance or Backup", deleteOpts.Timeout, deleteOpts.Name),
+		fmt.Sprintf("timed out after %s waiting for backup storage %q to be deleted; deletion is still running server-side — a stuck delete is almost always an Instance or Backup that still references the storage, check 'everestctl instance list --namespace %s' / 'everestctl backup list --namespace %s'",
+			deleteOpts.Timeout, deleteOpts.Name, deleteOpts.Namespace, deleteOpts.Namespace),
 	))
 }
 

--- a/commands/backupstorage/delete.go
+++ b/commands/backupstorage/delete.go
@@ -38,9 +38,12 @@ var (
 		Long: `Delete a BackupStorage through the Everest API.
 
 The name and namespace flags are required. The credentials Secret is not
-deleted by this command directly — it's owned by the BackupStorage and is
-garbage-collected by Kubernetes once the BackupStorage is actually gone,
-unless it was externally referenced before being adopted.
+deleted by this command directly. The BackupStorage controller adopts any
+credentials Secret with no existing owner, whether it was CLI-generated or
+supplied via --credentials-secret, and Kubernetes garbage-collects it once
+the BackupStorage is actually gone. A Secret shared across multiple backup
+storages via --credentials-secret is not protected from this: deleting
+whichever storage adopted it first takes the Secret down too.
 
 Interactively (a terminal, no --yes), you'll be asked to confirm with y/N.
 Pass --yes/-y to skip the prompt; in a non-interactive context (no terminal,

--- a/commands/backupstorage/delete.go
+++ b/commands/backupstorage/delete.go
@@ -1,0 +1,119 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupstorage
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli"
+	backupstoragecli "github.com/openeverest/openeverest/v2/pkg/cli/backupstorage"
+	"github.com/openeverest/openeverest/v2/pkg/cli/config"
+	"github.com/openeverest/openeverest/v2/pkg/cli/waitcmd"
+	"github.com/openeverest/openeverest/v2/pkg/logger"
+	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+var (
+	deleteCmd = &cobra.Command{
+		Use:   "delete [flags]",
+		Args:  cobra.NoArgs,
+		Short: "Delete a backup storage",
+		Long: `Delete a BackupStorage through the Everest API.
+
+The name and namespace flags are required. The credentials Secret is not
+deleted by this command directly — it's owned by the BackupStorage and is
+garbage-collected by Kubernetes once the BackupStorage is actually gone,
+unless it was externally referenced before being adopted.
+
+Interactively (a terminal, no --yes), you'll be asked to confirm with y/N.
+Pass --yes/-y to skip the prompt; in a non-interactive context (no terminal,
+or --json) omitting --yes fails immediately instead of hanging on a prompt
+nobody can answer.`,
+		Example: `  # Delete a backup storage (prompts y/N)
+  everestctl backup-storage delete --name my-s3 --namespace everest
+
+  # Scripted
+  everestctl backup-storage delete --name my-s3 --namespace everest -y
+
+  # Scripted teardown, wait until fully removed
+  everestctl backup-storage delete --name my-s3 --namespace everest --yes --wait --timeout 5m`,
+		PreRun: deletePreRun,
+		Run:    deleteRun,
+	}
+	deleteCfg  = &backupstoragecli.Config{}
+	deleteOpts = &backupstoragecli.DeleteOptions{}
+)
+
+func init() {
+	deleteCmd.Flags().StringVar(&deleteOpts.Name, cli.FlagBackupStorageName, "", "Backup storage name (required)")
+	deleteCmd.Flags().StringVar(&deleteOpts.Namespace, cli.FlagBackupStorageNamespace, "", "Namespace the backup storage is in (required)")
+	deleteCmd.Flags().StringVar(&deleteOpts.Cluster, cli.FlagBackupStorageCluster, "main", "Cluster name")
+	deleteCmd.Flags().StringVar(&deleteOpts.Context, cli.FlagBackupStorageContext, "", "Context to use (default: current context)")
+	deleteCmd.Flags().BoolVarP(&deleteOpts.Yes, cli.FlagYes, "y", false, "Skip the confirmation prompt")
+	deleteCmd.Flags().BoolVar(&deleteOpts.Wait, cli.FlagBackupStorageWait, false, "Block until the backup storage is fully deleted (Ctrl-C cancels only the wait, not the deletion)")
+	deleteCmd.Flags().DurationVar(&deleteOpts.Timeout, cli.FlagBackupStorageTimeout, 5*time.Minute, "Maximum time to wait (only valid with --wait); must be positive")
+
+	_ = deleteCmd.MarkFlagRequired(cli.FlagBackupStorageName)
+	_ = deleteCmd.MarkFlagRequired(cli.FlagBackupStorageNamespace)
+}
+
+func deletePreRun(cmd *cobra.Command, _ []string) {
+	deleteCfg.Pretty = !cmd.Flag(cli.FlagVerbose).Changed && !cmd.Flag(cli.FlagJSON).Changed
+}
+
+//nolint:dupl
+func deleteRun(cmd *cobra.Command, _ []string) {
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		output.PrintError(err, logger.GetLogger(), deleteCfg.Pretty)
+		os.Exit(waitcmd.ExitFailed)
+	}
+
+	if err := waitcmd.ValidateWaitFlags(deleteOpts.Wait, cmd.Flags().Changed(cli.FlagBackupStorageTimeout), deleteOpts.Timeout); err != nil {
+		output.PrintError(err, logger.GetLogger(), deleteCfg.Pretty)
+		os.Exit(waitcmd.ExitFailed)
+	}
+
+	ctx := cmd.Context()
+	stop := func() {}
+	if deleteOpts.Wait {
+		// Ctrl-C cancels only the wait; deletion continues server-side.
+		var cancel context.CancelFunc
+		ctx, cancel = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+		stop = cancel
+	}
+
+	d := backupstoragecli.NewDeleter(*deleteCfg, logger.GetLogger())
+	runErr := d.Run(ctx, *deleteOpts, cfgPath)
+	// Release the signal handler before os.Exit (which skips defers).
+	stop()
+	os.Exit(waitcmd.ExitCode(runErr, logger.GetLogger(), deleteCfg.Pretty,
+		fmt.Sprintf("wait cancelled; backup storage %q deletion continues in the background", deleteOpts.Name),
+		fmt.Sprintf("timed out after %s waiting for backup storage %q to be deleted", deleteOpts.Timeout, deleteOpts.Name),
+	))
+}
+
+// GetDeleteCmd returns the delete command.
+func GetDeleteCmd() *cobra.Command {
+	return deleteCmd
+}

--- a/commands/backupstorage/delete.go
+++ b/commands/backupstorage/delete.go
@@ -16,11 +16,8 @@
 package backupstorage
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -90,6 +87,7 @@ func init() {
 
 func deletePreRun(cmd *cobra.Command, _ []string) {
 	deleteCfg.Pretty = !cmd.Flag(cli.FlagVerbose).Changed && !cmd.Flag(cli.FlagJSON).Changed
+	deleteOpts.JSON = cmd.Flag(cli.FlagJSON).Changed
 }
 
 func deleteRun(cmd *cobra.Command, _ []string) {
@@ -104,19 +102,10 @@ func deleteRun(cmd *cobra.Command, _ []string) {
 		os.Exit(waitcmd.ExitFailed)
 	}
 
-	ctx := cmd.Context()
-	stop := func() {}
-	if deleteOpts.Wait {
-		// Ctrl-C cancels only the wait; deletion continues server-side.
-		var cancel context.CancelFunc
-		ctx, cancel = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-		stop = cancel
-	}
-
+	// Ctrl-C only cancels --wait; the cancellable context is set up inside
+	// Deleter.waitForDeletion, not here.
 	d := backupstoragecli.NewDeleter(*deleteCfg, logger.GetLogger())
-	runErr := d.Run(ctx, *deleteOpts, cfgPath)
-	// Release the signal handler before os.Exit (which skips defers).
-	stop()
+	runErr := d.Run(cmd.Context(), *deleteOpts, cfgPath)
 	os.Exit(waitcmd.ExitCode(runErr, logger.GetLogger(), deleteCfg.Pretty,
 		fmt.Sprintf("wait cancelled; backup storage %q deletion continues in the background", deleteOpts.Name),
 		fmt.Sprintf("timed out after %s waiting for backup storage %q to be deleted; deletion is still running server-side — a stuck delete is almost always an Instance or Backup that still references the storage, check 'everestctl instance list --namespace %s' / 'everestctl backup list --namespace %s'",

--- a/commands/backupstorage/delete.go
+++ b/commands/backupstorage/delete.go
@@ -81,7 +81,6 @@ func deletePreRun(cmd *cobra.Command, _ []string) {
 	deleteCfg.Pretty = !cmd.Flag(cli.FlagVerbose).Changed && !cmd.Flag(cli.FlagJSON).Changed
 }
 
-//nolint:dupl
 func deleteRun(cmd *cobra.Command, _ []string) {
 	cfgPath, err := config.DefaultPath()
 	if err != nil {
@@ -109,7 +108,7 @@ func deleteRun(cmd *cobra.Command, _ []string) {
 	stop()
 	os.Exit(waitcmd.ExitCode(runErr, logger.GetLogger(), deleteCfg.Pretty,
 		fmt.Sprintf("wait cancelled; backup storage %q deletion continues in the background", deleteOpts.Name),
-		fmt.Sprintf("timed out after %s waiting for backup storage %q to be deleted", deleteOpts.Timeout, deleteOpts.Name),
+		fmt.Sprintf("timed out after %s waiting for backup storage %q to be deleted — it may still be referenced by an Instance or Backup", deleteOpts.Timeout, deleteOpts.Name),
 	))
 }
 

--- a/pkg/cli/backup/create.go
+++ b/pkg/cli/backup/create.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/openeverest/openeverest/v2/client"
 	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/clienterr"
 	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
 	"github.com/openeverest/openeverest/v2/pkg/output"
 )
@@ -100,8 +101,8 @@ func (cr *CreateRunner) Run(ctx context.Context, opts CreateOptions, cfgPath str
 		if resp.StatusCode() == http.StatusConflict {
 			return fmt.Errorf("backup %q already exists in namespace %q", opts.Name, opts.Namespace)
 		}
-		if resp.JSONDefault != nil && resp.JSONDefault.Message != nil {
-			return fmt.Errorf("server error: %s", *resp.JSONDefault.Message)
+		if msg, ok := clienterr.Message(resp.JSONDefault); ok {
+			return fmt.Errorf("server error: %s", msg)
 		}
 		return fmt.Errorf("unexpected response creating backup: %s", resp.Status())
 	}

--- a/pkg/cli/backupstorage/delete.go
+++ b/pkg/cli/backupstorage/delete.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"go.uber.org/zap"
@@ -41,6 +43,7 @@ type DeleteOptions struct {
 	Cluster        string
 	Context        string        // overrides the active context when set
 	Yes            bool          // skip the confirmation prompt
+	JSON           bool          // --json was passed; forces non-interactive regardless of --verbose
 	IgnoreNotFound bool          // treat "backup storage already gone" (404) as a successful delete
 	Wait           bool          // block until the backup storage is fully deleted
 	Timeout        time.Duration // bounds --wait; must be positive
@@ -65,9 +68,11 @@ func NewDeleter(cfg Config, l *zap.SugaredLogger) *Deleter {
 }
 
 // Run deletes the backup storage: confirms, deletes, then waits if asked.
-// The credentials Secret is not handled here — the BackupStorage controller
-// adopts it via an owner reference, so Kubernetes garbage-collects it once
-// the BackupStorage is actually gone.
+// ctx stays plain here so Ctrl-C during confirm is a decline, not a
+// cancelled wait, see waitForDeletion. The credentials Secret is not
+// handled here — the BackupStorage controller adopts it via an owner
+// reference, so Kubernetes garbage-collects it once the BackupStorage is
+// actually gone.
 func (bd *Deleter) Run(ctx context.Context, opts DeleteOptions, cfgPath string) error {
 	c, err := authcli.NewAPIClient(authcli.Config{Pretty: bd.config.Pretty}, bd.l.Desugar().Sugar(), cfgPath, opts.Context)
 	if err != nil {
@@ -75,10 +80,10 @@ func (bd *Deleter) Run(ctx context.Context, opts DeleteOptions, cfgPath string) 
 	}
 
 	if opts.IgnoreNotFound && bd.backupStorageAlreadyGone(ctx, c, opts) {
-		return bd.emitDeleted(opts)
+		return bd.emitAlreadyGone(opts)
 	}
 
-	confirmOpts := confirm.Options{Yes: opts.Yes, JSON: !bd.config.Pretty, IsTerminal: opts.IsTerminal}
+	confirmOpts := confirm.Options{Yes: opts.Yes, JSON: opts.JSON, IsTerminal: opts.IsTerminal}
 	msg := fmt.Sprintf("Delete backup storage %q in namespace %q?", opts.Name, opts.Namespace)
 	if err := confirm.YesNo(ctx, confirmOpts, msg); err != nil {
 		return err
@@ -141,11 +146,28 @@ func (bd *Deleter) emitDeleted(opts DeleteOptions) error {
 		_, _ = fmt.Fprint(os.Stdout, output.Success("Backup storage %q deleted", opts.Name))
 		return nil
 	}
-	return writeDeleteResultJSON(opts.Name, opts.Namespace)
+	return writeDeleteResultJSON(opts.Name, opts.Namespace, true)
 }
 
-// waitForDeletion blocks until the backup storage is gone, like instance delete --wait.
+// emitAlreadyGone reports the --ignore-not-found short-circuit: nothing was
+// deleted, so "deleted" must stay false, it should only mean this run
+// actually deleted something.
+func (bd *Deleter) emitAlreadyGone(opts DeleteOptions) error {
+	if bd.config.Pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Info("Backup storage %q not found in namespace %q; nothing to delete", opts.Name, opts.Namespace))
+		return nil
+	}
+	return writeDeleteResultJSON(opts.Name, opts.Namespace, false)
+}
+
+// waitForDeletion blocks until the backup storage is gone, like instance
+// delete --wait. The cancellable context is set up here, not in Run, so
+// Ctrl-C during confirm (which runs first) is a decline, not a cancelled
+// wait.
 func (bd *Deleter) waitForDeletion(ctx context.Context, c *client.ClientWithResponses, opts DeleteOptions) error {
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
 	poll := newBackupStorageDeletePoll(c, opts.Cluster, opts.Namespace, opts.Name)
 
 	var onUpdate func(string)
@@ -168,7 +190,7 @@ func (bd *Deleter) waitForDeletion(ctx context.Context, c *client.ClientWithResp
 		_, _ = fmt.Fprint(os.Stdout, output.Success("Backup storage %q is deleted", opts.Name))
 		return nil
 	}
-	return writeDeleteResultJSON(opts.Name, opts.Namespace)
+	return writeDeleteResultJSON(opts.Name, opts.Namespace, true)
 }
 
 // newBackupStorageDeletePoll checks if the backup storage still exists. A 404
@@ -208,12 +230,12 @@ func deleteCondition(bs *client.BackupStorage) (wait.Outcome, string) {
 	return wait.Pending, "backup storage still exists — likely referenced by an Instance or Backup"
 }
 
-func writeDeleteResultJSON(name, namespace string) error {
+func writeDeleteResultJSON(name, namespace string, deleted bool) error {
 	result := struct {
 		Name      string `json:"name"`
 		Namespace string `json:"namespace"`
 		Deleted   bool   `json:"deleted"`
-	}{Name: name, Namespace: namespace, Deleted: true}
+	}{Name: name, Namespace: namespace, Deleted: deleted}
 	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
 		return fmt.Errorf("failed to encode delete result: %w", err)
 	}

--- a/pkg/cli/backupstorage/delete.go
+++ b/pkg/cli/backupstorage/delete.go
@@ -36,13 +36,14 @@ import (
 
 // DeleteOptions configures `backup-storage delete`.
 type DeleteOptions struct {
-	Name      string
-	Namespace string
-	Cluster   string
-	Context   string        // overrides the active context when set
-	Yes       bool          // skip the confirmation prompt
-	Wait      bool          // block until the backup storage is fully deleted
-	Timeout   time.Duration // bounds --wait; must be positive
+	Name           string
+	Namespace      string
+	Cluster        string
+	Context        string        // overrides the active context when set
+	Yes            bool          // skip the confirmation prompt
+	IgnoreNotFound bool          // treat "backup storage already gone" (404) as a successful delete
+	Wait           bool          // block until the backup storage is fully deleted
+	Timeout        time.Duration // bounds --wait; must be positive
 
 	// IsTerminal overrides the TTY check for the prompt. Set in tests.
 	IsTerminal func() bool
@@ -73,6 +74,10 @@ func (bd *Deleter) Run(ctx context.Context, opts DeleteOptions, cfgPath string) 
 		return err
 	}
 
+	if opts.IgnoreNotFound && bd.backupStorageAlreadyGone(ctx, c, opts) {
+		return bd.emitDeleted(opts)
+	}
+
 	confirmOpts := confirm.Options{Yes: opts.Yes, JSON: !bd.config.Pretty, IsTerminal: opts.IsTerminal}
 	msg := fmt.Sprintf("Delete backup storage %q in namespace %q?", opts.Name, opts.Namespace)
 	if err := confirm.YesNo(ctx, confirmOpts, msg); err != nil {
@@ -83,29 +88,50 @@ func (bd *Deleter) Run(ctx context.Context, opts DeleteOptions, cfgPath string) 
 	if err != nil {
 		return fmt.Errorf("delete backup storage request failed: %w", err)
 	}
-	if err := checkDeleteResponse(resp, opts); err != nil {
+
+	alreadyGone, err := checkDeleteResponse(resp, opts)
+	if err != nil {
 		return err
 	}
-	bd.l.Infof("deleted backup storage %q in namespace %q", opts.Name, opts.Namespace)
 
-	if !opts.Wait {
+	if !alreadyGone {
+		bd.l.Infof("deleted backup storage %q in namespace %q", opts.Name, opts.Namespace)
+	}
+
+	if !opts.Wait || alreadyGone {
 		return bd.emitDeleted(opts)
 	}
 	return bd.waitForDeletion(ctx, c, opts)
 }
 
-// checkDeleteResponse maps a DeleteBackupStorage response to an error, or nil on success.
-func checkDeleteResponse(resp *client.DeleteBackupStorageResponse, opts DeleteOptions) error {
+// backupStorageAlreadyGone checks, for --ignore-not-found, whether the backup
+// storage is already gone so Run can skip confirmation and --wait entirely
+// instead of asking the user to confirm deleting something that doesn't
+// exist. Any ambiguous result (fetch error, non-404 status) returns false so
+// the normal confirm+delete flow runs and surfaces the real error itself.
+func (bd *Deleter) backupStorageAlreadyGone(ctx context.Context, c *client.ClientWithResponses, opts DeleteOptions) bool {
+	resp, err := c.GetBackupStorageWithResponse(ctx, opts.Cluster, opts.Namespace, opts.Name)
+	if err != nil {
+		return false
+	}
+	return resp.StatusCode() == http.StatusNotFound
+}
+
+// checkDeleteResponse maps a DeleteBackupStorage response to (alreadyGone, error).
+func checkDeleteResponse(resp *client.DeleteBackupStorageResponse, opts DeleteOptions) (bool, error) {
 	switch {
 	case resp.StatusCode() == http.StatusNotFound:
-		return fmt.Errorf("backup storage %q not found in namespace %q", opts.Name, opts.Namespace)
+		if !opts.IgnoreNotFound {
+			return false, fmt.Errorf("backup storage %q not found in namespace %q", opts.Name, opts.Namespace)
+		}
+		return true, nil
 	case resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusNoContent:
 		if msg, ok := clienterr.Message(resp.JSON400, resp.JSONDefault); ok {
-			return fmt.Errorf("server error: %s", msg)
+			return false, fmt.Errorf("server error: %s", msg)
 		}
-		return fmt.Errorf("unexpected response deleting backup storage: %s", resp.Status())
+		return false, fmt.Errorf("unexpected response deleting backup storage: %s", resp.Status())
 	default:
-		return nil
+		return false, nil
 	}
 }
 
@@ -130,15 +156,11 @@ func (bd *Deleter) waitForDeletion(ctx context.Context, c *client.ClientWithResp
 		}
 	}
 
-	err := wait.Until(ctx, poll, deleteCondition, wait.Options{
+	if err := wait.Until(ctx, poll, deleteCondition, wait.Options{
 		Timeout:  opts.Timeout,
 		OnUpdate: onUpdate,
 		OnRetry:  func(err error) { bd.l.Warnf("%v — retrying", err) },
-	})
-	if errors.Is(err, wait.ErrTimeout) {
-		return fmt.Errorf("timed out waiting for backup storage %q to be deleted — it may still be referenced by an Instance or Backup: %w", opts.Name, err)
-	}
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/pkg/cli/backupstorage/delete.go
+++ b/pkg/cli/backupstorage/delete.go
@@ -17,8 +17,6 @@ package backupstorage
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -32,6 +30,7 @@ import (
 	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
 	"github.com/openeverest/openeverest/v2/pkg/cli/clienterr"
 	"github.com/openeverest/openeverest/v2/pkg/cli/confirm"
+	"github.com/openeverest/openeverest/v2/pkg/cli/deletion"
 	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
 	"github.com/openeverest/openeverest/v2/pkg/output"
 )
@@ -70,7 +69,7 @@ func NewDeleter(cfg Config, l *zap.SugaredLogger) *Deleter {
 // Run deletes the backup storage: confirms, deletes, then waits if asked.
 // ctx stays plain here so Ctrl-C during confirm is a decline, not a
 // cancelled wait, see waitForDeletion. The credentials Secret is not
-// handled here — the BackupStorage controller adopts it via an owner
+// handled here, the BackupStorage controller adopts it via an owner
 // reference, so Kubernetes garbage-collects it once the BackupStorage is
 // actually gone.
 func (bd *Deleter) Run(ctx context.Context, opts DeleteOptions, cfgPath string) error {
@@ -99,11 +98,12 @@ func (bd *Deleter) Run(ctx context.Context, opts DeleteOptions, cfgPath string) 
 		return err
 	}
 
-	if !alreadyGone {
-		bd.l.Infof("deleted backup storage %q in namespace %q", opts.Name, opts.Namespace)
+	if alreadyGone {
+		return bd.emitAlreadyGone(opts)
 	}
+	bd.l.Infof("deleted backup storage %q in namespace %q", opts.Name, opts.Namespace)
 
-	if !opts.Wait || alreadyGone {
+	if !opts.Wait {
 		return bd.emitDeleted(opts)
 	}
 	return bd.waitForDeletion(ctx, c, opts)
@@ -142,22 +142,14 @@ func checkDeleteResponse(resp *client.DeleteBackupStorageResponse, opts DeleteOp
 
 // emitDeleted prints success: a line in pretty mode, JSON otherwise.
 func (bd *Deleter) emitDeleted(opts DeleteOptions) error {
-	if bd.config.Pretty {
-		_, _ = fmt.Fprint(os.Stdout, output.Success("Backup storage %q deleted", opts.Name))
-		return nil
-	}
-	return writeDeleteResultJSON(opts.Name, opts.Namespace, true)
+	return deletion.EmitDeleted(bd.config.Pretty, "backup storage", opts.Name, opts.Namespace)
 }
 
 // emitAlreadyGone reports the --ignore-not-found short-circuit: nothing was
 // deleted, so "deleted" must stay false, it should only mean this run
 // actually deleted something.
 func (bd *Deleter) emitAlreadyGone(opts DeleteOptions) error {
-	if bd.config.Pretty {
-		_, _ = fmt.Fprint(os.Stdout, output.Info("Backup storage %q not found in namespace %q; nothing to delete", opts.Name, opts.Namespace))
-		return nil
-	}
-	return writeDeleteResultJSON(opts.Name, opts.Namespace, false)
+	return deletion.EmitAlreadyGone(bd.config.Pretty, "backup storage", opts.Name, opts.Namespace)
 }
 
 // waitForDeletion blocks until the backup storage is gone, like instance
@@ -186,11 +178,7 @@ func (bd *Deleter) waitForDeletion(ctx context.Context, c *client.ClientWithResp
 		return err
 	}
 
-	if bd.config.Pretty {
-		_, _ = fmt.Fprint(os.Stdout, output.Success("Backup storage %q is deleted", opts.Name))
-		return nil
-	}
-	return writeDeleteResultJSON(opts.Name, opts.Namespace, true)
+	return deletion.EmitWaitSucceeded(bd.config.Pretty, "backup storage", opts.Name, opts.Namespace)
 }
 
 // newBackupStorageDeletePoll checks if the backup storage still exists. A 404
@@ -199,45 +187,17 @@ func newBackupStorageDeletePoll(
 	c *client.ClientWithResponses,
 	cluster, namespace, name string,
 ) wait.PollFunc[*client.BackupStorage] {
-	return func(ctx context.Context) (*client.BackupStorage, error) {
+	return deletion.GonePoll("backup storage", name, func(ctx context.Context) (int, string, *client.BackupStorage, error) {
 		resp, err := c.GetBackupStorageWithResponse(ctx, cluster, namespace, name)
 		if err != nil {
-			if errors.Is(err, authcli.ErrTokenRefresh) {
-				return nil, fmt.Errorf("failed to fetch backup storage %q: %w", name, err)
-			}
-			return nil, &wait.RetryableError{Err: fmt.Errorf("failed to fetch backup storage %q: %w", name, err)}
+			return 0, "", nil, err
 		}
-		switch resp.StatusCode() {
-		case http.StatusOK:
-			if resp.JSON200 == nil {
-				return nil, &wait.RetryableError{Err: fmt.Errorf("empty response body fetching backup storage %q", name)}
-			}
-			return resp.JSON200, nil
-		case http.StatusNotFound:
-			return nil, nil // gone
-		case http.StatusUnauthorized:
-			return nil, fmt.Errorf("server rejected credentials — run 'everestctl auth login' again")
-		default:
-			return nil, &wait.RetryableError{Err: fmt.Errorf("unexpected response fetching backup storage %q: %s", name, resp.Status())}
-		}
-	}
+		return resp.StatusCode(), resp.Status(), resp.JSON200, nil
+	})
 }
 
 func deleteCondition(bs *client.BackupStorage) (wait.Outcome, string) {
-	if bs == nil {
-		return wait.Succeeded, "backup storage deleted"
-	}
-	return wait.Pending, "backup storage still exists — likely referenced by an Instance or Backup"
-}
-
-func writeDeleteResultJSON(name, namespace string, deleted bool) error {
-	result := struct {
-		Name      string `json:"name"`
-		Namespace string `json:"namespace"`
-		Deleted   bool   `json:"deleted"`
-	}{Name: name, Namespace: namespace, Deleted: deleted}
-	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
-		return fmt.Errorf("failed to encode delete result: %w", err)
-	}
-	return nil
+	return deletion.GoneCondition("backup storage deleted", func(*client.BackupStorage) string {
+		return "backup storage still exists — likely referenced by an Instance or Backup"
+	})(bs)
 }

--- a/pkg/cli/backupstorage/delete.go
+++ b/pkg/cli/backupstorage/delete.go
@@ -1,0 +1,199 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupstorage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/openeverest/openeverest/v2/client"
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/clienterr"
+	"github.com/openeverest/openeverest/v2/pkg/cli/confirm"
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
+	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+// DeleteOptions configures `backup-storage delete`.
+type DeleteOptions struct {
+	Name      string
+	Namespace string
+	Cluster   string
+	Context   string        // overrides the active context when set
+	Yes       bool          // skip the confirmation prompt
+	Wait      bool          // block until the backup storage is fully deleted
+	Timeout   time.Duration // bounds --wait; must be positive
+
+	// IsTerminal overrides the TTY check for the prompt. Set in tests.
+	IsTerminal func() bool
+}
+
+// Deleter implements `backup-storage delete` business logic.
+type Deleter struct {
+	config Config
+	l      *zap.SugaredLogger
+}
+
+// NewDeleter returns a new Deleter.
+func NewDeleter(cfg Config, l *zap.SugaredLogger) *Deleter {
+	bd := &Deleter{config: cfg, l: l.With("component", "backup-storage-deleter")}
+	if cfg.Pretty {
+		bd.l = zap.NewNop().Sugar()
+	}
+	return bd
+}
+
+// Run deletes the backup storage: confirms, deletes, then waits if asked.
+// The credentials Secret is not handled here — the BackupStorage controller
+// adopts it via an owner reference, so Kubernetes garbage-collects it once
+// the BackupStorage is actually gone.
+func (bd *Deleter) Run(ctx context.Context, opts DeleteOptions, cfgPath string) error {
+	c, err := authcli.NewAPIClient(authcli.Config{Pretty: bd.config.Pretty}, bd.l.Desugar().Sugar(), cfgPath, opts.Context)
+	if err != nil {
+		return err
+	}
+
+	confirmOpts := confirm.Options{Yes: opts.Yes, JSON: !bd.config.Pretty, IsTerminal: opts.IsTerminal}
+	msg := fmt.Sprintf("Delete backup storage %q in namespace %q?", opts.Name, opts.Namespace)
+	if err := confirm.YesNo(ctx, confirmOpts, msg); err != nil {
+		return err
+	}
+
+	resp, err := c.DeleteBackupStorageWithResponse(ctx, opts.Cluster, opts.Namespace, opts.Name)
+	if err != nil {
+		return fmt.Errorf("delete backup storage request failed: %w", err)
+	}
+	if err := checkDeleteResponse(resp, opts); err != nil {
+		return err
+	}
+	bd.l.Infof("deleted backup storage %q in namespace %q", opts.Name, opts.Namespace)
+
+	if !opts.Wait {
+		return bd.emitDeleted(opts)
+	}
+	return bd.waitForDeletion(ctx, c, opts)
+}
+
+// checkDeleteResponse maps a DeleteBackupStorage response to an error, or nil on success.
+func checkDeleteResponse(resp *client.DeleteBackupStorageResponse, opts DeleteOptions) error {
+	switch {
+	case resp.StatusCode() == http.StatusNotFound:
+		return fmt.Errorf("backup storage %q not found in namespace %q", opts.Name, opts.Namespace)
+	case resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusNoContent:
+		if msg, ok := clienterr.Message(resp.JSON400, resp.JSONDefault); ok {
+			return fmt.Errorf("server error: %s", msg)
+		}
+		return fmt.Errorf("unexpected response deleting backup storage: %s", resp.Status())
+	default:
+		return nil
+	}
+}
+
+// emitDeleted prints success: a line in pretty mode, JSON otherwise.
+func (bd *Deleter) emitDeleted(opts DeleteOptions) error {
+	if bd.config.Pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Success("Backup storage %q deleted", opts.Name))
+		return nil
+	}
+	return writeDeleteResultJSON(opts.Name, opts.Namespace)
+}
+
+// waitForDeletion blocks until the backup storage is gone, like instance delete --wait.
+func (bd *Deleter) waitForDeletion(ctx context.Context, c *client.ClientWithResponses, opts DeleteOptions) error {
+	poll := newBackupStorageDeletePoll(c, opts.Cluster, opts.Namespace, opts.Name)
+
+	var onUpdate func(string)
+	if bd.config.Pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Info("Backup storage %q deletion requested; waiting for it to be fully removed...", opts.Name))
+		onUpdate = func(msg string) {
+			_, _ = fmt.Fprintf(os.Stdout, "  %s\n", msg)
+		}
+	}
+
+	err := wait.Until(ctx, poll, deleteCondition, wait.Options{
+		Timeout:  opts.Timeout,
+		OnUpdate: onUpdate,
+		OnRetry:  func(err error) { bd.l.Warnf("%v — retrying", err) },
+	})
+	if errors.Is(err, wait.ErrTimeout) {
+		return fmt.Errorf("timed out waiting for backup storage %q to be deleted — it may still be referenced by an Instance or Backup: %w", opts.Name, err)
+	}
+	if err != nil {
+		return err
+	}
+
+	if bd.config.Pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Success("Backup storage %q is deleted", opts.Name))
+		return nil
+	}
+	return writeDeleteResultJSON(opts.Name, opts.Namespace)
+}
+
+// newBackupStorageDeletePoll checks if the backup storage still exists. A 404
+// means it's gone, which is success here (unlike a create-side poll).
+func newBackupStorageDeletePoll(
+	c *client.ClientWithResponses,
+	cluster, namespace, name string,
+) wait.PollFunc[*client.BackupStorage] {
+	return func(ctx context.Context) (*client.BackupStorage, error) {
+		resp, err := c.GetBackupStorageWithResponse(ctx, cluster, namespace, name)
+		if err != nil {
+			if errors.Is(err, authcli.ErrTokenRefresh) {
+				return nil, fmt.Errorf("failed to fetch backup storage %q: %w", name, err)
+			}
+			return nil, &wait.RetryableError{Err: fmt.Errorf("failed to fetch backup storage %q: %w", name, err)}
+		}
+		switch resp.StatusCode() {
+		case http.StatusOK:
+			if resp.JSON200 == nil {
+				return nil, &wait.RetryableError{Err: fmt.Errorf("empty response body fetching backup storage %q", name)}
+			}
+			return resp.JSON200, nil
+		case http.StatusNotFound:
+			return nil, nil // gone
+		case http.StatusUnauthorized:
+			return nil, fmt.Errorf("server rejected credentials — run 'everestctl auth login' again")
+		default:
+			return nil, &wait.RetryableError{Err: fmt.Errorf("unexpected response fetching backup storage %q: %s", name, resp.Status())}
+		}
+	}
+}
+
+func deleteCondition(bs *client.BackupStorage) (wait.Outcome, string) {
+	if bs == nil {
+		return wait.Succeeded, "backup storage deleted"
+	}
+	return wait.Pending, "backup storage still exists — likely referenced by an Instance or Backup"
+}
+
+func writeDeleteResultJSON(name, namespace string) error {
+	result := struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+		Deleted   bool   `json:"deleted"`
+	}{Name: name, Namespace: namespace, Deleted: true}
+	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		return fmt.Errorf("failed to encode delete result: %w", err)
+	}
+	return nil
+}

--- a/pkg/cli/backupstorage/delete_test.go
+++ b/pkg/cli/backupstorage/delete_test.go
@@ -137,10 +137,39 @@ func TestDelete_NotFound_WithIgnoreNotFound_Succeeds(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+//nolint:paralleltest // captureStdout mutates global os.Stdout; must run serially
+func TestDelete_IgnoreNotFound_DeleteRaces404_ReportsNotDeleted(t *testing.T) {
+	srv := newDeleteServer(t,
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		},
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"metadata":{"name":"my-s3","namespace":"everest"},"spec":{"type":"s3"}}`))
+		},
+	)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	opts := yesOpts()
+	opts.IgnoreNotFound = true
+
+	d := NewDeleter(Config{Pretty: false}, zap.NewNop().Sugar())
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = d.Run(context.Background(), opts, cfgPath)
+	})
+	require.NoError(t, runErr)
+	assert.JSONEq(t, `{"name":"my-s3","namespace":"everest","deleted":false}`, out)
+}
+
 // TestDelete_IgnoreNotFound_AlreadyGone_SkipsConfirmationAndWait proves the
 // --ignore-not-found short-circuit: when the backup storage is already gone,
 // both the confirmation prompt and --wait are skipped entirely (no --yes, no
-// TTY, and --wait: true all set here — none of it should matter), and the
+// TTY, and --wait: true all set here, none of it should matter), and the
 // DELETE endpoint itself is never called.
 func TestDelete_IgnoreNotFound_AlreadyGone_SkipsConfirmationAndWait(t *testing.T) {
 	t.Parallel()

--- a/pkg/cli/backupstorage/delete_test.go
+++ b/pkg/cli/backupstorage/delete_test.go
@@ -1,0 +1,229 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupstorage
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
+)
+
+func isTerminalFalse() bool { return false }
+
+// newDeleteServer fakes the backup storage DELETE (and optional GET) endpoint.
+func newDeleteServer(t *testing.T, deleteHandler, getHandler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	path := "/v1/clusters/main/namespaces/everest/backup-storages/my-s3"
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodDelete:
+			deleteHandler(w, r)
+		case http.MethodGet:
+			if getHandler != nil {
+				getHandler(w, r)
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+			}
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	return httptest.NewServer(mux)
+}
+
+// yesOpts sets --yes so tests skip the interactive prompt.
+func yesOpts() DeleteOptions {
+	return DeleteOptions{
+		Name:      "my-s3",
+		Namespace: "everest",
+		Cluster:   "main",
+		Yes:       true,
+	}
+}
+
+func TestDelete_HappyPath_NoWait(t *testing.T) {
+	t.Parallel()
+
+	srv := newDeleteServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}, nil)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	d := NewDeleter(Config{}, zap.NewNop().Sugar())
+	err := d.Run(context.Background(), yesOpts(), cfgPath)
+	assert.NoError(t, err)
+}
+
+func TestDelete_NotFound_Errors(t *testing.T) {
+	t.Parallel()
+
+	srv := newDeleteServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}, nil)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	d := NewDeleter(Config{}, zap.NewNop().Sugar())
+	err := d.Run(context.Background(), yesOpts(), cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `backup storage "my-s3" not found in namespace "everest"`)
+}
+
+func TestDelete_ServerError_ReturnsMessage(t *testing.T) {
+	t.Parallel()
+
+	srv := newDeleteServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": "backup storage still referenced by an instance"})
+	}, nil)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	d := NewDeleter(Config{}, zap.NewNop().Sugar())
+	err := d.Run(context.Background(), yesOpts(), cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "backup storage still referenced by an instance")
+}
+
+func TestDelete_NonInteractiveWithoutYes_FailsFast(t *testing.T) {
+	t.Parallel()
+
+	// Delete must not be called if confirmation fails.
+	called := false
+	srv := newDeleteServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}, nil)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	opts := DeleteOptions{
+		Name:       "my-s3",
+		Namespace:  "everest",
+		Cluster:    "main",
+		IsTerminal: isTerminalFalse,
+	}
+
+	d := NewDeleter(Config{}, zap.NewNop().Sugar())
+	err := d.Run(context.Background(), opts, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "confirmation required in non-interactive mode")
+	assert.False(t, called, "delete must not be issued when confirmation couldn't be obtained")
+}
+
+func TestDelete_JSONMode_NonInteractiveWithoutYes_FailsFast(t *testing.T) {
+	t.Parallel()
+
+	srv := newDeleteServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}, nil)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	opts := DeleteOptions{
+		Name:      "my-s3",
+		Namespace: "everest",
+		Cluster:   "main",
+		// IsTerminal is true here to prove --json alone forces non-interactive.
+		IsTerminal: func() bool { return true },
+	}
+
+	d := NewDeleter(Config{Pretty: false}, zap.NewNop().Sugar())
+	err := d.Run(context.Background(), opts, cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "confirmation required in non-interactive mode")
+}
+
+func TestDelete_WaitUntilGone_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	getCalls := 0
+	srv := newDeleteServer(t,
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+		func(w http.ResponseWriter, _ *http.Request) {
+			getCalls++
+			w.WriteHeader(http.StatusNotFound)
+		},
+	)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	opts := yesOpts()
+	opts.Wait = true
+	opts.Timeout = 0 // no timeout needed: the fake GET 404s on the very first poll
+
+	d := NewDeleter(Config{}, zap.NewNop().Sugar())
+	err := d.Run(context.Background(), opts, cfgPath)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, getCalls, 1)
+}
+
+func TestDelete_WaitTimesOut(t *testing.T) {
+	t.Parallel()
+
+	srv := newDeleteServer(t,
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+		func(w http.ResponseWriter, _ *http.Request) {
+			// Backup storage stays present (still referenced), so --wait times out.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"metadata":{"name":"my-s3","namespace":"everest"},"spec":{"type":"s3"}}`))
+		},
+	)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	opts := yesOpts()
+	opts.Wait = true
+	opts.Timeout = 50 * time.Millisecond // the immediate first poll sees the storage still present; the timeout then elapses before the 2s default poll interval ticks again
+
+	d := NewDeleter(Config{}, zap.NewNop().Sugar())
+	err := d.Run(context.Background(), opts, cfgPath)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wait.ErrTimeout)
+	assert.Contains(t, err.Error(), "may still be referenced")
+}

--- a/pkg/cli/backupstorage/delete_test.go
+++ b/pkg/cli/backupstorage/delete_test.go
@@ -98,6 +98,63 @@ func TestDelete_NotFound_Errors(t *testing.T) {
 	assert.Contains(t, err.Error(), `backup storage "my-s3" not found in namespace "everest"`)
 }
 
+func TestDelete_NotFound_WithIgnoreNotFound_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	srv := newDeleteServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}, nil)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	opts := yesOpts()
+	opts.IgnoreNotFound = true
+
+	d := NewDeleter(Config{}, zap.NewNop().Sugar())
+	err := d.Run(context.Background(), opts, cfgPath)
+	assert.NoError(t, err)
+}
+
+// TestDelete_IgnoreNotFound_AlreadyGone_SkipsConfirmationAndWait proves the
+// --ignore-not-found short-circuit: when the backup storage is already gone,
+// both the confirmation prompt and --wait are skipped entirely (no --yes, no
+// TTY, and --wait: true all set here — none of it should matter), and the
+// DELETE endpoint itself is never called.
+func TestDelete_IgnoreNotFound_AlreadyGone_SkipsConfirmationAndWait(t *testing.T) {
+	t.Parallel()
+
+	deleteCalled := false
+	srv := newDeleteServer(t,
+		func(w http.ResponseWriter, _ *http.Request) {
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		},
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		},
+	)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	opts := DeleteOptions{
+		Name:           "my-s3",
+		Namespace:      "everest",
+		Cluster:        "main",
+		IgnoreNotFound: true,
+		Wait:           true,
+		IsTerminal:     isTerminalFalse,
+	}
+
+	d := NewDeleter(Config{}, zap.NewNop().Sugar())
+	err := d.Run(context.Background(), opts, cfgPath)
+	require.NoError(t, err)
+	assert.False(t, deleteCalled, "delete must not be issued when the backup storage is already gone")
+}
+
 func TestDelete_ServerError_ReturnsMessage(t *testing.T) {
 	t.Parallel()
 
@@ -225,5 +282,4 @@ func TestDelete_WaitTimesOut(t *testing.T) {
 	err := d.Run(context.Background(), opts, cfgPath)
 	require.Error(t, err)
 	require.ErrorIs(t, err, wait.ErrTimeout)
-	assert.Contains(t, err.Error(), "may still be referenced")
 }

--- a/pkg/cli/backupstorage/delete_test.go
+++ b/pkg/cli/backupstorage/delete_test.go
@@ -224,6 +224,6 @@ func TestDelete_WaitTimesOut(t *testing.T) {
 	d := NewDeleter(Config{}, zap.NewNop().Sugar())
 	err := d.Run(context.Background(), opts, cfgPath)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, wait.ErrTimeout)
+	require.ErrorIs(t, err, wait.ErrTimeout)
 	assert.Contains(t, err.Error(), "may still be referenced")
 }

--- a/pkg/cli/backupstorage/delete_test.go
+++ b/pkg/cli/backupstorage/delete_test.go
@@ -18,8 +18,10 @@ package backupstorage
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -28,8 +30,26 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/openeverest/openeverest/v2/pkg/cli/confirm"
 	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
 )
+
+// captureStdout returns what fn writes to os.Stdout. Not parallel-safe
+// (os.Stdout is global), so callers must not use t.Parallel.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
 
 func isTerminalFalse() bool { return false }
 
@@ -217,7 +237,9 @@ func TestDelete_JSONMode_NonInteractiveWithoutYes_FailsFast(t *testing.T) {
 		Name:      "my-s3",
 		Namespace: "everest",
 		Cluster:   "main",
-		// IsTerminal is true here to prove --json alone forces non-interactive.
+		JSON:      true,
+		// IsTerminal is true here to prove --json alone forces non-interactive,
+		// independent of whether stdin is actually a real terminal.
 		IsTerminal: func() bool { return true },
 	}
 
@@ -225,6 +247,30 @@ func TestDelete_JSONMode_NonInteractiveWithoutYes_FailsFast(t *testing.T) {
 	err := d.Run(context.Background(), opts, cfgPath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "confirmation required in non-interactive mode")
+}
+
+func TestDelete_VerboseAloneDoesNotForceNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	srv := newDeleteServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}, nil)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	opts := DeleteOptions{
+		Name:       "my-s3",
+		Namespace:  "everest",
+		Cluster:    "main",
+		JSON:       false,
+		IsTerminal: func() bool { return true },
+	}
+
+	d := NewDeleter(Config{Pretty: false}, zap.NewNop().Sugar())
+	err := d.Run(context.Background(), opts, cfgPath)
+	assert.NotErrorIs(t, err, confirm.ErrNonInteractive, "verbose alone must not be treated as non-interactive")
 }
 
 func TestDelete_WaitUntilGone_Succeeds(t *testing.T) {
@@ -282,4 +328,43 @@ func TestDelete_WaitTimesOut(t *testing.T) {
 	err := d.Run(context.Background(), opts, cfgPath)
 	require.Error(t, err)
 	require.ErrorIs(t, err, wait.ErrTimeout)
+}
+
+// TestDelete_IgnoreNotFound_AlreadyGone_JSONOutput proves the short-circuit
+// output is honest: "deleted" is false, since this run never deleted
+// anything — the backup storage was already gone.
+//
+//nolint:paralleltest // mutates global os.Stdout; must run serially
+func TestDelete_IgnoreNotFound_AlreadyGone_JSONOutput(t *testing.T) {
+	deleteCalled := false
+	srv := newDeleteServer(t,
+		func(w http.ResponseWriter, _ *http.Request) {
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		},
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		},
+	)
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, newTestConfig(srv.URL).Save(cfgPath))
+
+	opts := DeleteOptions{
+		Name:           "my-s3",
+		Namespace:      "everest",
+		Cluster:        "main",
+		IgnoreNotFound: true,
+		IsTerminal:     isTerminalFalse,
+	}
+
+	d := NewDeleter(Config{Pretty: false}, zap.NewNop().Sugar())
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = d.Run(context.Background(), opts, cfgPath)
+	})
+	require.NoError(t, runErr)
+	assert.False(t, deleteCalled)
+	assert.JSONEq(t, `{"name":"my-s3","namespace":"everest","deleted":false}`, out)
 }

--- a/pkg/cli/deletion/deletion.go
+++ b/pkg/cli/deletion/deletion.go
@@ -1,0 +1,130 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package deletion holds the plumbing shared by every `<resource> delete
+// --wait` implementation: the "gone" wait.Condition, the GET-until-404 poll
+// shape, and the three output lines (deleted / already-gone /
+// wait-succeeded).
+package deletion
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
+	"github.com/openeverest/openeverest/v2/pkg/output"
+)
+
+// GoneCondition returns a wait.Condition for a delete-poll: nil means the
+// resource is gone (Succeeded); a non-nil value is Pending, with its
+// message computed by pendingMsg (which may inspect the live object, e.g.
+// to report phase/progress).
+func GoneCondition[T any](goneMsg string, pendingMsg func(*T) string) wait.Condition[*T] {
+	return func(v *T) (wait.Outcome, string) {
+		if v == nil {
+			return wait.Succeeded, goneMsg
+		}
+		return wait.Pending, pendingMsg(v)
+	}
+}
+
+// GonePoll builds a wait.PollFunc for a delete-poll around fetch,
+// classifying responses the same way every `<resource> delete --wait`
+// already does: a 404 means gone (nil, nil); a failed token refresh and a
+// 401 are terminal; everything else unexpected is retryable.
+func GonePoll[T any](
+	kind, name string,
+	fetch func(ctx context.Context) (statusCode int, statusText string, body *T, err error),
+) wait.PollFunc[*T] {
+	return func(ctx context.Context) (*T, error) {
+		status, statusText, body, err := fetch(ctx)
+		if err != nil {
+			if errors.Is(err, authcli.ErrTokenRefresh) {
+				return nil, fmt.Errorf("failed to fetch %s %q: %w", kind, name, err)
+			}
+			return nil, &wait.RetryableError{Err: fmt.Errorf("failed to fetch %s %q: %w", kind, name, err)}
+		}
+		switch status {
+		case http.StatusOK:
+			if body == nil {
+				return nil, &wait.RetryableError{Err: fmt.Errorf("empty response body fetching %s %q", kind, name)}
+			}
+			return body, nil
+		case http.StatusNotFound:
+			return nil, nil // gone
+		case http.StatusUnauthorized:
+			return nil, fmt.Errorf("server rejected credentials — run 'everestctl auth login' again")
+		default:
+			return nil, &wait.RetryableError{Err: fmt.Errorf("unexpected response fetching %s %q: %s", kind, name, statusText)}
+		}
+	}
+}
+
+// EmitDeleted prints success: a line in pretty mode, JSON otherwise.
+func EmitDeleted(pretty bool, kind, name, namespace string) error {
+	if pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Success("%s %q deleted", titleFirst(kind), name))
+		return nil
+	}
+	return writeResultJSON(name, namespace, true)
+}
+
+// EmitAlreadyGone reports a --ignore-not-found short-circuit: nothing was
+// deleted, so "deleted" must stay false — it should only ever mean this
+// run actually deleted something.
+func EmitAlreadyGone(pretty bool, kind, name, namespace string) error {
+	if pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Info("%s %q not found in namespace %q; nothing to delete", titleFirst(kind), name, namespace))
+		return nil
+	}
+	return writeResultJSON(name, namespace, false)
+}
+
+// EmitWaitSucceeded prints the --wait completion line: a line in pretty
+// mode, JSON otherwise. Wording ("is deleted") deliberately differs from
+// EmitDeleted's ("deleted") — this is reported after waiting *for* the
+// resource to become gone, not immediately after issuing the delete.
+func EmitWaitSucceeded(pretty bool, kind, name, namespace string) error {
+	if pretty {
+		_, _ = fmt.Fprint(os.Stdout, output.Success("%s %q is deleted", titleFirst(kind), name))
+		return nil
+	}
+	return writeResultJSON(name, namespace, true)
+}
+
+func writeResultJSON(name, namespace string, deleted bool) error {
+	result := struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+		Deleted   bool   `json:"deleted"`
+	}{Name: name, Namespace: namespace, Deleted: deleted}
+	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		return fmt.Errorf("failed to encode delete result: %w", err)
+	}
+	return nil
+}
+
+func titleFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}

--- a/pkg/cli/deletion/deletion_test.go
+++ b/pkg/cli/deletion/deletion_test.go
@@ -1,0 +1,253 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deletion
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
+)
+
+type widget struct {
+	Name string
+}
+
+// captureStdout returns what fn writes to os.Stdout. Not parallel-safe
+// (os.Stdout is global), so callers must not use t.Parallel.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func TestGoneCondition(t *testing.T) {
+	t.Parallel()
+
+	cond := GoneCondition("widget deleted", func(w *widget) string {
+		return "still there: " + w.Name
+	})
+
+	outcome, msg := cond(nil)
+	assert.Equal(t, wait.Succeeded, outcome)
+	assert.Equal(t, "widget deleted", msg)
+
+	outcome, msg = cond(&widget{Name: "foo"})
+	assert.Equal(t, wait.Pending, outcome)
+	assert.Equal(t, "still there: foo", msg)
+}
+
+func TestGonePoll_Gone(t *testing.T) {
+	t.Parallel()
+
+	poll := GonePoll[widget]("widget", "my-widget", func(context.Context) (int, string, *widget, error) {
+		return http.StatusNotFound, "404 Not Found", nil, nil
+	})
+
+	v, err := poll(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, v)
+}
+
+func TestGonePoll_StillPresent(t *testing.T) {
+	t.Parallel()
+
+	want := &widget{Name: "my-widget"}
+	poll := GonePoll[widget]("widget", "my-widget", func(context.Context) (int, string, *widget, error) {
+		return http.StatusOK, "200 OK", want, nil
+	})
+
+	v, err := poll(context.Background())
+	require.NoError(t, err)
+	assert.Same(t, want, v)
+}
+
+func TestGonePoll_EmptyBody_Retryable(t *testing.T) {
+	t.Parallel()
+
+	poll := GonePoll[widget]("widget", "my-widget", func(context.Context) (int, string, *widget, error) {
+		return http.StatusOK, "200 OK", nil, nil
+	})
+
+	_, err := poll(context.Background())
+	require.Error(t, err)
+	var re *wait.RetryableError
+	require.ErrorAs(t, err, &re)
+	assert.Contains(t, err.Error(), "empty response body fetching widget \"my-widget\"")
+}
+
+func TestGonePoll_Unauthorized_Terminal(t *testing.T) {
+	t.Parallel()
+
+	poll := GonePoll[widget]("widget", "my-widget", func(context.Context) (int, string, *widget, error) {
+		return http.StatusUnauthorized, "401 Unauthorized", nil, nil
+	})
+
+	_, err := poll(context.Background())
+	require.Error(t, err)
+	var re *wait.RetryableError
+	assert.NotErrorAs(t, err, &re, "401 must be terminal, not retryable")
+	assert.Contains(t, err.Error(), "run 'everestctl auth login' again")
+}
+
+func TestGonePoll_UnexpectedStatus_Retryable(t *testing.T) {
+	t.Parallel()
+
+	poll := GonePoll[widget]("widget", "my-widget", func(context.Context) (int, string, *widget, error) {
+		return http.StatusInternalServerError, "500 Internal Server Error", nil, nil
+	})
+
+	_, err := poll(context.Background())
+	require.Error(t, err)
+	var re *wait.RetryableError
+	require.ErrorAs(t, err, &re)
+	assert.Contains(t, err.Error(), "500 Internal Server Error")
+}
+
+func TestGonePoll_FetchError_Retryable(t *testing.T) {
+	t.Parallel()
+
+	poll := GonePoll[widget]("widget", "my-widget", func(context.Context) (int, string, *widget, error) {
+		return 0, "", nil, errors.New("connection reset")
+	})
+
+	_, err := poll(context.Background())
+	require.Error(t, err)
+	var re *wait.RetryableError
+	require.ErrorAs(t, err, &re)
+}
+
+func TestGonePoll_TokenRefreshFailure_Terminal(t *testing.T) {
+	t.Parallel()
+
+	poll := GonePoll[widget]("widget", "my-widget", func(context.Context) (int, string, *widget, error) {
+		return 0, "", nil, fmt.Errorf("refresh: %w", authcli.ErrTokenRefresh)
+	})
+
+	_, err := poll(context.Background())
+	require.Error(t, err)
+	var re *wait.RetryableError
+	assert.NotErrorAs(t, err, &re, "a failed token refresh must be terminal, not retryable")
+	assert.ErrorIs(t, err, authcli.ErrTokenRefresh)
+}
+
+//nolint:paralleltest // captureStdout mutates global os.Stdout; must run serially
+func TestEmitDeleted_Pretty(t *testing.T) {
+	out := captureStdout(t, func() {
+		err := EmitDeleted(true, "backup storage", "my-s3", "everest")
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, `Backup storage "my-s3" deleted`)
+}
+
+//nolint:paralleltest // captureStdout mutates global os.Stdout; must run serially
+func TestEmitDeleted_JSON(t *testing.T) {
+	out := captureStdout(t, func() {
+		err := EmitDeleted(false, "instance", "my-db", "everest")
+		require.NoError(t, err)
+	})
+	assert.JSONEq(t, `{"name":"my-db","namespace":"everest","deleted":true}`, out)
+}
+
+//nolint:paralleltest // captureStdout mutates global os.Stdout; must run serially
+func TestEmitAlreadyGone_Pretty(t *testing.T) {
+	out := captureStdout(t, func() {
+		err := EmitAlreadyGone(true, "instance", "my-db", "everest")
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, `Instance "my-db" not found in namespace "everest"; nothing to delete`)
+}
+
+//nolint:paralleltest // captureStdout mutates global os.Stdout; must run serially
+func TestEmitAlreadyGone_JSON(t *testing.T) {
+	out := captureStdout(t, func() {
+		err := EmitAlreadyGone(false, "backup storage", "my-s3", "everest")
+		require.NoError(t, err)
+	})
+	assert.JSONEq(t, `{"name":"my-s3","namespace":"everest","deleted":false}`, out)
+}
+
+//nolint:paralleltest // captureStdout mutates global os.Stdout; must run serially
+func TestEmitWaitSucceeded_Pretty(t *testing.T) {
+	out := captureStdout(t, func() {
+		err := EmitWaitSucceeded(true, "backup storage", "my-s3", "everest")
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, `Backup storage "my-s3" is deleted`)
+}
+
+//nolint:paralleltest // captureStdout mutates global os.Stdout; must run serially
+func TestEmitWaitSucceeded_JSON(t *testing.T) {
+	out := captureStdout(t, func() {
+		err := EmitWaitSucceeded(false, "instance", "my-db", "everest")
+		require.NoError(t, err)
+	})
+	assert.JSONEq(t, `{"name":"my-db","namespace":"everest","deleted":true}`, out)
+}
+
+func TestTitleFirst(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"instance", "Instance"},
+		{"backup storage", "Backup storage"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, titleFirst(tt.in))
+	}
+}
+
+// Ensure writeResultJSON's output is exactly the wire shape callers depend
+// on (field order doesn't matter for JSON, but the field set/types do).
+//
+//nolint:paralleltest // captureStdout mutates global os.Stdout; must run serially
+func TestWriteResultJSON_Shape(t *testing.T) {
+	out := captureStdout(t, func() {
+		require.NoError(t, writeResultJSON("my-s3", "everest", true))
+	})
+	var decoded struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+		Deleted   bool   `json:"deleted"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &decoded))
+	assert.Equal(t, "my-s3", decoded.Name)
+	assert.Equal(t, "everest", decoded.Namespace)
+	assert.True(t, decoded.Deleted)
+}

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -213,6 +213,8 @@ const (
 	FlagBackupStorageWait = "wait"
 	// FlagBackupStorageTimeout bounds --wait; only valid together with --wait.
 	FlagBackupStorageTimeout = "timeout"
+	// FlagBackupStorageIgnoreNotFound treats an already-deleted backup storage as success.
+	FlagBackupStorageIgnoreNotFound = "ignore-not-found"
 
 	// `backup-class` flags.
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -209,6 +209,10 @@ const (
 	FlagBackupStorageCredentialsSecret = "credentials-secret"
 	// FlagBackupStorageAccessKeyID is the access key ID (plain flag; the secret access key is never a flag).
 	FlagBackupStorageAccessKeyID = "access-key-id"
+	// FlagBackupStorageWait blocks delete until the backup storage is fully removed.
+	FlagBackupStorageWait = "wait"
+	// FlagBackupStorageTimeout bounds --wait; only valid together with --wait.
+	FlagBackupStorageTimeout = "timeout"
 
 	// `backup-class` flags.
 

--- a/pkg/cli/instance/create.go
+++ b/pkg/cli/instance/create.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/openeverest/openeverest/v2/client"
 	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/clienterr"
 	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
 	"github.com/openeverest/openeverest/v2/pkg/output"
 )
@@ -165,8 +166,8 @@ func (ic *InstanceCreator) Run(ctx context.Context, opts CreateOptions, cfgPath 
 		if resp.StatusCode() == http.StatusConflict {
 			return fmt.Errorf("instance %q already exists in namespace %q", opts.Name, opts.Namespace)
 		}
-		if resp.JSONDefault != nil && resp.JSONDefault.Message != nil {
-			return fmt.Errorf("server error: %s", *resp.JSONDefault.Message)
+		if msg, ok := clienterr.Message(resp.JSONDefault); ok {
+			return fmt.Errorf("server error: %s", msg)
 		}
 		return fmt.Errorf("unexpected response creating instance: %s", resp.Status())
 	}

--- a/pkg/cli/instance/delete.go
+++ b/pkg/cli/instance/delete.go
@@ -17,7 +17,6 @@ package instance
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -29,7 +28,9 @@ import (
 
 	"github.com/openeverest/openeverest/v2/client"
 	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/clienterr"
 	"github.com/openeverest/openeverest/v2/pkg/cli/confirm"
+	"github.com/openeverest/openeverest/v2/pkg/cli/deletion"
 	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
 	"github.com/openeverest/openeverest/v2/pkg/output"
 )
@@ -150,8 +151,8 @@ func checkDeleteResponse(resp *client.DeleteInstanceResponse, opts DeleteOptions
 		}
 		return true, nil
 	case resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusNoContent:
-		if resp.JSONDefault != nil && resp.JSONDefault.Message != nil {
-			return false, fmt.Errorf("server error: %s", *resp.JSONDefault.Message)
+		if msg, ok := clienterr.Message(resp.JSONDefault); ok {
+			return false, fmt.Errorf("server error: %s", msg)
 		}
 		return false, fmt.Errorf("unexpected response deleting instance: %s", resp.Status())
 	default:
@@ -227,22 +228,12 @@ func blastRadiusMessage(name, namespace, policy string, verified bool) string {
 
 // emitDeleted prints success: a line in pretty mode, JSON otherwise.
 func (id *Deleter) emitDeleted(opts DeleteOptions) error {
-	if id.config.Pretty {
-		_, _ = fmt.Fprint(os.Stdout, output.Success("Instance %q deleted", opts.Name))
-		return nil
-	}
-	return writeDeleteResultJSON(opts.Name, opts.Namespace, true)
+	return deletion.EmitDeleted(id.config.Pretty, "instance", opts.Name, opts.Namespace)
 }
 
-// emitAlreadyGone reports the --ignore-not-found short-circuit: nothing was
-// deleted, so "deleted" must stay false, it should only mean this run
-// actually deleted something.
+// emitAlreadyGone reports the --ignore-not-found short-circuit.
 func (id *Deleter) emitAlreadyGone(opts DeleteOptions) error {
-	if id.config.Pretty {
-		_, _ = fmt.Fprint(os.Stdout, output.Info("Instance %q not found in namespace %q; nothing to delete", opts.Name, opts.Namespace))
-		return nil
-	}
-	return writeDeleteResultJSON(opts.Name, opts.Namespace, false)
+	return deletion.EmitAlreadyGone(id.config.Pretty, "instance", opts.Name, opts.Namespace)
 }
 
 // waitForDeletion blocks until the instance is gone, like instance create
@@ -270,21 +261,5 @@ func (id *Deleter) waitForDeletion(ctx context.Context, c *client.ClientWithResp
 		return err
 	}
 
-	if id.config.Pretty {
-		_, _ = fmt.Fprint(os.Stdout, output.Success("Instance %q is deleted", opts.Name))
-		return nil
-	}
-	return writeDeleteResultJSON(opts.Name, opts.Namespace, true)
-}
-
-func writeDeleteResultJSON(name, namespace string, deleted bool) error {
-	result := struct {
-		Name      string `json:"name"`
-		Namespace string `json:"namespace"`
-		Deleted   bool   `json:"deleted"`
-	}{Name: name, Namespace: namespace, Deleted: deleted}
-	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
-		return fmt.Errorf("failed to encode delete result: %w", err)
-	}
-	return nil
+	return deletion.EmitWaitSucceeded(id.config.Pretty, "instance", opts.Name, opts.Namespace)
 }

--- a/pkg/cli/instance/wait.go
+++ b/pkg/cli/instance/wait.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/openeverest/openeverest/v2/client"
 	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/deletion"
 	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
 )
 
@@ -137,33 +138,17 @@ func newInstanceDeletePoll(
 	c *client.ClientWithResponses,
 	cluster, namespace, name string,
 ) wait.PollFunc[*client.Instance] {
-	return func(ctx context.Context) (*client.Instance, error) {
+	return deletion.GonePoll("instance", name, func(ctx context.Context) (int, string, *client.Instance, error) {
 		resp, err := c.GetInstanceWithResponse(ctx, cluster, namespace, name)
 		if err != nil {
-			if errors.Is(err, authcli.ErrTokenRefresh) {
-				return nil, fmt.Errorf("failed to fetch instance %q: %w", name, err)
-			}
-			return nil, &wait.RetryableError{Err: fmt.Errorf("failed to fetch instance %q: %w", name, err)}
+			return 0, "", nil, err
 		}
-		switch resp.StatusCode() {
-		case http.StatusOK:
-			if resp.JSON200 == nil {
-				return nil, &wait.RetryableError{Err: fmt.Errorf("empty response body fetching instance %q", name)}
-			}
-			return resp.JSON200, nil
-		case http.StatusNotFound:
-			return nil, nil // gone
-		case http.StatusUnauthorized:
-			return nil, fmt.Errorf("server rejected credentials — run 'everestctl auth login' again")
-		default:
-			return nil, &wait.RetryableError{Err: fmt.Errorf("unexpected response fetching instance %q: %s", name, resp.Status())}
-		}
-	}
+		return resp.StatusCode(), resp.Status(), resp.JSON200, nil
+	})
 }
 
 func deleteCondition(inst *client.Instance) (wait.Outcome, string) {
-	if inst == nil {
-		return wait.Succeeded, "instance deleted"
-	}
-	return wait.Pending, progressMessage(inst, instancePhase(inst))
+	return deletion.GoneCondition("instance deleted", func(v *client.Instance) string {
+		return progressMessage(v, instancePhase(v))
+	})(inst)
 }

--- a/pkg/cli/restore/create.go
+++ b/pkg/cli/restore/create.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/openeverest/openeverest/v2/client"
 	authcli "github.com/openeverest/openeverest/v2/pkg/cli/auth"
+	"github.com/openeverest/openeverest/v2/pkg/cli/clienterr"
 	"github.com/openeverest/openeverest/v2/pkg/cli/wait"
 	"github.com/openeverest/openeverest/v2/pkg/output"
 )
@@ -97,8 +98,8 @@ func (cr *CreateRunner) Run(ctx context.Context, opts CreateOptions, cfgPath str
 		if resp.StatusCode() == http.StatusConflict {
 			return fmt.Errorf("restore %q already exists in namespace %q", opts.Name, opts.Namespace)
 		}
-		if resp.JSONDefault != nil && resp.JSONDefault.Message != nil {
-			return fmt.Errorf("server error: %s", *resp.JSONDefault.Message)
+		if msg, ok := clienterr.Message(resp.JSONDefault); ok {
+			return fmt.Errorf("server error: %s", msg)
 		}
 		return fmt.Errorf("unexpected response creating restore: %s", resp.Status())
 	}


### PR DESCRIPTION
Deletes a BackupStorage through the Everest API, following the resource-removal confirmation flow from the shared pkg/cli/confirm helper (--yes skips the y/N prompt and the command fails fast in non-interactive contexts). An optional --wait/--timeout polls until the BackupStorage is actually removed, since deleting a storage that is still referenced by an Instance or Backup returns 204 No Content but leaves the resource in the Terminating state rather than failing synchronously. The credentials Secret is not deleted explicitly—the BackupStorage controller sets an owner reference on it, allowing Kubernetes garbage collection to remove the Secret automatically once the BackupStorage has been deleted.
Closes #2660 
Branched on issue #2658 