### PR TITLE
fix(session): fix nil pointer dereference on invalid JWT key

### DIFF
--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -171,8 +171,19 @@ func getPrivateKey() (*rsa.PrivateKey, error) {
 	if err != nil {
 		return nil, errors.Join(err, errors.New("failed to read JWT private key"))
 	}
+	return parsePrivateKeyPEM(pemString)
+}
+
+func parsePrivateKeyPEM(pemString []byte) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(pemString)
-	return x509.ParsePKCS1PrivateKey(block.Bytes)
+	if block == nil {
+		return nil, errors.New("failed to parse JWT private key: no valid PEM block found")
+	}
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, errors.Join(err, errors.New("failed to parse PKCS1 private key"))
+	}
+	return key, nil
 }
 
 // KeyFunc retruns a function for getting the public RSA keys used

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -268,3 +268,29 @@ func userSecret(file string) *corev1.Secret {
 		},
 	}
 }
+
+func TestParsePrivateKeyPEM(t *testing.T) {
+	t.Parallel()
+	t.Run("invalid non-PEM input", func(t *testing.T) {
+		t.Parallel()
+		key, err := parsePrivateKeyPEM([]byte("this is not a PEM encoded private key"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no valid PEM block found")
+		assert.Nil(t, key)
+	})
+
+	t.Run("valid PEM block but not a private key", func(t *testing.T) {
+		t.Parallel()
+		// A valid ECDSA private key. It will pass pem.Decode,
+		// but fail x509.ParsePKCS1PrivateKey.
+		fakePEM := `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIMd5RMrNFpJxgzplGEMjW9RZsSayx3pSIU3DCDJN+/fHoAoGCCqGSM49
+AwEHoUQDQgAEEjcF2+v4SMQLMAtwJYH6Hfk7hHi9Q3DRcCQuum/OgLYGAFBIgLQM
+E5Jhl+78Fpuymz9OK0ZpYYfeDH6wAPfC6g==
+-----END EC PRIVATE KEY-----`
+		key, err := parsePrivateKeyPEM([]byte(fakePEM))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse PKCS1 private key")
+		assert.Nil(t, key)
+	})
+}


### PR DESCRIPTION
Fixes #2850

### Description
This PR addresses a critical nil pointer dereference panic that occurs when `everest-server` attempts to read an invalid, empty, or corrupted JWT private key file (e.g. `/etc/jwt/id_rsa`).

Previously, `pem.Decode` would return a `nil` block if no valid PEM structure was found. The code unconditionally passed this `nil` block to `x509.ParsePKCS1PrivateKey(block.Bytes)`, causing a panic that crashed the entire server during startup.

### Solution Implemented
* Extracted the PEM decoding logic into a testable `parsePrivateKeyPEM` helper function.
* Added a strict `nil` check after `pem.Decode` to return a clear, descriptive error (`"no valid PEM block found"`) rather than panicking.
* Wrapped the subsequent `x509.ParsePKCS1PrivateKey` error so malformed keys also yield a helpful message.
* Added robust regression tests in `manager_test.go` to explicitly cover invalid non-PEM inputs and malformed PEM blocks.

/assign Harkirat1309
