### PR TITLE
fix(auth): backport token blocklist update error handling

### DIFF
--- a/pkg/session/blocklist_test.go
+++ b/pkg/session/blocklist_test.go
@@ -28,8 +28,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/openeverest/openeverest/v2/pkg/common"
 	"github.com/openeverest/openeverest/v2/pkg/kubernetes"
@@ -435,6 +437,71 @@ func TestBlocklist_IsBlocked(t *testing.T) {
 			assert.Equal(t, tc.blocked, blocked)
 		})
 	}
+}
+
+// TestTokenStore_Add_UpdateFailure asserts the invariant that Add reports
+// success only when the token is genuinely blocklisted. When the underlying
+// Secret update fails, Add must return the error rather than swallow it, and
+// the token must not be persisted to the blocklist Secret.
+//
+// This is a regression test for the missing backport of #2086 (see #2766): on
+// the unfixed code Add returns the nil `err` from the earlier GetSecret instead
+// of the update error, so a failed write is reported as success and the token
+// is never blocklisted.
+func TestTokenStore_Add_UpdateFailure(t *testing.T) {
+	t.Parallel()
+
+	l := zap.NewNop().Sugar()
+	ctx := context.Background()
+
+	//nolint:gosec // test token ID, not a credential
+	const shortenedToken = "9d1c1f98-a479-41e3-8939-c7cb3e049a331743679478"
+
+	// Fail every Secret update to simulate a transient write error (e.g. a 409
+	// conflict from concurrent logouts). Reads and the init-time create still
+	// succeed, so Add reaches the update and fails there.
+	mockClient := fakeclient.NewClientBuilder().
+		WithScheme(kubernetes.CreateScheme()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(
+				ctx context.Context,
+				c ctrlclient.WithWatch,
+				obj ctrlclient.Object,
+				opts ...ctrlclient.UpdateOption,
+			) error {
+				if _, ok := obj.(*corev1.Secret); ok {
+					return k8serrors.NewConflict(
+						schema.GroupResource{Resource: "secrets"},
+						obj.GetName(),
+						errors.New("simulated conflict"),
+					)
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		})
+	k := kubernetes.NewEmpty(l, "test-ns").WithKubernetesClient(mockClient.Build())
+
+	store, err := newTokenStore(ctx, k, l, "test-ns")
+	require.NoError(t, err)
+
+	// The Secret write fails, so Add must surface the error and not report
+	// success. The defect returned the wrong error variable, so pin that the
+	// surfaced error is the UpdateSecret conflict rather than merely "an error":
+	// kubernetes.UpdateSecret returns the client error unwrapped.
+	err = store.Add(ctx, shortenedToken)
+	require.Error(t, err)
+	assert.True(t, k8serrors.IsConflict(err), "Add must surface the UpdateSecret error, got %v", err)
+
+	// Read-back invariant: because the write failed, the token must not have
+	// reached the Secret. As in TestBlocklist_Block, the fake client does not do
+	// the StringData -> Data transformation the real API server does, so the
+	// assertion has to be on StringData.
+	secret, err := k.GetSecret(ctx, ctrlclient.ObjectKey{
+		Name:      common.EverestBlocklistSecretName,
+		Namespace: "test-ns",
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, secret.StringData[dataKey], shortenedToken)
 }
 
 func mockNewBlocklist(ctx context.Context, logger *zap.SugaredLogger, mockClient TokenStoreClient) (Blocklist, error) {

--- a/pkg/session/token_store.go
+++ b/pkg/session/token_store.go
@@ -76,9 +76,9 @@ func (ts *tokenStore) Add(ctx context.Context, shortenedToken string) error {
 	}
 
 	secret = addDataToSecret(ts.l, secret, shortenedToken, time.Now().UTC())
-	_, updateErr := ts.client.UpdateSecret(ctx, secret)
-	if updateErr != nil {
-		ts.l.Errorf("failed to update %s secret in the %s namespace with the %s shortened token, retrying: %v", secret.Name, secret.Namespace, shortenedToken, updateErr)
+	_, err = ts.client.UpdateSecret(ctx, secret)
+	if err != nil {
+		ts.l.Errorf("failed to update %s secret in the %s namespace with the %s shortened token, retrying: %v", secret.Name, secret.Namespace, shortenedToken, err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
## What

Backports the fix from #2086 to `release-2.0`.

Part of #2766

`tokenStore.Add` incorrectly returned the `GetSecret` error instead of the `UpdateSecret` error, causing blocklist update failures to be reported as success and preventing the retry logic from running.

## Changes

- Return the `UpdateSecret` error from `tokenStore.Add`, matching the existing fix in #2086.
- Add a regression test covering `UpdateSecret` failures.

## Testing

Added `TestTokenStore_Add_UpdateFailure`, which verifies that:

- `Add` returns an error when the Secret update fails.
- A read-back using `Exists` confirms the token was not blocklisted.

Verified locally:

- `go test ./pkg/session/...`
- `go test -race ./pkg/session/...`

## Related

- Backports #2086