### PR TITLE
fix(cli): backport three everestctl flag/message fixes from main

### DIFF
--- a/commands/install.go
+++ b/commands/install.go
@@ -135,7 +135,7 @@ func checkDBNamespaceParameters(cmd *cobra.Command) error {
 	}
 
 	// If user doesn't pass any --operator.* flags - need to ask explicitly.
-	askOperators := !cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed && !cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed && !cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed && !cmd.Flags().Lookup(cli.FlagOperatorMySQL).Changed && !installCfg.NamespaceAddConfig.SkipWizard
+	askOperators := namespaces.ShouldAskOperators(cmd, installCfg.NamespaceAddConfig.SkipWizard)
 
 	if askOperators {
 		// need to ask user to provide operators to be installed in interactive mode.

--- a/commands/namespaces/add.go
+++ b/commands/namespaces/add.go
@@ -95,7 +95,7 @@ func namespacesAddPreRun(cmd *cobra.Command, args []string) {
 	}
 
 	// If user doesn't pass any --operator.* flags - need to ask explicitly.
-	askOperators := !cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed && !cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed && !cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed && !cmd.Flags().Lookup(cli.FlagOperatorMySQL).Changed && !namespacesAddCfg.SkipWizard
+	askOperators := namespaces.ShouldAskOperators(cmd, namespacesAddCfg.SkipWizard)
 
 	if askOperators {
 		// need to ask user to provide operators to be installed in interactive mode.

--- a/commands/namespaces/update.go
+++ b/commands/namespaces/update.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	namespacesUpdateCmd = &cobra.Command{
-		Use:   "update <namespaces> [flags] ",
+		Use:   "update <namespaces> [flags]",
 		Args:  cobra.ExactArgs(1),
 		Long:  "Add database operator to existing namespace managed by Everest",
 		Short: "Add database operator to existing namespace managed by Everest",
@@ -89,7 +89,7 @@ func namespacesUpdatePreRun(cmd *cobra.Command, args []string) {
 	}
 
 	// If user doesn't pass any --operator.* flags - need to ask explicitly.
-	askOperators := !cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed && !cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed && !cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed && !cmd.Flags().Lookup(cli.FlagOperatorMySQL).Changed
+	askOperators := namespaces.ShouldAskOperators(cmd, namespacesUpdateCfg.SkipWizard)
 
 	if askOperators {
 		// need to ask user to provide operators to be installed in interactive mode.

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -61,9 +61,9 @@ func init() {
 	upgradeCmd.Flags().StringVar(&upgradeCfg.RepoURL, helm.FlagRepository, helm.DefaultHelmRepoURL, "Helm chart repository to download the Everest charts from")
 	upgradeCmd.Flags().StringSliceVar(&upgradeCfg.Values.Values, helm.FlagHelmSet, []string{}, "Set helm values on the command line (can specify multiple values with commas: key1=val1,key2=val2)")
 	upgradeCmd.Flags().StringSliceVarP(&upgradeCfg.Values.ValueFiles, helm.FlagHelmValues, "f", []string{}, "Specify values in a YAML file or a URL (can specify multiple)")
-	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmReuseValues, false, "Reuse the last release's values and merge in any overrides from the command line via --helm.set and -f")
+	upgradeCmd.Flags().BoolVar(&upgradeCfg.ReuseValues, helm.FlagHelmReuseValues, false, "Reuse the last release's values and merge in any overrides from the command line via --helm.set and -f")
 	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetValues, helm.FlagHelmResetValues, false, "Reset the values to the ones built into the chart")
-	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmResetThenReuseValues, false, "Reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f.")
+	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmResetThenReuseValues, false, "Reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --helm.set and -f.")
 }
 
 func upgradePreRun(_ *cobra.Command, _ []string) {

--- a/commands/upgrade_test.go
+++ b/commands/upgrade_test.go
@@ -1,0 +1,75 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli/helm"
+)
+
+//nolint:paralleltest
+func TestUpgradeCmdHelmFlagsBinding(t *testing.T) {
+	tests := []struct {
+		name               string
+		args               []string
+		expectedReuse      bool
+		expectedReset      bool
+		expectedResetReuse bool
+	}{
+		{
+			name:               "helm.reuse-values flag sets ReuseValues",
+			args:               []string{"--" + helm.FlagHelmReuseValues},
+			expectedReuse:      true,
+			expectedReset:      false,
+			expectedResetReuse: false,
+		},
+		{
+			name:               "helm.reset-values flag sets ResetValues",
+			args:               []string{"--" + helm.FlagHelmResetValues},
+			expectedReuse:      false,
+			expectedReset:      true,
+			expectedResetReuse: false,
+		},
+		{
+			name:               "helm.reset-then-reuse-values flag sets ResetThenReuseValues",
+			args:               []string{"--" + helm.FlagHelmResetThenReuseValues},
+			expectedReuse:      false,
+			expectedReset:      false,
+			expectedResetReuse: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset configuration state before parsing flags
+			upgradeCfg.ReuseValues = false
+			upgradeCfg.ResetValues = false
+			upgradeCfg.ResetThenReuseValues = false
+
+			err := upgradeCmd.ParseFlags(tc.args)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedReuse, upgradeCfg.ReuseValues)
+			assert.Equal(t, tc.expectedReset, upgradeCfg.ResetValues)
+			assert.Equal(t, tc.expectedResetReuse, upgradeCfg.ResetThenReuseValues)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlekSi/pointer v1.2.0
 	github.com/Percona-Lab/percona-version-service v0.0.0-20240311164804-ffbc02387a1b
 	github.com/VictoriaMetrics/operator/api v0.66.1
+	github.com/blang/semver/v4 v4.0.0
 	github.com/casbin/casbin/v2 v2.135.0
 	github.com/casbin/govaluate v1.10.0
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -109,7 +110,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/bombsimon/wsl/v4 v4.7.0 // indirect

--- a/pkg/cli/namespaces/add_test.go
+++ b/pkg/cli/namespaces/add_test.go
@@ -18,7 +18,11 @@ import (
 	"testing"
 
 	operatorUtils "github.com/percona/everest-operator/utils"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openeverest/openeverest/v2/pkg/cli"
 )
 
 func TestParseNamespaceNames(t *testing.T) {
@@ -181,6 +185,54 @@ func TestValidateNamespaces(t *testing.T) {
 			err := validateNamespaceNames(tc.input, "test-ns")
 			assert.Equal(t, tc.error, err)
 			// assert.ElementsMatch(t, tc.output, output)
+		})
+	}
+}
+
+func TestShouldAskOperators(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       []string
+		skipWizard bool
+		expected   bool
+	}{
+		{
+			name:       "no operator flags passed, skipWizard false",
+			args:       []string{},
+			skipWizard: false,
+			expected:   true,
+		},
+		{
+			name:       "operator flag passed, skipWizard false",
+			args:       []string{"--" + cli.FlagOperatorMongoDB + "=true"},
+			skipWizard: false,
+			expected:   false,
+		},
+		{
+			name:       "no operator flags passed, skipWizard true",
+			args:       []string{},
+			skipWizard: true,
+			expected:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := &cobra.Command{}
+			cmd.Flags().Bool(cli.FlagOperatorMongoDB, true, "")
+			cmd.Flags().Bool(cli.FlagOperatorPostgresql, true, "")
+			cmd.Flags().Bool(cli.FlagOperatorXtraDBCluster, true, "")
+			cmd.Flags().Bool(cli.FlagOperatorMySQL, true, "")
+
+			err := cmd.ParseFlags(tc.args)
+			require.NoError(t, err)
+
+			res := ShouldAskOperators(cmd, tc.skipWizard)
+			assert.Equal(t, tc.expected, res)
 		})
 	}
 }

