### PR TITLE
Add `-n` shorthand for namespace in `everestctl instance` commands

### DIFF
--- a/commands/instance/create.go
+++ b/commands/instance/create.go
@@ -92,7 +92,7 @@ to override any Instance spec field using dot-notation paths rooted at the spec
 
 func init() {
 	createCmd.Flags().StringVar(&createOpts.Name, cli.FlagInstanceName, "", "Instance name (required)")
-	createCmd.Flags().StringVar(&createOpts.Namespace, cli.FlagInstanceNamespace, "", "Namespace to create the instance in (required)")
+	createCmd.Flags().StringVarP(&createOpts.Namespace, cli.FlagInstanceNamespace, "n", "", "Namespace to create the instance in (required)")
 	createCmd.Flags().StringVar(&createOpts.Provider, cli.FlagInstanceProvider, "", "Provider name, e.g. percona-server-mongodb (required unless --preset is given)")
 	createCmd.Flags().StringVar(&createOpts.Preset, cli.FlagInstancePreset, "", "InstancePreset name to bootstrap from; --provider is inferred from the preset when omitted")
 	createCmd.Flags().StringVar(&createOpts.Cluster, cli.FlagInstanceCluster, "main", "Cluster name")

--- a/commands/instance/delete.go
+++ b/commands/instance/delete.go
@@ -73,7 +73,7 @@ list' for the namespace.`,
 
 func init() {
 	deleteCmd.Flags().StringVar(&deleteOpts.Name, cli.FlagInstanceName, "", "Instance name (required)")
-	deleteCmd.Flags().StringVar(&deleteOpts.Namespace, cli.FlagInstanceNamespace, "", "Namespace the instance is in (required)")
+	deleteCmd.Flags().StringVarP(&deleteOpts.Namespace, cli.FlagInstanceNamespace, "n", "", "Namespace the instance is in (required)")
 	deleteCmd.Flags().StringVar(&deleteOpts.Cluster, cli.FlagInstanceCluster, "main", "Cluster name")
 	deleteCmd.Flags().StringVar(&deleteOpts.Context, cli.FlagInstanceContext, "", "Context to use (default: current context)")
 	deleteCmd.Flags().StringVar(&deleteOpts.DeletionPolicy, cli.FlagInstanceDeletionPolicy, "",

--- a/commands/instance/status.go
+++ b/commands/instance/status.go
@@ -66,7 +66,7 @@ or emits one JSON object per line (NDJSON) in --json mode.`,
 
 func init() {
 	statusCmd.Flags().StringVar(&statusOpts.Name, cli.FlagInstanceName, "", "Instance name (required)")
-	statusCmd.Flags().StringVar(&statusOpts.Namespace, cli.FlagInstanceNamespace, "", "Namespace the instance lives in (required)")
+	statusCmd.Flags().StringVarP(&statusOpts.Namespace, cli.FlagInstanceNamespace, "n", "", "Namespace the instance lives in (required)")
 	statusCmd.Flags().StringVar(&statusOpts.Cluster, cli.FlagInstanceCluster, "main", "Cluster name")
 	statusCmd.Flags().StringVar(&statusOpts.Context, cli.FlagInstanceContext, "", "Context to use (default: current context)")
 	statusCmd.Flags().BoolVarP(&statusOpts.Watch, cli.FlagInstanceWatch, "w", false, "Poll continuously until Ctrl-C or token expiry")


### PR DESCRIPTION
## Summary

This PR adds the `-n` shorthand for the `--namespace` flag to the following `everestctl instance` commands:

* `instance create`
* `instance delete`
* `instance status`

The change updates the namespace flag registration from `StringVar` to `StringVarP` with the `n` shorthand, bringing these commands in line with the rest of the CLI (e.g. `backup`, `restore`, `backup-storage`, and `instance list`).

## Changes

* Added `-n` shorthand to `commands/instance/create.go`
* Added `-n` shorthand to `commands/instance/delete.go`
* Added `-n` shorthand to `commands/instance/status.go`
* No functional changes beyond the addition of the shorthand flag.

## Related Issue

Closes #2792
