### PR TITLE
docs(plugins): align providers filter docs with providerRef.name

### DIFF
--- a/api/extensions/v1alpha1/plugin_types.go
+++ b/api/extensions/v1alpha1/plugin_types.go
@@ -112,10 +112,12 @@ type PluginExtensionPoint struct {
 	// +optional
 	Icon string `json:"icon,omitempty"`
 
-	// Providers is an optional list of database engine types this extension point
-	// applies to. Values match spec.engine.type on the DatabaseCluster CR:
-	// "postgresql", "psmdb", "pxc".
-	// When omitted or empty, the extension point is shown for all engine types.
+	// Providers is an optional list of Provider names this extension point
+	// applies to. Values match spec.providerRef.name on the Instance CR, e.g.
+	// "provider-percona-postgresql", "percona-server-mongodb",
+	// "percona-xtradb-cluster". Provider names are not prefix-consistent
+	// across providers; check the target provider's own definition.
+	// When omitted or empty, the extension point is shown for all providers.
 	// +optional
 	Providers []string `json:"providers,omitempty"`
 }

--- a/api/openapi/crds.gen.yaml
+++ b/api/openapi/crds.gen.yaml
@@ -4717,10 +4717,12 @@ components:
                         type: string
                       providers:
                         description: |-
-                          Providers is an optional list of database engine types this extension point
-                          applies to. Values match spec.engine.type on the DatabaseCluster CR:
-                          "postgresql", "psmdb", "pxc".
-                          When omitted or empty, the extension point is shown for all engine types.
+                          Providers is an optional list of Provider names this extension point
+                          applies to. Values match spec.providerRef.name on the Instance CR, e.g.
+                          "provider-percona-postgresql", "percona-server-mongodb",
+                          "percona-xtradb-cluster". Provider names are not prefix-consistent
+                          across providers; check the target provider's own definition.
+                          When omitted or empty, the extension point is shown for all providers.
                         items:
                           type: string
                         type: array

