### PR TITLE
fix(cli): display correct operator constraint string in upgrade error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.43.3
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.33
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.3
+	github.com/blang/semver/v4 v4.0.0
 	github.com/casbin/casbin/v2 v2.135.0
 	github.com/casbin/govaluate v1.10.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
@@ -112,7 +113,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/bombsimon/wsl/v4 v4.7.0 // indirect

--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -473,7 +473,7 @@ func (u *Upgrade) checkOperatorRequirements(ctx context.Context, supVer *common.
 			if !c.constraints.Check(v) {
 				return fmt.Errorf(
 					"%s version %q does not meet minimum requirements of %q",
-					c.operatorName, v, supVer.PXCOperator.String(),
+					c.operatorName, v, c.constraints.String(),
 				)
 			}
 			u.l.Debugf("Finished requirements check for operator %s", c.operatorName)

--- a/pkg/cli/upgrade/upgrade_test.go
+++ b/pkg/cli/upgrade/upgrade_test.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,12 +25,18 @@ import (
 	"testing"
 
 	version "github.com/Percona-Lab/percona-version-service/versionpb"
+	"github.com/blang/semver/v4"
 	goversion "github.com/hashicorp/go-version"
+	olmversion "github.com/operator-framework/api/pkg/lib/version"
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/percona/everest/pkg/common"
 	"github.com/percona/everest/pkg/kubernetes"
 	versionservice "github.com/percona/everest/pkg/version_service"
 )
@@ -279,6 +286,131 @@ func TestUpgrade_ValidateVersionToUpgrade(t *testing.T) {
 			} else if err != nil {
 				t.Errorf("error = %v", err)
 			}
+		})
+	}
+}
+
+func TestUpgrade_checkOperatorRequirements(t *testing.T) {
+	t.Parallel()
+
+	pxcConstraint, err := goversion.NewConstraint(">= 1.10.0")
+	require.NoError(t, err)
+	pgConstraint, err := goversion.NewConstraint(">= 2.4.0")
+	require.NoError(t, err)
+	psmdbConstraint, err := goversion.NewConstraint(">= 1.15.0")
+	require.NoError(t, err)
+
+	supVer := &common.SupportedVersion{
+		PXCOperator:   pxcConstraint,
+		PGOperator:    pgConstraint,
+		PSMBDOperator: psmdbConstraint,
+	}
+
+	tests := []struct {
+		name          string
+		sub           *olmv1alpha1.Subscription
+		csv           *olmv1alpha1.ClusterServiceVersion
+		expectedError string
+	}{
+		{
+			name: "PostgreSQL operator fails requirement",
+			sub: &olmv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.PostgreSQLOperatorName,
+					Namespace: "everest",
+				},
+				Status: olmv1alpha1.SubscriptionStatus{
+					InstalledCSV: "pg-operator.v2.2.0",
+				},
+			},
+			csv: &olmv1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pg-operator.v2.2.0",
+					Namespace: "everest",
+				},
+				Spec: olmv1alpha1.ClusterServiceVersionSpec{
+					Version: olmversion.OperatorVersion{
+						Version: semver.MustParse("2.2.0"),
+					},
+				},
+			},
+			expectedError: `percona-postgresql-operator version "2.2.0" does not meet minimum requirements of ">= 2.4.0"`,
+		},
+		{
+			name: "MongoDB operator fails requirement",
+			sub: &olmv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.MongoDBOperatorName,
+					Namespace: "everest",
+				},
+				Status: olmv1alpha1.SubscriptionStatus{
+					InstalledCSV: "psmdb-operator.v1.12.0",
+				},
+			},
+			csv: &olmv1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "psmdb-operator.v1.12.0",
+					Namespace: "everest",
+				},
+				Spec: olmv1alpha1.ClusterServiceVersionSpec{
+					Version: olmversion.OperatorVersion{
+						Version: semver.MustParse("1.12.0"),
+					},
+				},
+			},
+			expectedError: `percona-server-mongodb-operator version "1.12.0" does not meet minimum requirements of ">= 1.15.0"`,
+		},
+		{
+			name: "PXC operator fails requirement",
+			sub: &olmv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.MySQLOperatorName,
+					Namespace: "everest",
+				},
+				Status: olmv1alpha1.SubscriptionStatus{
+					InstalledCSV: "pxc-operator.v1.9.0",
+				},
+			},
+			csv: &olmv1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pxc-operator.v1.9.0",
+					Namespace: "everest",
+				},
+				Spec: olmv1alpha1.ClusterServiceVersionSpec{
+					Version: olmversion.OperatorVersion{
+						Version: semver.MustParse("1.9.0"),
+					},
+				},
+			},
+			expectedError: `percona-xtradb-cluster-operator version "1.9.0" does not meet minimum requirements of ">= 1.10.0"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "everest",
+					Labels: map[string]string{common.KubernetesManagedByLabel: common.Everest},
+				},
+			}
+
+			client := fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.CreateScheme()).
+				WithObjects(ns, tt.sub, tt.csv).
+				Build()
+
+			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(client)
+			u := &Upgrade{
+				l:             zap.NewNop().Sugar(),
+				kubeConnector: k,
+			}
+
+			err := u.checkOperatorRequirements(context.Background(), supVer)
+			require.Error(t, err)
+			assert.Equal(t, tt.expectedError, err.Error())
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the misleading error message reported in #2842, where an upgrade
failure for the PostgreSQL or MongoDB operator incorrectly displayed the
MySQL/PXC operator's version constraint instead of its own.

Fixes #2842

## Changes

### `pkg/cli/upgrade/upgrade.go`

`checkOperatorRequirements` was hardcoding `supVer.PXCOperator.String()` in
the error message regardless of which operator actually failed the check.
Replaced it with `c.constraints.String()`, which reflects the constraint
for the operator being validated in that iteration:

```diff
 if !c.constraints.Check(v) {
     return fmt.Errorf(
         "%s version %q does not meet minimum requirements of %q",
-        c.operatorName, v, supVer.PXCOperator.String(),
+        c.operatorName, v, c.constraints.String(),
     )
 }
```

### `pkg/cli/upgrade/upgrade_test.go`

Added `TestUpgrade_checkOperatorRequirements` with subtests covering
version check failures for `percona-postgresql-operator` and
`percona-server-mongodb-operator`, asserting the error string contains
each operator's own constraint rather than the PXC one.

## Verification

- `go test ./pkg/cli/upgrade/...` — PASS
- `go test ./pkg/...` — PASS (full suite green)

## Notes for reviewers

This is a message-formatting fix only — no behavioral change to the
version check logic itself, so existing upgrade flows are unaffected.