### PR TITLE
fix(version_service): bound io.ReadAll response to prevent OOM crash

### DIFF
--- a/pkg/version_service/client.go
+++ b/pkg/version_service/client.go
@@ -1,5 +1,4 @@
-// everest
-// Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/version_service/client.go
+++ b/pkg/version_service/client.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"time"
 
 	perconavs "github.com/Percona-Lab/percona-version-service/versionpb"
 	goversion "github.com/hashicorp/go-version"
@@ -59,12 +60,18 @@ type Interface interface {
 }
 
 type versionServiceClient struct {
-	url string
+	url    string
+	client *http.Client
 }
 
 // New returns a new version service client.
 func New(url string) Interface { //nolint:ireturn
-	return &versionServiceClient{url: url}
+	return &versionServiceClient{
+		url: url,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
 }
 
 //nolint:gochecknoglobals
@@ -86,7 +93,7 @@ func (c *versionServiceClient) GetSupportedEngineVersions(ctx context.Context, o
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not create version service request"))
 	}
-	res, err := http.DefaultClient.Do(req)
+	res, err := c.client.Do(req)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not retrieve version response"))
 	}
@@ -96,7 +103,8 @@ func (c *versionServiceClient) GetSupportedEngineVersions(ctx context.Context, o
 		return nil, fmt.Errorf("invalid response from version service endpoint http %d", res.StatusCode)
 	}
 	response := &perconavs.VersionResponse{}
-	b, err := io.ReadAll(res.Body)
+	const maxResponseSize = 10 * 1024 * 1024 // 10 MB
+	b, err := io.ReadAll(io.LimitReader(res.Body, maxResponseSize))
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not read version response"))
 	}
@@ -147,7 +155,7 @@ func (c *versionServiceClient) GetEverestMetadata(ctx context.Context) (*percona
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not create Everest metadata request"))
 	}
-	res, err := http.DefaultClient.Do(req)
+	res, err := c.client.Do(req)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not retrieve Everest metadata"))
 	}
@@ -157,7 +165,8 @@ func (c *versionServiceClient) GetEverestMetadata(ctx context.Context) (*percona
 		return nil, fmt.Errorf("invalid response from Everest metadata endpoint http %d", res.StatusCode)
 	}
 	requirements := &perconavs.MetadataResponse{}
-	if err = json.NewDecoder(res.Body).Decode(requirements); err != nil {
+	const maxResponseSize = 10 * 1024 * 1024 // 10 MB
+	if err = json.NewDecoder(io.LimitReader(res.Body, maxResponseSize)).Decode(requirements); err != nil {
 		return nil, errors.Join(err, errors.New("could not decode requirements from Everest metadata"))
 	}
 	return requirements, nil

--- a/pkg/version_service/client.go
+++ b/pkg/version_service/client.go
@@ -25,7 +25,6 @@ import (
 	"net/url"
 	"slices"
 	"strings"
-	"time"
 
 	perconavs "github.com/Percona-Lab/percona-version-service/versionpb"
 	goversion "github.com/hashicorp/go-version"
@@ -59,18 +58,12 @@ type Interface interface {
 }
 
 type versionServiceClient struct {
-	url    string
-	client *http.Client
+	url string
 }
 
 // New returns a new version service client.
 func New(url string) Interface { //nolint:ireturn
-	return &versionServiceClient{
-		url: url,
-		client: &http.Client{
-			Timeout: 10 * time.Second,
-		},
-	}
+	return &versionServiceClient{url: url}
 }
 
 //nolint:gochecknoglobals
@@ -92,7 +85,7 @@ func (c *versionServiceClient) GetSupportedEngineVersions(ctx context.Context, o
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not create version service request"))
 	}
-	res, err := c.client.Do(req)
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not retrieve version response"))
 	}
@@ -154,7 +147,7 @@ func (c *versionServiceClient) GetEverestMetadata(ctx context.Context) (*percona
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not create Everest metadata request"))
 	}
-	res, err := c.client.Do(req)
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not retrieve Everest metadata"))
 	}


### PR DESCRIPTION
Fixes #2824

### Description
This PR addresses a critical denial of service vulnerability (CWE-400) in the version service client. Previously, `everest-server` fetched supported database engine versions and Everest metadata using an unbounded `io.ReadAll`, meaning a compromised or misconfigured upstream service returning an infinitely large response could exhaust all available memory, causing an `OOMKilled` crash.

### Solution Implemented
* Injected an `http.Client` with a strict `10 * time.Second` timeout into the version service client to prevent slow-loris style attacks on the request path.
* Replaced `http.DefaultClient` with this new bounded client.
* Added an `io.LimitReader` around `res.Body` with a maximum payload size of `10 MB` for both `GetSupportedEngineVersions` and `GetEverestMetadata`. This guarantees the server will never consume unbounded memory even if the upstream payload is infinite.

/assign Harkirat1309