--- a/pkg/cli/namespaces/utils.go
+++ b/pkg/cli/namespaces/utils.go
@@ -24,13 +24,26 @@ import (
 
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorUtils "github.com/percona/everest-operator/utils"
+	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/openeverest/openeverest/v2/pkg/cli"
 	"github.com/openeverest/openeverest/v2/pkg/common"
 	"github.com/openeverest/openeverest/v2/pkg/kubernetes"
 )
+
+// ShouldAskOperators reports whether the user should be prompted to choose
+// database operators: true only if none of the --operator.* flags were
+// explicitly set and the wizard isn't skipped.
+func ShouldAskOperators(cmd *cobra.Command, skipWizard bool) bool {
+	return !cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed &&
+		!cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed &&
+		!cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed &&
+		!cmd.Flags().Lookup(cli.FlagOperatorMySQL).Changed &&
+		!skipWizard
+}
 
 // ParseNamespaceNames parses a comma-separated namespaces string.
 // It returns a list of namespaces.

--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -486,7 +486,7 @@ func (u *Upgrade) checkOperatorRequirements(ctx context.Context, supVer *common.
 			if !c.constraints.Check(v) {
 				return fmt.Errorf(
 					"%s version %q does not meet minimum requirements of %q",
-					c.operatorName, v, supVer.PXCOperator.String(),
+					c.operatorName, v, c.constraints.String(),
 				)
 			}
 			u.l.Debugf("Finished requirements check for operator %s", c.operatorName)

--- a/pkg/cli/upgrade/upgrade_test.go
+++ b/pkg/cli/upgrade/upgrade_test.go
@@ -25,12 +25,18 @@ import (
 	"testing"
 
 	version "github.com/Percona-Lab/percona-version-service/versionpb"
+	"github.com/blang/semver/v4"
 	goversion "github.com/hashicorp/go-version"
+	olmversion "github.com/operator-framework/api/pkg/lib/version"
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/openeverest/openeverest/v2/pkg/common"
 	"github.com/openeverest/openeverest/v2/pkg/kubernetes"
 	versionservice "github.com/openeverest/openeverest/v2/pkg/version_service"
 )
@@ -280,6 +286,134 @@ func TestUpgrade_ValidateVersionToUpgrade(t *testing.T) {
 			} else if err != nil {
 				t.Errorf("error = %v", err)
 			}
+		})
+	}
+}
+
+func TestUpgrade_checkOperatorRequirements(t *testing.T) {
+	t.Parallel()
+
+	// GetDBNamespaces filters out the system namespace, so the DB namespace must differ from it.
+	const dbNamespace = "db-ns"
+
+	pxcConstraint, err := goversion.NewConstraint(">= 1.10.0")
+	require.NoError(t, err)
+	pgConstraint, err := goversion.NewConstraint(">= 2.4.0")
+	require.NoError(t, err)
+	psmdbConstraint, err := goversion.NewConstraint(">= 1.15.0")
+	require.NoError(t, err)
+
+	supVer := &common.SupportedVersion{
+		PXCOperator:   pxcConstraint,
+		PGOperator:    pgConstraint,
+		PSMBDOperator: psmdbConstraint,
+	}
+
+	tests := []struct {
+		name          string
+		sub           *olmv1alpha1.Subscription
+		csv           *olmv1alpha1.ClusterServiceVersion
+		expectedError string
+	}{
+		{
+			name: "PostgreSQL operator fails requirement",
+			sub: &olmv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.PostgreSQLOperatorName,
+					Namespace: dbNamespace,
+				},
+				Status: olmv1alpha1.SubscriptionStatus{
+					InstalledCSV: "pg-operator.v2.2.0",
+				},
+			},
+			csv: &olmv1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pg-operator.v2.2.0",
+					Namespace: dbNamespace,
+				},
+				Spec: olmv1alpha1.ClusterServiceVersionSpec{
+					Version: olmversion.OperatorVersion{
+						Version: semver.MustParse("2.2.0"),
+					},
+				},
+			},
+			expectedError: `percona-postgresql-operator version "2.2.0" does not meet minimum requirements of ">= 2.4.0"`,
+		},
+		{
+			name: "MongoDB operator fails requirement",
+			sub: &olmv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.MongoDBOperatorName,
+					Namespace: dbNamespace,
+				},
+				Status: olmv1alpha1.SubscriptionStatus{
+					InstalledCSV: "psmdb-operator.v1.12.0",
+				},
+			},
+			csv: &olmv1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "psmdb-operator.v1.12.0",
+					Namespace: dbNamespace,
+				},
+				Spec: olmv1alpha1.ClusterServiceVersionSpec{
+					Version: olmversion.OperatorVersion{
+						Version: semver.MustParse("1.12.0"),
+					},
+				},
+			},
+			expectedError: `percona-server-mongodb-operator version "1.12.0" does not meet minimum requirements of ">= 1.15.0"`,
+		},
+		{
+			name: "PXC operator fails requirement",
+			sub: &olmv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.MySQLOperatorName,
+					Namespace: dbNamespace,
+				},
+				Status: olmv1alpha1.SubscriptionStatus{
+					InstalledCSV: "pxc-operator.v1.9.0",
+				},
+			},
+			csv: &olmv1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pxc-operator.v1.9.0",
+					Namespace: dbNamespace,
+				},
+				Spec: olmv1alpha1.ClusterServiceVersionSpec{
+					Version: olmversion.OperatorVersion{
+						Version: semver.MustParse("1.9.0"),
+					},
+				},
+			},
+			expectedError: `percona-xtradb-cluster-operator version "1.9.0" does not meet minimum requirements of ">= 1.10.0"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   dbNamespace,
+					Labels: map[string]string{common.KubernetesManagedByLabel: common.Everest},
+				},
+			}
+
+			client := fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.CreateScheme()).
+				WithObjects(ns, tt.sub, tt.csv).
+				Build()
+
+			k := kubernetes.NewEmpty(zap.NewNop().Sugar(), "everest").WithKubernetesClient(client)
+			u := &Upgrade{
+				l:             zap.NewNop().Sugar(),
+				kubeConnector: k,
+			}
+
+			err := u.checkOperatorRequirements(context.Background(), supVer)
+			require.Error(t, err)
+			assert.Equal(t, tt.expectedError, err.Error())
 		})
 	}
 }


### PR DESCRIPTION
## What

Backports three CLI fixes that landed on `main` and were never ported to `release-2.0`. Each is a separate commit, and each carries the regression test from its upstream PR.

| Commit | Upstream | Defect on `release-2.0` |
|---|---|---|
| `--helm.reuse-values` binding | #2826 | `commands/upgrade.go:64` bound the flag to `upgradeCfg.ResetThenReuseValues` — the *same field* as `--helm.reset-then-reuse-values`. Passing `--helm.reuse-values` therefore reset the release values before reusing them instead of merging into them, and the two flags silently aliased each other. Also corrects the stale `--set` reference in the reset-then-reuse help text to `--helm.set`. |
| `--skip-wizard` on `namespaces update` | #2811 | `commands/namespaces/update.go:92` computed `askOperators` without consulting `SkipWizard`, so `everestctl namespaces update --skip-wizard` still dropped the user into the interactive operator prompt. `namespaces add` and `install` already handled it. |
| operator constraint message | #2843 | `pkg/cli/upgrade/upgrade.go:489` reported `supVer.PXCOperator` for *every* operator, so a PG or PSMDB operator below the minimum version was told to satisfy the PXC constraint. |

The `--skip-wizard` fix brings along upstream's `namespaces.ShouldAskOperators` helper, so `install`, `namespaces add` and `namespaces update` share one predicate instead of three copies of the same four-term conjunction.

## Why now

Found while auditing everything merged to `main` since `release-2.0` diverged (merge base `1233c71`) that never got ported — the same class of gap as #2766 / #2769.

## Notes for the reviewer

The `#2843` regression test needed adapting rather than cherry-picking:

- `kubernetes.NewEmpty` takes a namespace argument on `release-2.0`, but not on `main`.
- `GetDBNamespaces` filters out the system namespace on `release-2.0`, so the fixture uses a distinct `db-ns` for the DB namespace. Upstream's fixture put both in `everest`, which on this branch yields an empty namespace list and a vacuously passing test.

The other two tests are ported verbatim modulo the `github.com/openeverest/openeverest/v2` import path.

## Testing

```
go build ./...
go test ./commands/... ./pkg/cli/namespaces/... ./pkg/cli/upgrade/...
```

All green. Each test fails against the unfixed code on this branch.
