### PR TITLE
fix: create a fresh Everest API backoff per operation

### DIFF
--- a/internal/server/handlers/k8s/database_cluster.go
+++ b/internal/server/handlers/k8s/database_cluster.go
@@ -48,6 +48,9 @@ const (
 	// PG default upload interval
 	// https://github.com/percona/percona-postgresql-operator/blob/82673d4d80aa329b5bd985889121280caad064fb/internal/pgbackrest/postgres.go#L58
 	pgDefaultUploadInterval = 60
+
+	everestAPIBackoffInterval   = time.Second
+	everestAPIBackoffMaxRetries = 10
 )
 
 func (h *k8sHandler) CreateDatabaseCluster(ctx context.Context, db *everestv1alpha1.DatabaseCluster) (*everestv1alpha1.DatabaseCluster, error) {
@@ -260,8 +263,15 @@ func (h *k8sHandler) GetDatabaseClusterPitr(ctx context.Context, namespace, name
 	return response, nil
 }
 
-//nolint:gochecknoglobals
-var everestAPIConstantBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 10) //nolint:mnd
+func newEverestAPIBackoff(ctx context.Context) backoff.BackOff { //nolint:ireturn // The backoff package exposes policies through this interface.
+	return backoff.WithContext(
+		backoff.WithMaxRetries(
+			backoff.NewConstantBackOff(everestAPIBackoffInterval),
+			everestAPIBackoffMaxRetries,
+		),
+		ctx,
+	)
+}
 
 func (h *k8sHandler) ensureBackupStorageProtection(ctx context.Context, backup *everestv1alpha1.DatabaseClusterBackup) error {
 	// We wrap this logic in a retry loop to reduce the chances of resource conflicts.
@@ -276,7 +286,7 @@ func (h *k8sHandler) ensureBackupStorageProtection(ctx context.Context, backup *
 			_, err = h.kubeConnector.UpdateDatabaseClusterBackup(ctx, backup)
 			return err
 		},
-		backoff.WithContext(everestAPIConstantBackoff, ctx),
+		newEverestAPIBackoff(ctx),
 	)
 }
 
@@ -292,7 +302,7 @@ func (h *k8sHandler) ensureBackupForegroundDeletion(ctx context.Context, backup 
 			_, err = h.kubeConnector.UpdateDatabaseClusterBackup(ctx, backup)
 			return err
 		},
-		backoff.WithContext(everestAPIConstantBackoff, ctx),
+		newEverestAPIBackoff(ctx),
 	)
 }
 

--- a/internal/server/handlers/k8s/database_cluster_test.go
+++ b/internal/server/handlers/k8s/database_cluster_test.go
@@ -16,9 +16,11 @@ package k8s
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +31,41 @@ import (
 	"github.com/percona/everest/pkg/common"
 	"github.com/percona/everest/pkg/kubernetes"
 )
+
+func TestNewEverestAPIBackoffHasIndependentRetryBudget(t *testing.T) {
+	t.Parallel()
+
+	first := newEverestAPIBackoff(t.Context())
+	second := newEverestAPIBackoff(t.Context())
+
+	for range everestAPIBackoffMaxRetries {
+		require.Equal(t, everestAPIBackoffInterval, first.NextBackOff())
+	}
+	require.Equal(t, backoff.Stop, first.NextBackOff())
+	require.Equal(t, everestAPIBackoffInterval, second.NextBackOff())
+}
+
+func TestNewEverestAPIBackoffSupportsConcurrentOperations(t *testing.T) {
+	t.Parallel()
+
+	policies := []backoff.BackOff{
+		newEverestAPIBackoff(t.Context()),
+		newEverestAPIBackoff(t.Context()),
+	}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, policy := range policies {
+		wg.Go(func() {
+			<-start
+			for range 1_000 {
+				policy.Reset()
+				policy.NextBackOff()
+			}
+		})
+	}
+	close(start)
+	wg.Wait()
+}
 
 func TestLatestRestorableDate(t *testing.T) {
 	t.Parallel()

--- a/internal/server/handlers/k8s/database_engine.go
+++ b/internal/server/handlers/k8s/database_engine.go
@@ -123,7 +123,7 @@ func (h *k8sHandler) setLockDBEnginesForUpgrade(
 				}
 			}
 			return nil
-		}, backoff.WithContext(everestAPIConstantBackoff, ctx),
+		}, newEverestAPIBackoff(ctx),
 	)
 }
 
@@ -382,7 +382,7 @@ func (h *k8sHandler) startOperatorUpgradeWithRetry(ctx context.Context, namespac
 		func() error {
 			return h.startOperatorUpgrade(ctx, namespace)
 		},
-		backoff.WithContext(everestAPIConstantBackoff, ctx),
+		newEverestAPIBackoff(ctx),
 	)
 }
 
@@ -416,7 +416,7 @@ func (h *k8sHandler) startOperatorUpgrade(ctx context.Context, namespace string)
 			func() error {
 				_, err := h.kubeConnector.ApproveInstallPlan(ctx, types.NamespacedName{Namespace: namespace, Name: plan})
 				return err
-			}, backoff.WithContext(everestAPIConstantBackoff, ctx),
+			}, newEverestAPIBackoff(ctx),
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Why

`everestAPIConstantBackoff` is a package-level `WithMaxRetries` wrapper, and that wrapper stores a mutable retry counter. Reusing it across concurrent request handlers makes unrelated operations consume the same budget and races on the counter.

Fixes #2760.

## What changed

- Replace the stateful package-level backoff with `newEverestAPIBackoff(ctx)`.
- Construct a fresh constant backoff, retry wrapper, and context wrapper for each of the five retry operations.
- Keep the one-second interval and ten-retry limit as named constants.
- Add regression coverage for independent retry budgets and concurrent policy use under the race detector.

## Verification

Observed locally:

- `go test -race ./internal/server/handlers/k8s -run '^TestNewEverestAPIBackoff'` — passed
- The focused race tests repeated 25 times — passed
- `go test -race ./internal/server/handlers/k8s` — passed
- `make copyright-check` — passed
- `gofumpt`, `goimports`, and `go-consistent` checks — passed
- `git diff --check` — passed

Local `go vet` and `golangci-lint` attempts stopped before analysis when the machine ran out of disk space; this was an infrastructure interruption rather than a reported code finding. The issue-relevant package, race, formatting, consistency, and copyright checks above completed successfully, and CI will run the repository-wide gates.

AI disclosure: this contribution was substantially AI-assisted. I reviewed the implementation, its concurrency behavior, the final diff, and the observed verification results before submitting.
