### PR TITLE
fix: correct nanosecond truncation in latestRestorableDate

### DIFF
--- a/internal/server/handlers/k8s/database_cluster.go
+++ b/internal/server/handlers/k8s/database_cluster.go
@@ -386,7 +386,7 @@ func latestRestorableDate(now, latestBackupTime time.Time, heuristicsInterval in
 		return nil
 	}
 	// delete nanoseconds since they're not accepted by restoration
-	now = now.Truncate(time.Duration(now.Nanosecond()) * time.Nanosecond)
+	now = now.Truncate(time.Second)
 	// heuristic: latest restorable date is now minus uploadInterval
 	date := now.Add(-time.Duration(heuristicsInterval) * time.Second).UTC()
 	// not able to restore if after the latest backup passed less than uploadInterval time,

--- a/internal/server/handlers/k8s/database_cluster_test.go
+++ b/internal/server/handlers/k8s/database_cluster_test.go
@@ -42,6 +42,8 @@ func TestLatestRestorableDate(t *testing.T) {
 
 	now := time.Date(2024, 3, 12, 12, 0, 0, 0, time.UTC)
 	restorable := now.Add(-600 * time.Second)
+	nowWithNanos := time.Date(2024, 3, 12, 12, 0, 0, 999999999, time.UTC)
+	restorableFromNanos := time.Date(2024, 3, 12, 11, 50, 0, 0, time.UTC)
 	cases := []tCase{
 		{
 			name:             "backup 5 min ago, upload interval 10 min",
@@ -56,6 +58,13 @@ func TestLatestRestorableDate(t *testing.T) {
 			latestBackupTime: now.Add(-900 * time.Second),
 			now:              now,
 			expected:         &restorable,
+		},
+		{
+			name:             "now has sub-second precision — nanoseconds must be stripped from result",
+			uploadInterval:   600,
+			latestBackupTime: time.Date(2024, 3, 12, 11, 44, 59, 0, time.UTC),
+			now:              nowWithNanos,
+			expected:         &restorableFromNanos,
 		},
 	}
 


### PR DESCRIPTION
What's the problem?

In `internal/server/handlers/k8s/database_cluster.go`, the `latestRestorableDate` function tries to strip sub-second precision from the current time before calculating the latest PITR date.

However, the truncation logic was written as:

```go
// delete nanoseconds since they're not accepted by restoration
now = now.Truncate(time.Duration(now.Nanosecond()) * time.Nanosecond)
```

`time.Truncate(d)` rounds a `time.Time` down to the nearest multiple of `d`. Using `now.Nanosecond() * time.Nanosecond` passes a dynamic sub-second duration (e.g. 482,109,234 ns) into `Truncate`, rather than truncating to the nearest full second.

As a result, sub-second precision was never properly stripped from `now`, leaving nanosecond residue in the calculated `latestDate` timestamp. When a user tries to perform a Point-in-Time Recovery (PITR) restore using this timestamp, the database operator rejects the request due to the sub-second precision.

### Why wasn't this caught by unit tests?

The existing test case in `TestLatestRestorableDate` initialized `now` using `time.Date(2024, 3, 12, 12, 0, 0, 0, time.UTC)` where the nanosecond field was explicitly set to `0`. Because `now.Nanosecond()` evaluated to `0`, the broken `Truncate` call returned the time unmodified, which happened to have zero nanoseconds, completely masking the bug.

### What changed?

1. Replaced the self-referential `Truncate` call with `now = now.Truncate(time.Second)`, which cleanly strips all sub-second precision (milliseconds, microseconds, nanoseconds) as intended.
2. Added a test case to `TestLatestRestorableDate` where `now` has `999999999` nanoseconds to ensure sub-second truncation is explicitly verified and won't regress.

### Code Diff

```diff
diff --git a/internal/server/handlers/k8s/database_cluster.go b/internal/server/handlers/k8s/database_cluster.go
index 067ef114..15bf16c8 100644
--- a/internal/server/handlers/k8s/database_cluster.go
+++ b/internal/server/handlers/k8s/database_cluster.go
@@ -386,7 +386,7 @@ func latestRestorableDate(now, latestBackupTime time.Time, heuristicsInterval in
 		return nil
 	}
 	// delete nanoseconds since they're not accepted by restoration
-	now = now.Truncate(time.Duration(now.Nanosecond()) * time.Nanosecond)
+	now = now.Truncate(time.Second)
 	// heuristic: latest restorable date is now minus uploadInterval
 	date := now.Add(-time.Duration(heuristicsInterval) * time.Second).UTC()
 	// not able to restore if after the latest backup passed less than uploadInterval time,
```