### PR TITLE
fix(cli): bind `--helm.reuse-values` flag to `ReuseValues` in `upgradeCmd`

### DIFF
--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -61,9 +61,9 @@ func init() {
 	upgradeCmd.Flags().StringVar(&upgradeCfg.RepoURL, helm.FlagRepository, helm.DefaultHelmRepoURL, "Helm chart repository to download the Everest charts from")
 	upgradeCmd.Flags().StringSliceVar(&upgradeCfg.Values.Values, helm.FlagHelmSet, []string{}, "Set helm values on the command line (can specify multiple values with commas: key1=val1,key2=val2)")
 	upgradeCmd.Flags().StringSliceVarP(&upgradeCfg.Values.ValueFiles, helm.FlagHelmValues, "f", []string{}, "Specify values in a YAML file or a URL (can specify multiple)")
-	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmReuseValues, false, "Reuse the last release's values and merge in any overrides from the command line via --helm.set and -f")
+	upgradeCmd.Flags().BoolVar(&upgradeCfg.ReuseValues, helm.FlagHelmReuseValues, false, "Reuse the last release's values and merge in any overrides from the command line via --helm.set and -f")
 	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetValues, helm.FlagHelmResetValues, false, "Reset the values to the ones built into the chart")
-	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmResetThenReuseValues, false, "Reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f.")
+	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmResetThenReuseValues, false, "Reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --helm.set and -f.")
 }
 
 func upgradePreRun(_ *cobra.Command, _ []string) {

--- a/commands/upgrade_test.go
+++ b/commands/upgrade_test.go
@@ -1,0 +1,75 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/percona/everest/pkg/cli/helm"
+)
+
+//nolint:paralleltest
+func TestUpgradeCmdHelmFlagsBinding(t *testing.T) {
+	tests := []struct {
+		name               string
+		args               []string
+		expectedReuse      bool
+		expectedReset      bool
+		expectedResetReuse bool
+	}{
+		{
+			name:               "helm.reuse-values flag sets ReuseValues",
+			args:               []string{"--" + helm.FlagHelmReuseValues},
+			expectedReuse:      true,
+			expectedReset:      false,
+			expectedResetReuse: false,
+		},
+		{
+			name:               "helm.reset-values flag sets ResetValues",
+			args:               []string{"--" + helm.FlagHelmResetValues},
+			expectedReuse:      false,
+			expectedReset:      true,
+			expectedResetReuse: false,
+		},
+		{
+			name:               "helm.reset-then-reuse-values flag sets ResetThenReuseValues",
+			args:               []string{"--" + helm.FlagHelmResetThenReuseValues},
+			expectedReuse:      false,
+			expectedReset:      false,
+			expectedResetReuse: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset configuration state before parsing flags
+			upgradeCfg.ReuseValues = false
+			upgradeCfg.ResetValues = false
+			upgradeCfg.ResetThenReuseValues = false
+
+			err := upgradeCmd.ParseFlags(tc.args)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedReuse, upgradeCfg.ReuseValues)
+			assert.Equal(t, tc.expectedReset, upgradeCfg.ResetValues)
+			assert.Equal(t, tc.expectedResetReuse, upgradeCfg.ResetThenReuseValues)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a flag-binding bug in `everestctl upgrade` where `--helm.reuse-values` (`helm.FlagHelmReuseValues`) was bound to `&upgradeCfg.ResetThenReuseValues` instead of `&upgradeCfg.ReuseValues`. As a result, `upgradeCfg.ReuseValues` was never populated from CLI input, and passing `--helm.reuse-values` silently triggered a `ResetThenReuseValues` Helm upgrade strategy instead of `ReuseValues`.

Resolves #2825 

---

## Root Cause

`commands/upgrade.go`, lines 64–66:

```go
upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmReuseValues, false, "Reuse the last release's values and merge in any overrides from the command line via --helm.set and -f")
upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetValues, helm.FlagHelmResetValues, false, "Reset the values to the ones built into the chart")
upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmResetThenReuseValues, false, "Reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --helm.set and -f.")
```

`helm.FlagHelmReuseValues` and `helm.FlagHelmResetThenReuseValues` both bound to the same struct field (`ResetThenReuseValues`), making `ReuseValues` unreachable from the CLI and collapsing two distinct Helm upgrade strategies into one.

---

## Changes

### 1. Fixed flag binding — `commands/upgrade.go`

```diff
-upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmReuseValues, false, "Reuse the last release's values and merge in any overrides from the command line via --helm.set and -f")
+upgradeCmd.Flags().BoolVar(&upgradeCfg.ReuseValues, helm.FlagHelmReuseValues, false, "Reuse the last release's values and merge in any overrides from the command line via --helm.set and -f")
 upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetValues, helm.FlagHelmResetValues, false, "Reset the values to the ones built into the chart")
-upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmResetThenReuseValues, false, "Reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f.")
+upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmResetThenReuseValues, false, "Reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --helm.set and -f.")
```

### 2. Added unit tests — `commands/upgrade_test.go`

Covers flag parsing for `upgradeCmd`, asserting each `--helm.*` flag binds to its own distinct struct field with no aliasing:

```go
func TestUpgradeCmdHelmFlagsBinding(t *testing.T) {
	tests := []struct {
		name               string
		args               []string
		expectedReuse      bool
		expectedReset      bool
		expectedResetReuse bool
	}{
		{
			name:               "helm.reuse-values flag sets ReuseValues",
			args:               []string{"--" + helm.FlagHelmReuseValues},
			expectedReuse:      true,
			expectedReset:      false,
			expectedResetReuse: false,
		},
		{
			name:               "helm.reset-values flag sets ResetValues",
			args:               []string{"--" + helm.FlagHelmResetValues},
			expectedReuse:      false,
			expectedReset:      true,
			expectedResetReuse: false,
		},
		{
			name:               "helm.reset-then-reuse-values flag sets ResetThenReuseValues",
			args:               []string{"--" + helm.FlagHelmResetThenReuseValues},
			expectedReuse:      false,
			expectedReset:      false,
			expectedResetReuse: true,
		},
	}
	// ...
}
```

---

## Test Results

**Targeted test:**
```text
$ go test -v ./commands/...
=== RUN   TestUpgradeCmdHelmFlagsBinding
=== RUN   TestUpgradeCmdHelmFlagsBinding/helm.reuse-values_flag_sets_ReuseValues
=== RUN   TestUpgradeCmdHelmFlagsBinding/helm.reset-values_flag_sets_ResetValues
=== RUN   TestUpgradeCmdHelmFlagsBinding/helm.reset-then-reuse-values_flag_sets_ResetThenReuseValues
--- PASS: TestUpgradeCmdHelmFlagsBinding (0.00s)
PASS
ok  	github.com/percona/everest/commands	0.022s
```

