### PR TITLE
fix(ui): add missing noreferrer to external links (#2482)

### DIFF
--- a/ui/apps/everest/src/components/app-bar/help-icon/HelpIcon.tsx
+++ b/ui/apps/everest/src/components/app-bar/help-icon/HelpIcon.tsx
@@ -75,7 +75,7 @@ const AppBarHelpIcon = () => {
           underline="none"
           color="inherit"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
           href="https://openeverest.io/support/"
         >
           <MenuItem onClick={handleClose}>
@@ -86,7 +86,7 @@ const AppBarHelpIcon = () => {
           underline="none"
           color="inherit"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
           href="https://openeverest.io/docs/"
         >
           <MenuItem onClick={handleClose}>
@@ -97,7 +97,7 @@ const AppBarHelpIcon = () => {
           underline="none"
           color="inherit"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
           href="https://github.com/openeverest/openeverest/issues"
         >
           <MenuItem onClick={handleClose}>
@@ -108,7 +108,7 @@ const AppBarHelpIcon = () => {
           underline="none"
           color="inherit"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
           href="https://openeverest.io/#community"
         >
           <MenuItem onClick={handleClose}>

--- a/ui/apps/everest/src/components/empty-state-databases/empty-state-databases.tsx
+++ b/ui/apps/everest/src/components/empty-state-databases/empty-state-databases.tsx
@@ -38,7 +38,7 @@ const EmptyStateDatabases = ({
               Click{' '}
               <Link
                 target="_blank"
-                rel="noopener"
+                rel="noopener noreferrer"
                 href="https://openeverest.io/documentation/current/administer/rbac.html"
               >
                 here

--- a/ui/apps/everest/src/components/empty-state/empty-state.tsx
+++ b/ui/apps/everest/src/components/empty-state/empty-state.tsx
@@ -25,7 +25,11 @@ import { EmptyStateIcon } from '@percona/ui-lib';
 
 const ContactSupportLink = ({ msg }: { msg: string }) => {
   return (
-    <Link target="_blank" rel="noopener" href="https://openeverest.io/support/">
+    <Link
+      target="_blank"
+      rel="noopener noreferrer"
+      href="https://openeverest.io/support/"
+    >
       <Button
         startIcon={
           <HelpIcon

--- a/ui/apps/everest/src/components/linked-alert/LinkedAlert.tsx
+++ b/ui/apps/everest/src/components/linked-alert/LinkedAlert.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Alert, Box, Link, Stack } from '@mui/material';
 import { LinkedAlertProps } from './LinkedAlert.types';
 
@@ -34,7 +48,7 @@ const LinkedAlert = ({
             underline="none"
             color="inherit"
             target="_blank"
-            rel="noopener"
+            rel="noopener noreferrer"
             {...linkProps}
           >
             {linkContent}

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/old-cards/db-details/connection-details.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/old-cards/db-details/connection-details.tsx
@@ -63,6 +63,7 @@ export const ConnectionDetails = ({
             <Link
               href="https://openeverest.io/documentation/current/networking/nodeport_support.html"
               target="_blank"
+              rel="noopener noreferrer"
             >
               instructions
             </Link>

--- a/ui/apps/everest/src/pages/login/Login.tsx
+++ b/ui/apps/everest/src/pages/login/Login.tsx
@@ -36,7 +36,7 @@ const LoginLinkButton = ({
   href: string;
 }) => {
   return (
-    <Link target="_blank" rel="noopener" href={href}>
+    <Link target="_blank" rel="noopener noreferrer" href={href}>
       <Button startIcon={icon}>{text}</Button>
     </Link>
   );


### PR DESCRIPTION
## What

Backport of #2482 from `main`.

External links opened with `target="_blank"` carried `rel="noopener"` only, so the destination still received the OpenEverest URL in the `Referer` header. Adds `noreferrer` at all eight sites:

- `components/app-bar/help-icon/HelpIcon.tsx` (×4)
- `components/empty-state-databases/empty-state-databases.tsx`
- `components/empty-state/empty-state.tsx`
- `components/linked-alert/LinkedAlert.tsx`
- `pages/login/Login.tsx`

Plus one site the upstream PR also covered that had **no** `rel` at all — `pages/db-cluster-details/cluster-overview/old-cards/db-details/connection-details.tsx` (the NodePort docs link). That file sits under `old-cards/` on this branch, which is why a straight cherry-pick would have missed it.

## Why now

Found while auditing everything merged to `main` since `release-2.0` diverged (merge base `1233c71`) that never got ported — the same class of gap as #2766 / #2769.

## Notes for the reviewer

`LinkedAlert.tsx` had no copyright header; header added via `make copyright-headers` so the copyright CI check passes on the changed-file set.

## Testing

- `npx prettier --check` clean on all six files.
- `make copyright-check FILES_FILE=…` passes.
- No `rel="noopener"` without `noreferrer`, and no `target="_blank"` without a `rel`, remains anywhere under `ui/apps/everest/src`.
