### PR TITLE
docs: align issue assignment with the Kubernetes contributor guidelines

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -85,20 +85,13 @@ jobs:
             const labels = (issue.labels || []).map((l) => l.name);
             let newcomerNote = '';
 
+            // Taking an issue is not the same as us having agreed to the fix.
+            const triageNote = labels.includes('needs-triage')
+              ? "- Nobody has triaged this yet, so we haven't agreed it should be fixed, or fixed this way. If it's more than a small, obvious fix, it's worth waiting for that decision before writing much code."
+              : '';
+
             // Maintainers bypass the gates below.
             if (!commenterIsMaintainer) {
-              // Filing an issue does not reserve it: it has not been triaged,
-              // and we may not agree it is a bug or want it fixed this way.
-              if (issue.user.login === commenter && !labels.includes('help wanted')) {
-                await reply(`@${commenter} opening an issue doesn't reserve it — it still needs to be triaged first, and we may not agree it's a bug or may want it fixed differently. A maintainer will review it and assign you if it's a good fit. See [CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md#working-on-issues).`);
-                return;
-              }
-
-              if (!labels.includes('help wanted')) {
-                await reply(`@${commenter} this issue isn't open for self-assignment yet — it needs the \`help wanted\` label, which a maintainer adds once the issue has been triaged and we'd welcome help with it.\n\nComment to say you'd like to take it and a maintainer will get back to you. See [CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md#working-on-issues).`);
-                return;
-              }
-
               const open = await github.rest.search.issuesAndPullRequests({
                 q: `repo:${owner}/${repo} is:issue is:open assignee:${commenter}`,
                 advanced_search: 'true',
@@ -144,5 +137,6 @@ jobs:
               '- Open your pull request with `Fixes #' + issue_number + '` in the description.',
               '- If you get stuck or change your mind, comment `/unassign` — no hard feelings.',
               '- If there is no visible progress for two weeks we will check in, and unassign a week after that so somebody else can pick it up.',
+              triageNote,
               newcomerNote,
             ].filter(Boolean).join('\n'));

--- a/.github/workflows/triage-labels.yml
+++ b/.github/workflows/triage-labels.yml
@@ -1,0 +1,50 @@
+name: Triage labels
+
+# Keeps exactly one triage label on every open issue, so "has anybody looked at
+# this?" is always answerable from the label list. `needs-triage` goes on at
+# creation and comes off only when a maintainer records a decision by applying
+# `triage/accepted` or `triage/needs-information` — and goes back on if the
+# decision label is later removed.
+#
+# Label events raised by this workflow use GITHUB_TOKEN, which does not start
+# another workflow run, so this cannot loop.
+
+on:
+  issues:
+    types: [opened, reopened, labeled, unlabeled]
+
+permissions:
+  issues: write
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue = context.payload.issue;
+            if (issue.state !== 'open') return;
+
+            const NEEDS_TRIAGE = 'needs-triage';
+            const DECISIONS = ['triage/accepted', 'triage/needs-information'];
+
+            const labels = (issue.labels || []).map((l) => l.name);
+            const decided = DECISIONS.some((d) => labels.includes(d));
+            const marked = labels.includes(NEEDS_TRIAGE);
+
+            if (decided && marked) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: issue.number, name: NEEDS_TRIAGE,
+                });
+              } catch { /* removed by somebody else in the meantime */ }
+              return;
+            }
+
+            if (!decided && !marked) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: issue.number, labels: [NEEDS_TRIAGE],
+              });
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,29 +46,37 @@ Labels tell you where an issue stands:
 
 | Label | What it means for you |
 | --- | --- |
