### PR TITLE
fix: truncate PITR restorable date to whole seconds

### DIFF
--- a/internal/server/handlers/k8s/database_cluster.go
+++ b/internal/server/handlers/k8s/database_cluster.go
@@ -386,7 +386,7 @@ func latestRestorableDate(now, latestBackupTime time.Time, heuristicsInterval in
 		return nil
 	}
 	// delete nanoseconds since they're not accepted by restoration
-	now = now.Truncate(time.Duration(now.Nanosecond()) * time.Nanosecond)
+	now = now.Truncate(time.Second)
 	// heuristic: latest restorable date is now minus uploadInterval
 	date := now.Add(-time.Duration(heuristicsInterval) * time.Second).UTC()
 	// not able to restore if after the latest backup passed less than uploadInterval time,

--- a/internal/server/handlers/k8s/database_cluster_test.go
+++ b/internal/server/handlers/k8s/database_cluster_test.go
@@ -42,6 +42,8 @@ func TestLatestRestorableDate(t *testing.T) {
 
 	now := time.Date(2024, 3, 12, 12, 0, 0, 0, time.UTC)
 	restorable := now.Add(-600 * time.Second)
+	nowWithNanos := time.Date(2024, 3, 12, 12, 0, 0, 999999999, time.UTC)
+	restorableFromNanos := time.Date(2024, 3, 12, 11, 50, 0, 0, time.UTC)
 	cases := []tCase{
 		{
 			name:             "backup 5 min ago, upload interval 10 min",
@@ -56,6 +58,13 @@ func TestLatestRestorableDate(t *testing.T) {
 			latestBackupTime: now.Add(-900 * time.Second),
 			now:              now,
 			expected:         &restorable,
+		},
+		{
+			name:             "now has nanosecond precision — must be stripped",
+			uploadInterval:   600,
+			latestBackupTime: time.Date(2024, 3, 12, 11, 44, 59, 0, time.UTC),
+			now:              nowWithNanos,
+			expected:         &restorableFromNanos,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Fixes #2793 by correcting nanosecond stripping in `latestRestorableDate` (`internal/server/handlers/k8s/database_cluster.go`).
- Replaces `now.Truncate(time.Duration(now.Nanosecond()) * time.Nanosecond)` with `now.Truncate(time.Second)`, which matches the intended behavior in the comment (“delete nanoseconds since they're not accepted by restoration”).
- The previous call truncated to a multiple of the *current* nanosecond component, so sub-second precision could remain in the returned `latestDate` and cause PITR restores to fail downstream.
- Adds a regression case to `TestLatestRestorableDate` where `now` has non-zero nanoseconds, so the bug cannot be masked by zero-nanosecond fixtures.

## Changes
- `latestRestorableDate`: use `time.Second` truncation.
- `TestLatestRestorableDate`: cover nanosecond precision on `now`.

## Test plan
- [x] `go test ./internal/server/handlers/k8s/ -run TestLatestRestorableDate -count=1`
- [ ] Confirm existing cases still pass (backup too recent → `nil`; backup old enough → truncated restorable date).
- [ ] Confirm the new nanosecond case expects whole-second UTC output with no sub-second component.

## Notes
- Related duplicate report: #2801 (closed as duplicate of #2793).
- DCO: commit is signed off with `Signed-off-by`.