### PR TITLE
fix(docs): align provider filter documentation and SDK examples with providerRef.name (#2804)

### DIFF
--- a/api/extensions/v1alpha1/plugin_types.go
+++ b/api/extensions/v1alpha1/plugin_types.go
@@ -1,0 +1,228 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	common "github.com/openeverest/openeverest/v2/api/common/v1alpha1"
+)
+
+// PluginSpec defines the desired state of Plugin
+type PluginSpec struct {
+	// DisplayName is the human-readable name shown in the UI sidebar.
+	// +required
+	DisplayName string `json:"displayName"`
+
+	// Description is a short human-readable description of what the plugin does.
+	// +optional
+	Description string `json:"description,omitempty"`
+
+	// Version is the SemVer version of the plugin.
+	// +optional
+	Version string `json:"version,omitempty"`
+
+	// Vendor is the name of the plugin author or organisation.
+	// +optional
+	Vendor string `json:"vendor,omitempty"`
+
+	// Icon is a URL to the plugin's icon image.
+	// +optional
+	Icon string `json:"icon,omitempty"`
+
+	// CompatibleHostVersions is a SemVer range expression specifying which
+	// OpenEverest host versions this plugin supports (e.g. ">=2.0.0 <3.0.0").
+	// +optional
+	CompatibleHostVersions string `json:"compatibleHostVersions,omitempty"`
+
+	// Frontend defines the optional frontend contribution of the plugin.
+	// +optional
+	Frontend *PluginFrontend `json:"frontend,omitempty"`
+
+	// Backend defines the optional backend contribution of the plugin.
+	// +optional
+	Backend *PluginBackend `json:"backend,omitempty"`
+
+	// Enabled controls whether the plugin is active. A disabled plugin
+	// is not returned by the list endpoint and its proxy routes are inactive.
+	// +optional
+	// +kubebuilder:default=true
+	Enabled bool `json:"enabled,omitempty"`
+
+	// Permissions declares what OpenEverest API resources this plugin needs access to.
+	// +optional
+	Permissions []PluginPermission `json:"permissions,omitempty"`
+
+	// CLI defines an optional CLI contribution. When set, `everestctl extension run`
+	// can exec a container from the specified image.
+	// +optional
+	CLI *PluginCLI `json:"cli,omitempty"`
+}
+
+// PluginFrontend defines the frontend contribution of a plugin.
+type PluginFrontend struct {
+	// BundlePath is the path on the backend that serves the plugin's
+	// frontend ESM bundle (e.g. "/main.js"). The Everest server exposes
+	// this as /v1/plugins/<name>/<bundlePath> for the UI to import().
+	// +optional
+	// +kubebuilder:default="/main.js"
+	BundlePath string `json:"bundlePath,omitempty"`
+
+	// BundleIntegrity is an optional SRI hash for verifying the bundle.
+	// +optional
+	BundleIntegrity string `json:"bundleIntegrity,omitempty"`
+
+	// ExtensionPoints declares the UI extension points this plugin fills.
+	// This enables the host to show/hide contributions before loading the bundle
+	// and enables RBAC-based filtering.
+	// +optional
+	ExtensionPoints []PluginExtensionPoint `json:"extensionPoints,omitempty"`
+}
+
+// PluginExtensionPoint declares a single UI extension point contribution.
+type PluginExtensionPoint struct {
+	// Type is the kind of extension point (e.g. "route", "sidebarItem",
+	// "clusterDetailTab", "clusterAction", "clusterCard",
+	// "globalDashboardWidget", "settingsPanel", "instanceCreateFormSection",
+	// "instanceEditFormSection", "themeOverride").
+	// +required
+	Type string `json:"type"`
+
+	// Label is the human-readable label displayed for this contribution.
+	// +optional
+	Label string `json:"label,omitempty"`
+
+	// Path is an optional sub-path (used by "route" and tab-type extension points).
+	// +optional
+	Path string `json:"path,omitempty"`
+
+	// Icon is an optional icon identifier.
+	// +optional
+	Icon string `json:"icon,omitempty"`
+
+	// Providers is an optional list of database engine provider names this extension point
+	// applies to. Values match spec.providerRef.name on the Instance CR
+	// (e.g., "percona-server-mongodb", "percona-xtradb-cluster", "postgresql").
+	// When omitted or empty, the extension point is shown for all engine types.
+	// +optional
+	Providers []string `json:"providers,omitempty"`
+}
+
+// PluginBackend defines the backend contribution of a plugin.
+// Exactly one of ServiceRef or ExternalURL must be set.
+type PluginBackend struct {
+	// ServiceRef references an in-cluster Kubernetes Service.
+	// The Everest server resolves it to http://<name>.<namespace>.svc:<port>
+	// and reverse-proxies /v1/plugins/<pluginName>/* to that address.
+	// +optional
+	ServiceRef *PluginBackendServiceRef `json:"serviceRef,omitempty"`
+
+	// ExternalURL is the HTTPS base URL of an externally hosted backend
+	// (e.g. "https://sql-explorer.example.com"). Mutually exclusive with ServiceRef.
+	// +optional
+	ExternalURL string `json:"externalUrl,omitempty"`
+
+	// CredentialsSecretRef references a Secret in the same namespace as
+	// the InstalledExtension entry whose "token" key is forwarded as the
+	// Authorization header to the external backend. Only meaningful when
+	// ExternalURL is set.
+	// +optional
+	CredentialsSecretRef *common.SecretRef `json:"credentialsSecretRef,omitempty"`
+}
+
+// PluginBackendServiceRef points to an in-cluster Kubernetes Service.
+type PluginBackendServiceRef struct {
+	// Namespace of the Service.
+	// +required
+	Namespace string `json:"namespace"`
+	// Name of the Service.
+	// +required
+	Name string `json:"name"`
+	// Port is the service port number.
+	// +required
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	Port int32 `json:"port"`
+}
+
+// PluginPermission declares a single permission the plugin requires.
+type PluginPermission struct {
+	// Verb is the action (e.g. "read", "create", "update", "delete").
+	// +required
+	Verb string `json:"verb"`
+
+	// Resource is the OpenEverest API resource (e.g. "database-clusters").
+	// +required
+	Resource string `json:"resource"`
+}
+
+// PluginCLI describes the CLI contribution of a plugin.
+type PluginCLI struct {
+	// Image is the OCI image reference for the CLI container.
+	// +required
+	Image string `json:"image"`
+
+	// Subcommand is the name used under `everestctl extension run <subcommand>`.
+	// Defaults to the plugin name if not set.
+	// +optional
+	Subcommand string `json:"subcommand,omitempty"`
+
+	// Description is a short human-readable description for the CLI help text.
+	// +optional
+	Description string `json:"description,omitempty"`
+}
+
+// PluginStatus defines the observed state of Plugin.
+type PluginStatus struct {
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster,shortName=plg;plugin
+// +kubebuilder:printcolumn:name="Display Name",type="string",JSONPath=".spec.displayName"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.version"
+// +kubebuilder:printcolumn:name="Backend URL",type="string",JSONPath=".spec.backend.url"
+// +kubebuilder:printcolumn:name="Enabled",type="boolean",JSONPath=".spec.enabled"
+
+// Plugin is the Schema for the plugins API. It registers an external plugin
+// with the Everest platform, enabling its UI bundle to be loaded dynamically
+// and its backend to be reverse-proxied through the Everest server.
+type Plugin struct {
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitzero"`
+
+	// +required
+	Spec PluginSpec `json:"spec"`
+	// +optional
+	Status PluginStatus `json:"status,omitzero"`
+}
+
+// +kubebuilder:object:root=true
+
+// PluginList contains a list of Plugin
+type PluginList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitzero"`
+	Items           []Plugin `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&Plugin{}, &PluginList{})
+}

--- a/ui/packages/plugin-sdk/src/types.ts
+++ b/ui/packages/plugin-sdk/src/types.ts
@@ -1,0 +1,286 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { ComponentType } from "react";
+
+// ---------------------------------------------------------------------------
+// Extension types — what a plugin can contribute to the host
+// ---------------------------------------------------------------------------
+
+/** A page route rendered inside the host shell at /plugins/<pluginName>/* */
+export interface RouteExtension {
+  type: "route";
+  /** Human-readable label (used in breadcrumbs, page title, etc.) */
+  label: string;
+  /** The React component rendered for this route. Receives PluginRouteProps. */
+  component: ComponentType<PluginRouteProps>;
+}
+
+/** A sidebar navigation item added to the host's drawer. */
+export interface SidebarExtension {
+  type: "sidebarItem";
+  /** Text shown in the sidebar */
+  label: string;
+  /** Optional icon URL (absolute or relative path to a PNG/SVG image). */
+  icon?: string;
+}
+
+/** An extra tab on the database instance detail page. */
+export interface ClusterDetailTabExtension {
+  type: "clusterDetailTab";
+  /** Tab label text. */
+  label: string;
+  /** URL-safe slug used as the tab route segment (e.g. "query" → /databases/:ns/:name/query). */
+  path: string;
+  /** The component rendered when the tab is active. Receives ClusterDetailTabProps. */
+  component: ComponentType<ClusterDetailTabProps>;
+  /**
+   * Optional list of provider names this extension point applies to.
+   * Matches spec.providerRef.name on the Instance CR.
+   *
+   * @example providers: ["postgresql"]                     // PostgreSQL only
+   * @example providers: ["percona-server-mongodb"]         // Percona Server for MongoDB only
+   */
+  providers?: string[];
+}
+
+/** A context-menu action in the databases table row. */
+export interface ClusterActionExtension {
+  type: "clusterAction";
+  /** Action label text shown in the menu. */
+  label: string;
+  /** The component rendered when the action is triggered. Receives ClusterActionProps. */
+  component: ComponentType<ClusterActionProps>;
+  /**
+   * Optional engine type filter. When set, the action is only shown for clusters
+   * whose `spec.engine.type` matches one of the listed values.
+   * Omit to show for all engine types.
+   */
+  providers?: string[];
+}
+
+/** A widget card on the cluster overview page. */
+export interface ClusterCardExtension {
+  type: "clusterCard";
+  /** Card title. */
+  label: string;
+  /** The component rendered inside the card. Receives ClusterCardProps. */
+  component: ComponentType<ClusterCardProps>;
+  /**
+   * Optional engine type filter. When set, the card is only shown for clusters
+   * whose `spec.engine.type` matches one of the listed values.
+   * Omit to show for all engine types.
+   */
+  providers?: string[];
+}
+
+/** A card on the home / dashboard page. */
+export interface GlobalDashboardWidgetExtension {
+  type: "globalDashboardWidget";
+  /** Widget card title. */
+  label: string;
+  /** The component rendered inside the widget. Receives GlobalDashboardWidgetProps. */
+  component: ComponentType<GlobalDashboardWidgetProps>;
+}
+
+/** An extra tab inside the Settings page. */
+export interface SettingsPanelExtension {
+  type: "settingsPanel";
+  /** Tab label text. */
+  label: string;
+  /** URL-safe slug used as the settings tab route segment. */
+  path: string;
+  /** The component rendered when the tab is active. Receives SettingsPanelProps. */
+  component: ComponentType<SettingsPanelProps>;
+}
+
+/**
+ * A collapsible section in the create-instance wizard.
+ * Lets infrastructure plugins collect configuration during instance creation.
+ */
+export interface InstanceCreateFormSectionExtension {
+  type: "instanceCreateFormSection";
+  /** Section heading label. */
+  label: string;
+  /** The component rendered inside the collapsible section. */
+  component: ComponentType<InstanceCreateFormSectionProps>;
+  /**
+   * Optional engine type filter. When set, the section is only shown for
+   * instances whose provider matches one of the listed values.
+   * Omit to show for all engine types.
+   */
+  providers?: string[];
+}
+
+/**
+ * A collapsible section in the edit-instance / instance detail page.
+ * Lets infrastructure plugins expose configuration editing for existing instances.
+ */
+export interface InstanceEditFormSectionExtension {
+  type: "instanceEditFormSection";
+  /** Section heading label. */
+  label: string;
+  /** The component rendered inside the collapsible section. */
+  component: ComponentType<InstanceEditFormSectionProps>;
+  /**
+   * Optional engine type filter. When set, the section is only shown for
+   * instances whose provider matches one of the listed values.
+   * Omit to show for all engine types.
+   */
+  providers?: string[];
+}
+
+/** Union of all supported extension types. */
+export type Extension =
+  | RouteExtension
+  | SidebarExtension
+  | ClusterDetailTabExtension
+  | ClusterActionExtension
+  | ClusterCardExtension
+  | GlobalDashboardWidgetExtension
+  | SettingsPanelExtension
+  | InstanceCreateFormSectionExtension
+  | InstanceEditFormSectionExtension;
+
+// ---------------------------------------------------------------------------
+// Props passed to plugin-provided components
+// ---------------------------------------------------------------------------
+
+/** Props injected by the host into a plugin's route component. */
+export interface PluginRouteProps {
+  /** The registered name of the plugin (matches the Plugin CR name). */
+  pluginName: string;
+  /** The wildcard sub-path after /plugins/<pluginName>/. */
+  subPath?: string;
+}
+
+/** Props injected into a clusterDetailTab component. */
+export interface ClusterDetailTabProps {
+  /** The Instance resource. */
+  cluster: unknown;
+  /** Kubernetes namespace the instance lives in. */
+  namespace: string;
+  /** Instance name. */
+  instanceName: string;
+}
+
+/** Props injected into a clusterAction component. */
+export interface ClusterActionProps {
+  /** The Instance resource. */
+  cluster: unknown;
+  /** Kubernetes namespace. */
+  namespace: string;
+  /** Callback to close the action modal/popover. */
+  onClose: () => void;
+}
+
+/** Props injected into a clusterCard component. */
+export interface ClusterCardProps {
+  /** The Instance resource. */
+  cluster: unknown;
+  /** Kubernetes namespace. */
+  namespace: string;
+}
+
+/** Props injected into a globalDashboardWidget component. */
+export interface GlobalDashboardWidgetProps {
+  /** Namespaces the current user has access to. */
+  namespaces: string[];
+}
+
+/** Props injected into a settingsPanel component. */
+export interface SettingsPanelProps {
+  /** Currently logged-in user identifier. */
+  currentUser: string;
+}
+
+/** Props injected into an instanceCreateFormSection component. */
+export interface InstanceCreateFormSectionProps {
+  /** Current form state (read-only snapshot). */
+  formValues: Record<string, unknown>;
+  /** Callback to update the plugin's config section. */
+  onChange: (config: Record<string, unknown>) => void;
+  /** Target namespace for the instance. */
+  namespace: string;
+}
+
+/** Props injected into an instanceEditFormSection component. */
+export interface InstanceEditFormSectionProps {
+  /** The existing instance resource. */
+  instance: unknown;
+  /** Current form state (read-only snapshot). */
+  formValues: Record<string, unknown>;
+  /** Callback to update the plugin's config section. */
+  onChange: (config: Record<string, unknown>) => void;
+  /** Namespace the instance lives in. */
+  namespace: string;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin API — the object passed to register()
+// ---------------------------------------------------------------------------
+
+/** The API object provided to a plugin's register() function by the host. */
+export interface PluginApi {
+  /**
+   * The host's React instance.
+   *
+   * @deprecated Since v0.2. Plugins should use a native `import React from 'react'`
+   * (or named imports like `import { useEffect } from 'react'`). The host exposes
+   * `react`, `react-dom`, `@mui/material`, `@emotion/react`, `@emotion/styled`,
+   * `react-router-dom`, and `@openeverest/plugin-sdk` as singletons via a browser
+   * import map, so bare-specifier imports in a plugin bundle resolve to the same
+   * module instance the host itself uses. This keeps React context (theme,
+   * router, auth, etc.) shared across the boundary.
+   *
+   * This field remains for backwards compatibility with plugins built against
+   * v0.1 of the SDK and will be removed in v1.0.
+   */
+  React: typeof import("react");
+
+  /** Register a UI extension with the host. */
+  registerExtension(extension: Extension): void;
+
+  /**
+   * Make an authenticated API call through the host's proxy.
+   * Equivalent to fetch(`/v1/plugins/${pluginName}${path}`, init).
+   * The host automatically attaches the auth token.
+   */
+  fetch(path: string, init?: RequestInit): Promise<Response>;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entry point contract
+// ---------------------------------------------------------------------------
+
+/**
+ * The function signature that a plugin module must export.
+ * The host calls this after dynamically importing the plugin's bundle.
+ *
+ * @example
+ * ```ts
+ * import type { PluginRegisterFn, PluginApi } from '@openeverest/plugin-sdk';
+ *
+ * const register: PluginRegisterFn = (api) => {
+ *   const React = api.React;
+ *   const MyPage = () => React.createElement('h1', null, 'Hello!');
+ *
+ *   api.registerExtension({ type: 'sidebarItem', label: 'My Plugin' });
+ *   api.registerExtension({ type: 'route', label: 'My Plugin', component: MyPage });
+ * };
+ *
+ * export default register;
+ * ```
+ */
+export type PluginRegisterFn = (api: PluginApi) => void;


### PR DESCRIPTION
### Summary
Fixes #2804

Aligns doc comments in `plugin_types.go` and JSDoc examples in `@openeverest/plugin-sdk` (`types.ts`) with actual runtime comparison logic. 

### Context
Currently, `pages/db-cluster-details/db-cluster-details.tsx` and `plugin-form-sections.tsx` filter extension points against `engineType` derived from `instance?.spec?.providerRef?.name` (e.g., `percona-server-mongodb`). However, the existing doc comments and JSDoc examples previously directed authors to use v1 `spec.engine.type` shortnames (e.g., `psmdb`), causing declared extension points to silently fail filtering.

### Changes
- Updated `PluginExtensionPoint.Providers` doc comment in `api/extensions/v1alpha1/plugin_types.go` to reference `spec.providerRef.name`.
- Updated `@example` JSDoc annotations in `ui/packages/plugin-sdk/src/types.ts` to use valid Provider CR names (e.g., `percona-server-mongodb`).