### PR TITLE
fix(rbac): add configurable timeout to ConfigMap adapter Kubernetes API calls (#2799)

### DIFF
--- a/pkg/rbac/configmap-adapter/adapter.go
+++ b/pkg/rbac/configmap-adapter/adapter.go
@@ -20,7 +20,9 @@ package configmapadapter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/casbin/casbin/v2/model"
 	"go.uber.org/zap"
@@ -30,6 +32,8 @@ import (
 
 	rbacutils "github.com/percona/everest/pkg/rbac/utils"
 )
+
+const defaultKubeAPITimeout = 10 * time.Second
 
 type k8s interface {
 	GetConfigMap(ctx context.Context, key ctrlclient.ObjectKey) (*corev1.ConfigMap, error)
@@ -41,6 +45,18 @@ type Adapter struct {
 	kubeClient     k8s
 	namespacedName types.NamespacedName
 	l              *zap.SugaredLogger
+	timeout        time.Duration
+}
+
+// Option is a functional option for the Adapter.
+type Option func(*Adapter)
+
+// WithTimeout sets the timeout for Kubernetes API calls made by the adapter.
+// If not set, defaultKubeAPITimeout (10s) is used.
+func WithTimeout(d time.Duration) Option {
+	return func(a *Adapter) {
+		a.timeout = d
+	}
 }
 
 // New constructs a new adapter that manages a policy inside a ConfigMap.
@@ -48,12 +64,18 @@ func New(
 	l *zap.SugaredLogger,
 	kubeClient k8s,
 	namespacedName types.NamespacedName,
+	opts ...Option,
 ) *Adapter {
-	return &Adapter{
+	a := &Adapter{
 		kubeClient:     kubeClient,
 		namespacedName: namespacedName,
 		l:              l,
+		timeout:        defaultKubeAPITimeout,
 	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
 }
 
 // ConfigMap returns the configmap used for RBAC.
@@ -63,9 +85,12 @@ func (a *Adapter) ConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
 
 // LoadPolicy loads all policy rules from the storage.
 func (a *Adapter) LoadPolicy(model model.Model) error {
-	cm, err := a.kubeClient.GetConfigMap(context.Background(), a.namespacedName)
+	ctx, cancel := context.WithTimeout(context.Background(), a.timeout)
+	defer cancel()
+
+	cm, err := a.kubeClient.GetConfigMap(ctx, a.namespacedName)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to load RBAC policy configmap %q: %w", a.namespacedName, err)
 	}
 
 	data, ok := cm.Data["policy.csv"]

--- a/pkg/rbac/configmap-adapter/adapter.go
+++ b/pkg/rbac/configmap-adapter/adapter.go
@@ -90,7 +90,7 @@ func (a *Adapter) LoadPolicy(model model.Model) error {
 
 	cm, err := a.kubeClient.GetConfigMap(ctx, a.namespacedName)
 	if err != nil {
-		return fmt.Errorf("failed to load RBAC policy configmap %q: %w", a.namespacedName, err)
+		return fmt.Errorf("failed to load RBAC policy configmap %s: %w", a.namespacedName, err)
 	}
 
 	data, ok := cm.Data["policy.csv"]

--- a/pkg/rbac/configmap-adapter/adapter.go
+++ b/pkg/rbac/configmap-adapter/adapter.go
@@ -48,34 +48,18 @@ type Adapter struct {
 	timeout        time.Duration
 }
 
-// Option is a functional option for the Adapter.
-type Option func(*Adapter)
-
-// WithTimeout sets the timeout for Kubernetes API calls made by the adapter.
-// If not set, defaultKubeAPITimeout (10s) is used.
-func WithTimeout(d time.Duration) Option {
-	return func(a *Adapter) {
-		a.timeout = d
-	}
-}
-
 // New constructs a new adapter that manages a policy inside a ConfigMap.
 func New(
 	l *zap.SugaredLogger,
 	kubeClient k8s,
 	namespacedName types.NamespacedName,
-	opts ...Option,
 ) *Adapter {
-	a := &Adapter{
+	return &Adapter{
 		kubeClient:     kubeClient,
 		namespacedName: namespacedName,
 		l:              l,
 		timeout:        defaultKubeAPITimeout,
 	}
-	for _, opt := range opts {
-		opt(a)
-	}
-	return a
 }
 
 // ConfigMap returns the configmap used for RBAC.

--- a/pkg/rbac/configmap-adapter/adapter_test.go
+++ b/pkg/rbac/configmap-adapter/adapter_test.go
@@ -1,0 +1,172 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configmapadapter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/casbin/casbin/v2/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// testRBACModel is a minimal Casbin RBAC model definition matching the
+// production model in data/rbac/model.conf.
+const testRBACModel = `
+[request_definition]
+r = sub, res, act, obj
+
+[policy_definition]
+p = sub, res, act, obj
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
+
+[matchers]
+m = g(r.sub, p.sub) && globMatch(r.res, p.res) && globMatch(r.act, p.act) && globMatch(r.obj, p.obj)
+`
+
+// mockK8s implements the k8s interface for testing.
+type mockK8s struct {
+	cm    *corev1.ConfigMap
+	err   error
+	delay time.Duration
+}
+
+func (m *mockK8s) GetConfigMap(ctx context.Context, _ ctrlclient.ObjectKey) (*corev1.ConfigMap, error) {
+	if m.delay > 0 {
+		select {
+		case <-time.After(m.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return m.cm, m.err
+}
+
+func TestLoadPolicy(t *testing.T) {
+	t.Parallel()
+
+	validCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm",
+			Namespace: "test-ns",
+		},
+		Data: map[string]string{
+			"policy.csv": "p, role:admin, database-clusters, *, *",
+		},
+	}
+
+	nn := types.NamespacedName{Namespace: "test-ns", Name: "test-cm"}
+	l := zap.NewNop().Sugar()
+
+	testcases := []struct {
+		desc      string
+		mock      *mockK8s
+		timeout   time.Duration
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			desc: "happy path - loads policy within timeout",
+			mock: &mockK8s{
+				cm: validCM,
+			},
+			wantErr: false,
+		},
+		{
+			desc: "timeout - API call exceeds timeout",
+			mock: &mockK8s{
+				cm:    validCM,
+				delay: 500 * time.Millisecond,
+			},
+			timeout:   100 * time.Millisecond,
+			wantErr:   true,
+			errSubstr: "context deadline exceeded",
+		},
+		{
+			desc: "API error - wraps error with configmap context",
+			mock: &mockK8s{
+				err: errors.New("connection refused"),
+			},
+			wantErr:   true,
+			errSubstr: "failed to load RBAC policy configmap",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var opts []Option
+			if tc.timeout > 0 {
+				opts = append(opts, WithTimeout(tc.timeout))
+			}
+			adapter := New(l, tc.mock, nn, opts...)
+
+			m, err := model.NewModelFromString(testRBACModel)
+			require.NoError(t, err)
+
+			done := make(chan error, 1)
+			go func() {
+				done <- adapter.LoadPolicy(m)
+			}()
+
+			select {
+			case err := <-done:
+				if tc.wantErr {
+					assert.Error(t, err)
+					if tc.errSubstr != "" {
+						assert.ErrorContains(t, err, tc.errSubstr)
+					}
+				} else {
+					assert.NoError(t, err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("LoadPolicy did not return within bounded time — possible hang")
+			}
+		})
+	}
+}
+
+func TestDefaultTimeout(t *testing.T) {
+	t.Parallel()
+	l := zap.NewNop().Sugar()
+	nn := types.NamespacedName{Namespace: "ns", Name: "cm"}
+	adapter := New(l, &mockK8s{}, nn)
+	assert.Equal(t, defaultKubeAPITimeout, adapter.timeout)
+}
+
+func TestWithTimeout(t *testing.T) {
+	t.Parallel()
+	l := zap.NewNop().Sugar()
+	nn := types.NamespacedName{Namespace: "ns", Name: "cm"}
+	custom := 500 * time.Millisecond
+	adapter := New(l, &mockK8s{}, nn, WithTimeout(custom))
+	assert.Equal(t, custom, adapter.timeout)
+}

--- a/pkg/rbac/configmap-adapter/adapter_test.go
+++ b/pkg/rbac/configmap-adapter/adapter_test.go
@@ -120,7 +120,6 @@ func TestLoadPolicy(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/rbac/configmap-adapter/adapter_test.go
+++ b/pkg/rbac/configmap-adapter/adapter_test.go
@@ -85,7 +85,7 @@ func TestLoadPolicy(t *testing.T) {
 	nn := types.NamespacedName{Namespace: "test-ns", Name: "test-cm"}
 	l := zap.NewNop().Sugar()
 
-	testcases := []struct {
+	testCases := []struct {
 		desc      string
 		mock      *mockK8s
 		timeout   time.Duration
@@ -119,7 +119,8 @@ func TestLoadPolicy(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
+	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -140,12 +141,13 @@ func TestLoadPolicy(t *testing.T) {
 			select {
 			case err := <-done:
 				if tc.wantErr {
-					assert.Error(t, err)
 					if tc.errSubstr != "" {
-						assert.ErrorContains(t, err, tc.errSubstr)
+						require.ErrorContains(t, err, tc.errSubstr)
+					} else {
+						require.Error(t, err)
 					}
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				}
 			case <-time.After(2 * time.Second):
 				t.Fatal("LoadPolicy did not return within bounded time — possible hang")

--- a/pkg/rbac/configmap-adapter/adapter_test.go
+++ b/pkg/rbac/configmap-adapter/adapter_test.go
@@ -19,6 +19,7 @@ package configmapadapter
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"testing"
 	"time"
 
@@ -30,26 +31,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/percona/everest/data"
 )
-
-// testRBACModel is a minimal Casbin RBAC model definition matching the
-// production model in data/rbac/model.conf.
-const testRBACModel = `
-[request_definition]
-r = sub, res, act, obj
-
-[policy_definition]
-p = sub, res, act, obj
-
-[role_definition]
-g = _, _
-
-[policy_effect]
-e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
-
-[matchers]
-m = g(r.sub, p.sub) && globMatch(r.res, p.res) && globMatch(r.act, p.act) && globMatch(r.obj, p.obj)
-`
 
 // mockK8s implements the k8s interface for testing.
 type mockK8s struct {
@@ -123,51 +107,30 @@ func TestLoadPolicy(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			var opts []Option
+			adapter := New(l, tc.mock, nn)
 			if tc.timeout > 0 {
-				opts = append(opts, WithTimeout(tc.timeout))
+				adapter.timeout = tc.timeout
 			}
-			adapter := New(l, tc.mock, nn, opts...)
 
-			m, err := model.NewModelFromString(testRBACModel)
+			modelData, err := fs.ReadFile(data.RBAC, "rbac/model.conf")
+			require.NoError(t, err)
+			m, err := model.NewModelFromString(string(modelData))
 			require.NoError(t, err)
 
-			done := make(chan error, 1)
-			go func() {
-				done <- adapter.LoadPolicy(m)
-			}()
+			err = adapter.LoadPolicy(m)
 
-			select {
-			case err := <-done:
-				if tc.wantErr {
-					if tc.errSubstr != "" {
-						require.ErrorContains(t, err, tc.errSubstr)
-					} else {
-						require.Error(t, err)
-					}
+			if tc.wantErr {
+				if tc.errSubstr != "" {
+					require.ErrorContains(t, err, tc.errSubstr)
 				} else {
-					require.NoError(t, err)
+					require.Error(t, err)
 				}
-			case <-time.After(2 * time.Second):
-				t.Fatal("LoadPolicy did not return within bounded time — possible hang")
+			} else {
+				require.NoError(t, err)
+				got, err := m.GetPolicy("p", "p")
+				require.NoError(t, err)
+				assert.Equal(t, [][]string{{"role:admin", "database-clusters", "*", "*"}}, got)
 			}
 		})
 	}
-}
-
-func TestDefaultTimeout(t *testing.T) {
-	t.Parallel()
-	l := zap.NewNop().Sugar()
-	nn := types.NamespacedName{Namespace: "ns", Name: "cm"}
-	adapter := New(l, &mockK8s{}, nn)
-	assert.Equal(t, defaultKubeAPITimeout, adapter.timeout)
-}
-
-func TestWithTimeout(t *testing.T) {
-	t.Parallel()
-	l := zap.NewNop().Sugar()
-	nn := types.NamespacedName{Namespace: "ns", Name: "cm"}
-	custom := 500 * time.Millisecond
-	adapter := New(l, &mockK8s{}, nn, WithTimeout(custom))
-	assert.Equal(t, custom, adapter.timeout)
 }


### PR DESCRIPTION
## Summary

Fixes #2799 
The RBAC ConfigMap adapter's `LoadPolicy()` method in `pkg/rbac/configmap-adapter/adapter.go` used `context.Background()` with **no timeout** when calling `kubeClient.GetConfigMap(...)`. If the Kubernetes API server was slow, unreachable, or the network was partitioned, this call could block **indefinitely**, hanging RBAC initialization and preventing the server from starting or responding.

## Root Cause Analysis

In the original code:

```go
func (a *Adapter) LoadPolicy(model model.Model) error {
    cm, err := a.kubeClient.GetConfigMap(context.Background(), a.namespacedName)
    if err != nil {
        return err
    }
}
```

`context.Background()` creates an empty context with **no deadline, no timeout, and no cancellation signal**. Since `LoadPolicy()` is called during server startup and RBAC policy reload, a hang here blocks the entire server.

## Changes

### `pkg/rbac/configmap-adapter/adapter.go`
- Added `defaultKubeAPITimeout = 10 * time.Second` constant
- - Added `timeout` field to `Adapter` struct
- - Added `Option` type and `WithTimeout(d)` functional option
- - Updated `New()` to accept `...Option` (backward-compatible)
- - Fixed `LoadPolicy()` to use `context.WithTimeout` instead of `context.Background()`
- - Improved error wrapping with ConfigMap name for diagnosability
### `pkg/rbac/configmap-adapter/adapter_test.go` (NEW)
Added 5 unit tests with a mock k8s client supporting configurable delay.

## Testing

### Real test output:

```
$ go test -v -count=1 ./pkg/rbac/configmap-adapter/...
=== RUN   TestLoadPolicy
=== PAUSE TestLoadPolicy
=== RUN   TestDefaultTimeout
=== PAUSE TestDefaultTimeout
=== RUN   TestWithTimeout
=== PAUSE TestWithTimeout
=== CONT  TestLoadPolicy
=== RUN   TestLoadPolicy/happy_path_-_loads_policy_within_timeout
=== RUN   TestLoadPolicy/timeout_-_API_call_exceeds_timeout
=== RUN   TestLoadPolicy/API_error_-_wraps_error_with_configmap_context
--- PASS: TestDefaultTimeout (0.00s)
--- PASS: TestWithTimeout (0.00s)
--- PASS: TestLoadPolicy (0.00s)
    --- PASS: TestLoadPolicy/happy_path_-_loads_policy_within_timeout (0.00s)
    --- PASS: TestLoadPolicy/API_error_-_wraps_error_with_configmap_context (0.00s)
    --- PASS: TestLoadPolicy/timeout_-_API_call_exceeds_timeout (0.10s)
PASS
ok      github.com/percona/everest/pkg/rbac/configmap-adapter   6.592s
```

- `go vet ./pkg/rbac/configmap-adapter/...` - no issues found
## Backward Compatibility

No breaking changes. The `New()` constructor accepts variadic `...Option` - existing callers pass no options and work identically. The `persist.Adapter` interface contract is unchanged.