### PR TITLE
fix(session): avoid nil pointer panic when the JWT private key PEM is invalid

### DIFF
--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -171,8 +171,24 @@ func getPrivateKey() (*rsa.PrivateKey, error) {
 	if err != nil {
 		return nil, errors.Join(err, errors.New("failed to read JWT private key"))
 	}
+	return parsePrivateKeyPEM(pemString)
+}
+
+// parsePrivateKeyPEM decodes a PEM-encoded PKCS1 RSA private key.
+//
+// pem.Decode returns a nil block (without an error) when the input does not
+// contain a valid PEM block, so that case must be checked explicitly before
+// the block is dereferenced.
+func parsePrivateKeyPEM(pemString []byte) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(pemString)
-	return x509.ParsePKCS1PrivateKey(block.Bytes)
+	if block == nil {
+		return nil, errors.New("failed to decode JWT private key: no PEM data found")
+	}
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, errors.Join(err, errors.New("failed to parse JWT private key"))
+	}
+	return key, nil
 }
 
 // KeyFunc retruns a function for getting the public RSA keys used

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -171,7 +171,11 @@ func getPrivateKey() (*rsa.PrivateKey, error) {
 	if err != nil {
 		return nil, errors.Join(err, errors.New("failed to read JWT private key"))
 	}
-	return parsePrivateKeyPEM(pemString)
+	key, err := parsePrivateKeyPEM(pemString)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", common.EverestJWTPrivateKeyFile, err)
+	}
+	return key, nil
 }
 
 // parsePrivateKeyPEM decodes a PEM-encoded PKCS1 RSA private key.

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -16,6 +16,10 @@ package session
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"testing"
 	"time"
@@ -32,6 +36,67 @@ import (
 	"github.com/percona/everest/pkg/common"
 	"github.com/percona/everest/pkg/kubernetes"
 )
+
+// testRSAKeyBits is deliberately small since these keys are only used to
+// exercise the PEM decoding path in tests, not for any real cryptographic use.
+const testRSAKeyBits = 2048
+
+func TestParsePrivateKeyPEM(t *testing.T) {
+	t.Parallel()
+
+	validKey, err := rsa.GenerateKey(rand.Reader, testRSAKeyBits)
+	require.NoError(t, err)
+	validPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(validKey),
+	})
+
+	tcases := []struct {
+		name        string
+		in          []byte
+		expectError bool
+	}{
+		{
+			name:        "valid PKCS1 PEM key",
+			in:          validPEM,
+			expectError: false,
+		},
+		{
+			name:        "empty input",
+			in:          []byte(""),
+			expectError: true,
+		},
+		{
+			name:        "not PEM-encoded data",
+			in:          []byte("this is not a PEM encoded private key"),
+			expectError: true,
+		},
+		{
+			name: "PEM block that is not a valid PKCS1 key",
+			in: pem.EncodeToMemory(&pem.Block{
+				Type:  "RSA PRIVATE KEY",
+				Bytes: []byte("not actually a key"),
+			}),
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			key, err := parsePrivateKeyPEM(tc.in)
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Nil(t, key)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, key)
+			assert.Equal(t, validKey.N, key.N)
+		})
+	}
+}
 
 func TestExtractUsername(t *testing.T) {
 	t.Parallel()

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -93,7 +93,7 @@ func TestParsePrivateKeyPEM(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.NotNil(t, key)
-			assert.Equal(t, validKey.N, key.N)
+			assert.True(t, key.Equal(validKey))
 		})
 	}
 }


### PR DESCRIPTION
## What

`getPrivateKey()` in `pkg/session/manager.go` decoded the everest JWT signing key with `pem.Decode()` and dereferenced the result without checking for `nil`. `pem.Decode` returns a `nil` block (with a `nil` error) when it can't find a valid PEM block, so an empty, truncated, or otherwise invalid key file crashed the whole server with a nil pointer panic instead of a clean startup error.

This PR:
- extracts the decode+parse step into a small `parsePrivateKeyPEM()` helper
- checks for a `nil` block after `pem.Decode` and returns a descriptive error instead of panicking
- wraps the `x509.ParsePKCS1PrivateKey` error instead of returning it bare, so a malformed-but-present PEM block also gets a clear message
- adds `TestParsePrivateKeyPEM` covering a valid key, empty input, non-PEM input, and a PEM block that isn't a valid PKCS1 key

## Why

`getPrivateKey()` runs inside `session.New()`, i.e. on every everest-server startup. Any deployment issue that leaves `/etc/jwt/id_rsa` empty or corrupted (bad secret, manual edit, partial write) currently takes the whole process down with an unhelpful panic instead of a clear "invalid JWT private key" error.

## Testing

- `go build ./...`
- `go test ./pkg/session/...`: new test panics on the old code (nil pointer dereference at the old `block.Bytes` line) and passes cleanly after the fix; full package suite passes

Fixes #2850
