### PR TITLE
fix(cli): reject unknown subcommands on grouping commands

### DIFF
--- a/commands/accounts.go
+++ b/commands/accounts.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,10 +25,10 @@ import (
 
 var accountsCmd = &cobra.Command{
 	Use:   "accounts <command> [flags]",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.NoArgs,
 	Long:  "Manage Everest accounts",
 	Short: "Manage Everest accounts",
-	Run:   func(_ *cobra.Command, _ []string) {},
+	RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 }
 
 func init() {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -1,0 +1,88 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// parentCommands are the commands that exist only to group subcommands.
+var parentCommands = [][]string{
+	{"namespaces"},
+	{"settings"},
+	{"accounts"},
+	{"settings", "rbac"},
+	{"settings", "oidc"},
+}
+
+// execRoot runs the root command with the given arguments and returns the error
+// main() would turn into a non-zero exit code. The commands share the package-level
+// rootCmd, so these must not run in parallel.
+func execRoot(t *testing.T, args ...string) error {
+	t.Helper()
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+	return rootCmd.Execute()
+}
+
+// Cobra checks Runnable() before it validates Args, so a parent command with no
+// Run at all returns flag.ErrHelp and exits 0 whatever it is given, and one with
+// an empty Run exits 0 silently. Either way a typo looks like success, which
+// hides mistakes from CI scripts that gate on the exit code.
+//
+//nolint:paralleltest // execRoot mutates the package-level rootCmd.
+func TestParentCommandsRejectUnknownSubcommand(t *testing.T) {
+	for _, parent := range parentCommands {
+		path := strings.Join(parent, " ")
+		t.Run(path, func(t *testing.T) {
+			err := execRoot(t, append(parent, "bogus-subcommand")...)
+			require.Error(t, err, "%s accepted an unknown subcommand", path)
+			require.Contains(t, err.Error(), `unknown command "bogus-subcommand"`)
+		})
+	}
+}
+
+// Invoked with no subcommand, a parent command should print its help and succeed.
+//
+//nolint:paralleltest // execRoot mutates the package-level rootCmd.
+func TestParentCommandsWithoutArgsPrintHelp(t *testing.T) {
+	for _, parent := range parentCommands {
+		path := strings.Join(parent, " ")
+		t.Run(path, func(t *testing.T) {
+			require.NoError(t, execRoot(t, parent...))
+		})
+	}
+}
+
+// Rejecting positional args on the parent must not stop it from routing to a
+// real subcommand.
+//
+//nolint:paralleltest // reads the package-level rootCmd.
+func TestParentCommandsRouteToSubcommands(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"namespaces", "list"})
+	require.NoError(t, err)
+	require.Equal(t, "list", cmd.Name())
+}

--- a/commands/namespaces.go
+++ b/commands/namespaces.go
@@ -25,10 +25,10 @@ import (
 
 var namespacesCmd = &cobra.Command{
 	Use:   "namespaces <command> [flags]",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.NoArgs,
 	Long:  "Manage Everest database namespaces",
 	Short: "Manage Everest database namespaces",
-	Run:   func(_ *cobra.Command, _ []string) {},
+	RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 }
 
 func init() {

--- a/commands/settings.go
+++ b/commands/settings.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,10 +25,10 @@ import (
 
 var settingsCmd = &cobra.Command{
 	Use:   "settings <command> [flags]",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.NoArgs,
 	Long:  "Configure Everest settings",
 	Short: "Configure Everest settings",
-	Run:   func(_ *cobra.Command, _ []string) {},
+	RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 }
 
 func init() {

--- a/commands/settings/oidc.go
+++ b/commands/settings/oidc.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,9 +25,10 @@ import (
 
 var settingsOIDCCmd = &cobra.Command{
 	Use:   "oidc <command> [flags]",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.NoArgs,
 	Long:  "Manage settings related to OIDC",
 	Short: "Manage settings related to OIDC",
+	RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 }
 
 func init() {

--- a/commands/settings/rbac.go
+++ b/commands/settings/rbac.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,9 +25,10 @@ import (
 
 var settingsRBACCmd = &cobra.Command{
 	Use:   "rbac <command> [flags]",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.NoArgs,
 	Long:  "Manage RBAC settings",
 	Short: "Manage RBAC settings",
+	RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 }
 
 func init() {


### PR DESCRIPTION
## Why

`everestctl namespaces`, `settings`, `accounts`, `settings rbac` and `settings oidc`
exist only to group subcommands. All five accepted an unrecognised subcommand and
exited `0`, so a typo was indistinguishable from success — silently for three of
them, and with a help dump for the other two. Scripts and CI pipelines that gate on
the exit code could not tell a misspelled invocation from a real run.

Fixes #2816 

## Root cause

Cobra checks `!c.Runnable() → flag.ErrHelp` (`command.go:955`) *before* it validates
`Args` (`command.go:968`). That produced two variants of the same bug:

- `namespaces`, `settings`, `accounts` — `Args: cobra.ExactArgs(1)` plus an empty
  `Run`. The stray subcommand satisfied the arg count, the empty `Run` executed, and
  the process exited `0` with no output at all.
- `settings rbac`, `settings oidc` — `Args: cobra.ExactArgs(1)` and **no** `Run`.
  Being unrunnable, they returned `flag.ErrHelp` before `Args` was ever consulted,
  printed help, and exited `0`.

The consequence is that removing `Args`/`Run` alone does not fix this: a command must
be runnable for its `Args` validator to run at all.

## What changed

Each grouping command now sets `Args: cobra.NoArgs` and a `RunE` that prints help.
`cobra.NoArgs` already emits the exact "unknown command" error we want, so no custom
error construction was needed, and `RunE` makes the command runnable so the validator
is reached.

This matches the convention already used elsewhere in the CLI — `status`, `install`,
`upgrade`, `uninstall` and `version` all use `cobra.NoArgs` and were already correct.

## Behaviour

Before:

```console
$ everestctl namespaces llist
$ echo $?
0
```

After:

```console
$ everestctl namespaces llist
Error: unknown command "llist" for "everestctl namespaces"
Usage:
  everestctl namespaces <command> [flags]
$ echo $?
1
```

Invoked bare, the commands print their help and exit `0`:

```console
$ everestctl namespaces
Manage Everest database namespaces

Usage:
  everestctl namespaces <command> [flags]
$ echo $?
0
```

**One change beyond the reported bug:** bare `everestctl namespaces` previously exited
`1` with `accepts 1 arg(s), received 0`. It now prints help and exits `0`, which is the
conventional behaviour for a command that only groups subcommands, and is consistent
with `everestctl --help`. Flagging it in case reviewers would rather keep the non-zero
exit there.

## Testing

Adds `commands/commands_test.go`, the first test in this package. It drives the real
`rootCmd` and asserts that each grouping command returns an error for an unknown
subcommand, succeeds when invoked bare, and still routes to genuine subcommands.

I confirmed the tests fail against the previous code by reverting `namespaces.go`
(empty `Run`) and `settings/rbac.go` (no `Run`) and re-running — both variants of the
bug are caught.

`make test` passes in full under `-race`. `golangci-lint` reports no issues in
`commands/...`. `make copyright-check` passes; four files picked up the OpenEverest
copyright line via `make copyright-headers`.

`make check` still reports two `misspell` findings in
`internal/server/handlers/rbac/kubernetes_test.go`. These are pre-existing on `main`
and unrelated to this change, so I have left them out to keep this PR to one concern.