--- a/client/crds.gen.go
+++ b/client/crds.gen.go
@@ -3137,10 +3137,12 @@ type Plugin struct {
 				// Path Path is an optional sub-path (used by "route" and tab-type extension points).
 				Path *string `json:"path,omitempty"`
 
-				// Providers Providers is an optional list of database engine types this extension point
-				// applies to. Values match spec.engine.type on the DatabaseCluster CR:
-				// "postgresql", "psmdb", "pxc".
-				// When omitted or empty, the extension point is shown for all engine types.
+				// Providers Providers is an optional list of Provider names this extension point
+				// applies to. Values match spec.providerRef.name on the Instance CR, e.g.
+				// "provider-percona-postgresql", "percona-server-mongodb",
+				// "percona-xtradb-cluster". Provider names are not prefix-consistent
+				// across providers; check the target provider's own definition.
+				// When omitted or empty, the extension point is shown for all providers.
 				Providers *[]string `json:"providers,omitempty"`
 
 				// Type Type is the kind of extension point (e.g. "route", "sidebarItem",

--- a/config/crd/bases/extensions.openeverest.io_plugins.yaml
+++ b/config/crd/bases/extensions.openeverest.io_plugins.yaml
@@ -184,10 +184,12 @@ spec:
                           type: string
                         providers:
                           description: |-
-                            Providers is an optional list of database engine types this extension point
-                            applies to. Values match spec.engine.type on the DatabaseCluster CR:
-                            "postgresql", "psmdb", "pxc".
-                            When omitted or empty, the extension point is shown for all engine types.
+                            Providers is an optional list of Provider names this extension point
+                            applies to. Values match spec.providerRef.name on the Instance CR, e.g.
+                            "provider-percona-postgresql", "percona-server-mongodb",
+                            "percona-xtradb-cluster". Provider names are not prefix-consistent
+                            across providers; check the target provider's own definition.
+                            When omitted or empty, the extension point is shown for all providers.
                           items:
                             type: string
                           type: array

--- a/internal/server/api/crds.gen.go
+++ b/internal/server/api/crds.gen.go
@@ -3137,10 +3137,12 @@ type Plugin struct {
 				// Path Path is an optional sub-path (used by "route" and tab-type extension points).
 				Path *string `json:"path,omitempty"`
 
-				// Providers Providers is an optional list of database engine types this extension point
-				// applies to. Values match spec.engine.type on the DatabaseCluster CR:
-				// "postgresql", "psmdb", "pxc".
-				// When omitted or empty, the extension point is shown for all engine types.
+				// Providers Providers is an optional list of Provider names this extension point
+				// applies to. Values match spec.providerRef.name on the Instance CR, e.g.
+				// "provider-percona-postgresql", "percona-server-mongodb",
+				// "percona-xtradb-cluster". Provider names are not prefix-consistent
+				// across providers; check the target provider's own definition.
+				// When omitted or empty, the extension point is shown for all providers.
 				Providers *[]string `json:"providers,omitempty"`
 
 				// Type Type is the kind of extension point (e.g. "route", "sidebarItem",

--- a/ui/api/crds.gen.types.ts
+++ b/ui/api/crds.gen.types.ts
@@ -3060,10 +3060,12 @@ export interface components {
                         /** @description Path is an optional sub-path (used by "route" and tab-type extension points). */
                         path?: string;
                         /**
-                         * @description Providers is an optional list of database engine types this extension point
-                         *     applies to. Values match spec.engine.type on the DatabaseCluster CR:
-                         *     "postgresql", "psmdb", "pxc".
-                         *     When omitted or empty, the extension point is shown for all engine types.
+                         * @description Providers is an optional list of Provider names this extension point
+                         *     applies to. Values match spec.providerRef.name on the Instance CR, e.g.
+                         *     "provider-percona-postgresql", "percona-server-mongodb",
+                         *     "percona-xtradb-cluster". Provider names are not prefix-consistent
+                         *     across providers; check the target provider's own definition.
+                         *     When omitted or empty, the extension point is shown for all providers.
                          */
                         providers?: string[];
                         /**

--- a/ui/apps/everest/src/pages/database-form/plugin-form-sections.tsx
+++ b/ui/apps/everest/src/pages/database-form/plugin-form-sections.tsx
@@ -31,7 +31,7 @@ interface PluginFormSectionsProps {
   formValues: Record<string, unknown>;
   /** Target namespace. */
   namespace: string;
-  /** Database engine type (provider), e.g. "psmdb", "pxc", "postgresql". */
+  /** Provider name, from `spec.providerRef.name`, e.g. "percona-server-mongodb". */
   engineType?: string;
   /** Existing instance (only for edit mode). */
   instance?: unknown;

--- a/ui/packages/plugin-sdk/src/types.ts
+++ b/ui/packages/plugin-sdk/src/types.ts
@@ -46,13 +46,15 @@ export interface ClusterDetailTabExtension {
   /** The component rendered when the tab is active. Receives ClusterDetailTabProps. */
   component: ComponentType<ClusterDetailTabProps>;
   /**
-   * Optional list of database engine types this tab applies to.
-   * Values match `spec.engine.type` on the DatabaseCluster CR:
-   * `"postgresql"`, `"psmdb"`, `"pxc"`.
-   * When omitted (or empty) the tab is shown for all engine types.
+   * Optional list of Provider names this tab applies to.
+   * Values match `spec.providerRef.name` on the Instance CR, e.g.
+   * `"provider-percona-postgresql"`, `"percona-server-mongodb"`,
+   * `"percona-xtradb-cluster"`. Provider names are not prefix-consistent
+   * across providers; check the target provider's own definition.
+   * When omitted (or empty) the tab is shown for all providers.
    *
-   * @example providers: ["postgresql"]        // PostgreSQL only
-   * @example providers: ["psmdb", "pxc"]      // MongoDB and MySQL only
+   * @example providers: ["provider-percona-postgresql"]  // PostgreSQL only
+   * @example providers: ["percona-server-mongodb", "percona-xtradb-cluster"]  // MongoDB and MySQL only
    */
   providers?: string[];
 }
@@ -65,9 +67,9 @@ export interface ClusterActionExtension {
   /** The component rendered when the action is triggered. Receives ClusterActionProps. */
   component: ComponentType<ClusterActionProps>;
   /**
-   * Optional engine type filter. When set, the action is only shown for clusters
-   * whose `spec.engine.type` matches one of the listed values.
-   * Omit to show for all engine types.
+   * Optional Provider filter. When set, the action is only shown for clusters
+   * whose `spec.providerRef.name` matches one of the listed values.
+   * Omit to show for all providers.
    */
   providers?: string[];
 }
@@ -80,9 +82,9 @@ export interface ClusterCardExtension {
   /** The component rendered inside the card. Receives ClusterCardProps. */
   component: ComponentType<ClusterCardProps>;
   /**
-   * Optional engine type filter. When set, the card is only shown for clusters
-   * whose `spec.engine.type` matches one of the listed values.
-   * Omit to show for all engine types.
+   * Optional Provider filter. When set, the card is only shown for clusters
+   * whose `spec.providerRef.name` matches one of the listed values.
+   * Omit to show for all providers.
    */
   providers?: string[];
 }
@@ -118,9 +120,9 @@ export interface InstanceCreateFormSectionExtension {
   /** The component rendered inside the collapsible section. */
   component: ComponentType<InstanceCreateFormSectionProps>;
   /**
-   * Optional engine type filter. When set, the section is only shown for
-   * instances whose provider matches one of the listed values.
-   * Omit to show for all engine types.
+   * Optional Provider filter. When set, the section is only shown for
+   * instances whose `spec.providerRef.name` matches one of the listed values.
+   * Omit to show for all providers.
    */
   providers?: string[];
 }
@@ -136,9 +138,9 @@ export interface InstanceEditFormSectionExtension {
   /** The component rendered inside the collapsible section. */
   component: ComponentType<InstanceEditFormSectionProps>;
   /**
-   * Optional engine type filter. When set, the section is only shown for
-   * instances whose provider matches one of the listed values.
-   * Omit to show for all engine types.
+   * Optional Provider filter. When set, the section is only shown for
+   * instances whose `spec.providerRef.name` matches one of the listed values.
+   * Omit to show for all providers.
    */
   providers?: string[];
 }


### PR DESCRIPTION
The `providers` filter on plugin extension points (`db-cluster-details.tsx:82-86`,
`plugin-form-sections.tsx:77-81`) compares against `instance.spec.providerRef.name`, a
Provider CR name like `percona-server-mongodb`. `PluginExtensionPoint.Providers` in
`plugin_types.go` and the `@example` lines in `plugin-sdk/src/types.ts` instead told authors
to write v1 `spec.engine.type` shortnames: `psmdb`, `pxc`, `postgresql`.
`["psmdb"].includes("percona-server-mongodb")` is false, so an extension point written from
the documented example is filtered out on every instance, with nothing logged.

This updates the doc comment on `PluginExtensionPoint.Providers` and the docs to match what
the filter actually compares against:

- The five extension-point types in `types.ts` that expose `providers`
  (`clusterDetailTab`, `clusterAction`, `clusterCard`, `instanceCreateFormSection`,
  `instanceEditFormSection`) now describe `providerRef.name`, with corrected `@example` values.
- The `engineType` prop doc in `plugin-form-sections.tsx` gets the same correction, since it
  is the file that performs the comparison and carried the identical wrong values.
- The CRD, OpenAPI schema, and generated Go/TypeScript types follow from `make gen`.

The comparison logic itself does not change.

Also worth flagging: provider names are not consistent with each other.
`provider-percona-postgresql` keeps its `provider-` prefix in its own `definition/provider.yaml`
and example manifest; `percona-server-mongodb` and `percona-xtradb-cluster` don't. One example
would be wrong for one of the three, so the comment points at the provider's own definition
instead of implying a pattern that isn't there. Happy to drop that and open a separate issue if
you'd rather the names were made uniform.

This leaves out two adjacent behaviour changes the issue also raised, to keep it reviewable: a
console warning when a declared `providers` value matches no known provider, and
`PluginTabHost.tsx`, which resolves `:tabs` on `ext.type`/`ext.path` only with no `providers`
check, so a direct URL still renders a tab the tab bar correctly hides. Happy to open either as
a follow-up.

`make gen` run twice with no further diff; `go vet`, `go build ./...`, `golangci-lint` at the
merge base, and the everest app's `eslint`/`tsc --noEmit` all pass.

#2823 is open against `main` for the same fix; the plugin framework isn't on `main`, so it
can't land there.

Fixes #2804
