### PR TITLE
fix(test): repair the release-2.0 test build after cherry-picks

### DIFF
--- a/pkg/kubernetes/resources_test.go
+++ b/pkg/kubernetes/resources_test.go
@@ -137,7 +137,7 @@ func TestGetConsumedCPUAndMemoryCountsRunningInitContainers(t *testing.T) {
 		WithScheme(CreateScheme()).
 		WithObjects(pod).
 		Build()
-	k := NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
+	k := NewEmpty(zap.NewNop().Sugar(), "test-ns").WithKubernetesClient(mockClient)
 
 	cpuMillis, memoryBytes, err := k.GetConsumedCPUAndMemory(context.Background(), "everest")
 	require.NoError(t, err)

--- a/pkg/rbac/configmap-adapter/adapter_test.go
+++ b/pkg/rbac/configmap-adapter/adapter_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/percona/everest/data"
+	"github.com/openeverest/openeverest/v2/data"
 )
 
 // mockK8s implements the k8s interface for testing.


### PR DESCRIPTION
`release-2.0` does not build its tests. Two commits cherry-picked from `main` today applied cleanly but do not compile here, because the branches have diverged in exactly the places they touch.

| | `main` | `release-2.0` |
|---|---|---|
| module | `github.com/percona/everest` | `github.com/openeverest/openeverest/v2` |
| `NewEmpty` | `(l *zap.SugaredLogger)` | `(l *zap.SugaredLogger, namespace string)` |

- `pkg/kubernetes/resources_test.go:140` calls `NewEmpty` with one argument, from #2719. Correct on `main`; the namespace parameter arrived on the v2 line with #2283.
- `pkg/rbac/configmap-adapter/adapter_test.go:35` imports `github.com/percona/everest/data`, from #2822. Correct on `main`; here the same `data.RBAC` embed lives at `github.com/openeverest/openeverest/v2/data`, which `pkg/rbac/rbac.go` already imports.

Neither original PR is at fault — both targeted `main` and are green there. `git cherry-pick` reported no conflict because the surrounding text matched, and neither landed through a PR into `release-2.0`, so nothing built them against this branch.

The `"test-ns"` argument is inert: `GetConsumedCPUAndMemory` takes its namespace as an explicit parameter, so the struct field is never read on that path. It matches `accounts_test.go` in the same package.

`go vet ./...` is clean again and `go test ./pkg/kubernetes/... ./pkg/rbac/...` passes.

Every open PR targeting `release-2.0` is red on `Test` until this lands — #2769, #2847, #2817 and #2848 among them.