-| `needs-triage` | Not reviewed yet. Please don't start work on it. |
+| `needs-triage` | Nobody has looked at it yet. Added automatically when the issue is opened. |
 | `triage/needs-information` | We're waiting on the reporter before deciding. |
 | `triage/accepted` | We agree this should be done. |
 | [`help wanted`](https://github.com/openeverest/openeverest/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+no%3Aassignee) | Accepted, and we'd welcome community help. **Claim these yourself with `/assign`.** |
 | [`good first issue`](https://github.com/openeverest/openeverest/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee) | A `help wanted` issue that needs no deep background. Ideal if this is your first contribution here. |
 
-**This applies to issues you open yourself.** Filing an issue does not reserve it, and a new issue has not been reviewed yet — we may not agree that it is a bug, or may not want it fixed the way you propose.
+**The triage labels are maintained by a bot, so they are always current.** `needs-triage` is applied to every issue as it is opened, and is removed only when a maintainer records a decision by applying `triage/accepted` or `triage/needs-information`. If a decision label is later taken off, `needs-triage` comes back. Exactly one of the three is on every open issue, so "has anybody looked at this yet?" is answerable at a glance.
+
+They describe where our thinking has got to, not what you are allowed to do. An issue sitting at `needs-triage` means we might decide it isn't a bug, or that we don't want it fixed the way it proposes — which is worth knowing before you spend a weekend on it, and is the only reason to wait.
+
+**This applies to issues you open yourself.** Filing an issue does not assign it to you — comment `/assign` if you want it.
+
+**Small, obvious fixes don't need to wait for any of this.** A wrong error message, a missing nil check, a typo in a log line — open the pull request and reference the issue. Triage exists to stop you sinking days into something we may not want, not to make you queue for permission to fix something that is plainly broken.
+
+**What a `good first issue` should give you.** Before we apply that label, the issue should describe both the problem and the shape of the fix, link the code and the tests you will need to touch, need no unusual setup or deep background, and have somebody willing to answer questions while you work on it. If one of those is missing, say so in the thread — that is a shortcoming in the issue, not in you.
 
 ### Claiming an issue
 
-**If it is labelled `help wanted`, comment `/assign`.** A bot assigns it to you straight away; no maintainer needs to be involved. Comment `/unassign` at any time to release it.
+**Comment `/assign` on any open issue.** A bot assigns it to you straight away — no maintainer needs to be involved, and you do not need to wait for the issue to be triaged. Comment `/unassign` at any time to release it. The bot will decline only if somebody else already has it, or if you are at your limit: **at most two open assigned issues at a time**.
 
-The bot will decline if the issue is already assigned, if it isn't labelled `help wanted` yet, or if you are at your limit: **at most two open assigned issues at a time**.
+**Being assigned is not the same as us agreeing to the fix.** If the issue still says `needs-triage`, we might yet decide it isn't a bug, or that we want it solved differently. For a small, obvious fix — a wrong error message, a missing nil check — go straight ahead. For anything larger, waiting for the triage decision costs you a few days and can save you a weekend. That is a judgement call about your own time, not a rule.
 
 If you have already had a pull request merged here, please consider leaving `good first issue` items for people who haven't — there are rarely many of them, and they are the easiest way into the project for someone new. That is a courtesy rather than a rule, and the bot will not stop you.
 
-**For anything else, comment to say you'd like to take it** — for example, *"I'd like to work on this"* — and wait for a maintainer to accept the issue and assign it. Waiting stops two people solving the same problem in parallel, and stops you spending time on a report that turns out not to be a bug or that we have decided not to fix.
-
-**If nobody has replied within 5 business days, go ahead and start**, and leave a second comment saying so. You should not be blocked by our silence. If someone else has already said they started, coordinate with them in the thread rather than opening a competing pull request.
+**If the same thing gets reported twice, the earliest report wins.** We keep the first one and close later ones against it, whether or not a pull request happens to be attached to the later one. Whoever fixes it references the original issue.
 
 ### While you are working
 
-Please do not open a pull request for an issue assigned to someone else — it will be closed. Reference the issue with `Fixes #123` in your pull request description.
+Please do not open a pull request for an issue that is assigned to somebody else. If you have already written the fix, say so in the issue thread rather than opening it: if the assignee has gone quiet, or is happy to hand it over, a maintainer will sort it out there.
+
+Reference the issue with `Fixes #123` in your pull request description.
 
 If an assigned issue shows no visible progress for two weeks, a bot will ask whether you are still on it, and will unassign it about a week later if there is no reply. No hard feelings — comment `/assign` and it is yours again.
 
@@ -78,6 +86,35 @@ Two things stop that clock, and you can ask for either in the issue thread:
 - **`lifecycle/frozen`** — the work is simply a long one and will legitimately take more than a few weeks.
 
 Before investing significant time in an implementation, consider sharing your design ideas in the issue thread or in our [community channels](https://openeverest.io/#community) (Slack and more). Early feedback from maintainers and other contributors can save effort, surface existing work, and help your PR land faster.
+
+## Pull requests
+
+### Keep them small
+
+Small pull requests get reviewed faster and are more likely to be correct. Reviewer attention is the scarce resource here: someone with twenty minutes will pick up a hundred-line change and postpone a thousand-line one, possibly several times over.
+
+- **One concern per pull request.** While implementing something you will find bad names, missing tests, weak types. Please do fix them — in a separate pull request. Unrelated changes in the same diff bury the change that actually matters.
+- **Land preparatory work first.** If your change needs a refactor to fit, send the refactor on its own. It is easier to review, and it stops you rebasing it forever.
+- **Don't sweep the whole repository.** A one-line change repeated across forty files needs sign-off from everyone who owns those files, and the review cost rarely justifies the benefit. If you want to do one of these, split it by area and open the first one to find out whether we agree before doing the rest.
+- **Style-only and linter-only changes need agreement first.** Ask in the issue or in our [community channels](https://openeverest.io/#community) before opening them. A linter we have not enabled is usually a decision rather than an oversight, and reformatting churn makes every open pull request conflict.
+- **Trivial edits cost a review too.** A single typo fix is rarely worth one on its own — if you are fixing one, read the rest of the file and fix everything you find there.
+
+Open it as a **draft** while you are still working, and mark it ready for review when you want eyes on it. Explain the *why* in the description; the *what* is already in the diff.
+
+### Getting it reviewed
+
+Give it time before chasing it: a pull request opened this morning has not gone quiet, it has just been opened. Once a week or so has passed with no response at all:
+
+1. Check CI is green and there are no merge conflicts — nobody starts a review on a red pull request.
+2. Check the description says why the change is needed, not just what it does.
+3. Comment on the pull request asking for a review. This is welcome, not nagging.
+4. Bring it to our [community channels](https://openeverest.io/#community), or to a [community meeting](https://github.com/openeverest#openeverest-community-meetings).
+
+We would much rather be nudged than have your work sit there while you assume we have quietly said no.
+
+### It's fine to push back
+
+Reviewers get things wrong. If you have a good reason for doing something a particular way, say so — you might be overruled, but you might also be right, and we would rather have the argument than have you silently apply a change you think is worse.
 
 ## AI-assisted contributions
 


### PR DESCRIPTION
Aligns our issue workflow with the [Kubernetes contributor guidelines](https://www.kubernetes.dev/docs/guide/), which is the model most people arriving here already know.

## Why

Self-assignment only worked once a maintainer had labelled an issue `help wanted`, and the issue's own author was refused outright. Everyone else was told to comment and wait — which produces no state anywhere: no label, no assignee, nothing a person or a workflow can act on.

A few days ago a contributor filed a bug, was told to hold off until triage, and did. Two days later somebody else filed the same bug and opened a pull request immediately without claiming anything. That pull request was picked up and the original report was closed as the duplicate. Every step was individually defensible; the outcome was that we rewarded skipping the queue at the expense of the person who did as we asked.

## What changes

**`/assign` works on any open issue, instantly.** Both gates are gone. Kubernetes lets contributors self-assign without waiting for triage or for a maintainer, and protects the assignee at the other end instead: *"creating a PR when someone else is already working on an issue is not a good practice and is discouraged"*. Ours now does the same. Being assigned still isn't us agreeing to the fix, and the bot says so when the issue is untriaged.

**Triage labels are maintained by a bot.** `needs-triage` on open, removed when a maintainer records a decision, put back if that decision is undone — so exactly one triage label is always present, as in `kubernetes/kubernetes`. Ours came from the issue templates alone and was never removed, which is why #2761 still carries it next to its resolution.

**Duplicates are resolved by report time**, per their triage guide: reference the original, close the duplicate. Nothing said this before, so it ran towards whichever issue had a pull request attached.

**"Don't start work on it" is gone**, and a new pull request section covers scope and size — one concern per PR, no repository-wide sweeps, linter-only changes need agreement first — along with how to get a stalled review moving, and that pushing back on a review is fine.

The two-issue cap and the stale-assignment reaper stay as they are. Kubernetes has no cap and reclaims on a longer clock; ours is tighter on both counts, deliberately, given current volume.