### PR TITLE
fix(cli): respect --skip-wizard flag in everestctl namespaces update 

### DIFF
--- a/commands/install.go
+++ b/commands/install.go
@@ -132,7 +132,7 @@ func checkDBNamespaceParameters(cmd *cobra.Command) error {
 	}
 
 	// If user doesn't pass any --operator.* flags - need to ask explicitly.
-	askOperators := !cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed && !cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed && !cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed && !cmd.Flags().Lookup(cli.FlagOperatorMySQL).Changed && !installCfg.NamespaceAddConfig.SkipWizard
+	askOperators := namespaces.ShouldAskOperators(cmd, installCfg.NamespaceAddConfig.SkipWizard)
 
 	if askOperators {
 		// need to ask user to provide operators to be installed in interactive mode.

--- a/commands/namespaces/add.go
+++ b/commands/namespaces/add.go
@@ -95,7 +95,7 @@ func namespacesAddPreRun(cmd *cobra.Command, args []string) {
 	}
 
 	// If user doesn't pass any --operator.* flags - need to ask explicitly.
-	askOperators := !cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed && !cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed && !cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed && !cmd.Flags().Lookup(cli.FlagOperatorMySQL).Changed && !namespacesAddCfg.SkipWizard
+	askOperators := namespaces.ShouldAskOperators(cmd, namespacesAddCfg.SkipWizard)
 
 	if askOperators {
 		// need to ask user to provide operators to be installed in interactive mode.

--- a/commands/namespaces/update.go
+++ b/commands/namespaces/update.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	namespacesUpdateCmd = &cobra.Command{
-		Use:   "update <namespaces> [flags] ",
+		Use:   "update <namespaces> [flags]",
 		Args:  cobra.ExactArgs(1),
 		Long:  "Add database operator to existing namespace managed by Everest",
 		Short: "Add database operator to existing namespace managed by Everest",
@@ -89,7 +89,7 @@ func namespacesUpdatePreRun(cmd *cobra.Command, args []string) {
 	}
 
 	// If user doesn't pass any --operator.* flags - need to ask explicitly.
-	askOperators := !cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed && !cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed && !cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed && !cmd.Flags().Lookup(cli.FlagOperatorMySQL).Changed
+	askOperators := !cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed && !cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed && !cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed && !cmd.Flags().Lookup(cli.FlagOperatorMySQL).Changed && !namespacesUpdateCfg.SkipWizard
 
 	if askOperators {
 		// need to ask user to provide operators to be installed in interactive mode.

--- a/commands/namespaces/update.go
+++ b/commands/namespaces/update.go
@@ -89,7 +89,7 @@ func namespacesUpdatePreRun(cmd *cobra.Command, args []string) {
 	}
 
 	// If user doesn't pass any --operator.* flags - need to ask explicitly.
-	askOperators := !cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed && !cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed && !cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed && !cmd.Flags().Lookup(cli.FlagOperatorMySQL).Changed && !namespacesUpdateCfg.SkipWizard
+	askOperators := namespaces.ShouldAskOperators(cmd, namespacesUpdateCfg.SkipWizard)
 
 	if askOperators {
 		// need to ask user to provide operators to be installed in interactive mode.

--- a/pkg/cli/namespaces/add_test.go
+++ b/pkg/cli/namespaces/add_test.go
@@ -1,11 +1,30 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package namespaces
 
 import (
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	operatorUtils "github.com/percona/everest-operator/utils"
+	"github.com/percona/everest/pkg/cli"
 )
 
 func TestParseNamespaceNames(t *testing.T) {
@@ -168,6 +187,54 @@ func TestValidateNamespaces(t *testing.T) {
 			err := validateNamespaceNames(tc.input)
 			assert.Equal(t, tc.error, err)
 			// assert.ElementsMatch(t, tc.output, output)
+		})
+	}
+}
+
+func TestShouldAskOperators(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       []string
+		skipWizard bool
+		expected   bool
+	}{
+		{
+			name:       "no operator flags passed, skipWizard false",
+			args:       []string{},
+			skipWizard: false,
+			expected:   true,
+		},
+		{
+			name:       "operator flag passed, skipWizard false",
+			args:       []string{"--" + cli.FlagOperatorMongoDB + "=true"},
+			skipWizard: false,
+			expected:   false,
+		},
+		{
+			name:       "no operator flags passed, skipWizard true",
+			args:       []string{},
+			skipWizard: true,
+			expected:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := &cobra.Command{}
+			cmd.Flags().Bool(cli.FlagOperatorMongoDB, true, "")
+			cmd.Flags().Bool(cli.FlagOperatorPostgresql, true, "")
+			cmd.Flags().Bool(cli.FlagOperatorXtraDBCluster, true, "")
+			cmd.Flags().Bool(cli.FlagOperatorMySQL, true, "")
+
+			err := cmd.ParseFlags(tc.args)
+			require.NoError(t, err)
+
+			res := ShouldAskOperators(cmd, tc.skipWizard)
+			assert.Equal(t, tc.expected, res)
 		})
 	}
 }

--- a/pkg/cli/namespaces/utils.go
+++ b/pkg/cli/namespaces/utils.go
@@ -23,14 +23,27 @@ import (
 	"strings"
 
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	operatorUtils "github.com/percona/everest-operator/utils"
+	"github.com/percona/everest/pkg/cli"
 	"github.com/percona/everest/pkg/common"
 	"github.com/percona/everest/pkg/kubernetes"
 )
+
+// ShouldAskOperators reports whether the user should be prompted to choose
+// database operators: true only if none of the --operator.* flags were
+// explicitly set and the wizard isn't skipped.
+func ShouldAskOperators(cmd *cobra.Command, skipWizard bool) bool {
+	return !cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed &&
+		!cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed &&
+		!cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed &&
+		!cmd.Flags().Lookup(cli.FlagOperatorMySQL).Changed &&
+		!skipWizard
+}
 
 // ParseNamespaceNames parses a comma-separated namespaces string.
 // It returns a list of namespaces.


### PR DESCRIPTION
## Description

Fixes #2810

When executing `everestctl namespaces update <namespaces> --skip-wizard` without explicitly specifying operator flags (e.g., `--operator.mongodb=true`), the command failed with:
Error: can't ask user for operators to install: interactive mode is disabled

### Root Cause
In `commands/namespaces/update.go`, `askOperators` was missing `&& !namespacesUpdateCfg.SkipWizard` in its evaluation logic during `namespacesUpdatePreRun`. When `--skip-wizard` was supplied without explicit operator flags, `askOperators` evaluated to `true` and invoked `PopulateOperators()`. `PopulateOperators()` then threw `ErrInteractiveModeDisabled` because `SkipWizard` was active.

### Changes Made
1. Added `&& !namespacesUpdateCfg.SkipWizard` to `askOperators` in `commands/namespaces/update.go`.
2. Removed trailing whitespace from `Use: "update <namespaces> [flags] "` in `namespacesUpdateCmd`.

## How to Test
1. Run `everestctl namespaces update <ns> --skip-wizard` on a managed namespace without passing operator flags.
2. Confirm the command runs in non-interactive mode using default operator configurations without triggering `ErrInteractiveModeDisabled`.
3. Verify all Go builds pass: `go build ./...`.

## Checklist
- [x] Code builds clean (`go build ./...`)
- [x] Commits follow standard conventional commit guidelines
- [x] Links to issue #2810
