### PR TITLE
ci: backport SBOM attestation and two workflow fixes from main

### DIFF
--- a/.github/workflows/dev-fe-e2e.yaml
+++ b/.github/workflows/dev-fe-e2e.yaml
@@ -28,6 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PMM_HELM_VER: "1.3.21"
+      # Store Playwright browsers on the roomier /mnt partition to avoid
+      # ENOSPC failures when installing Chromium on the smaller root volume.
+      PLAYWRIGHT_BROWSERS_PATH: /mnt/ms-playwright
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -169,6 +172,8 @@ jobs:
       - name: Install Chromium for Playwright
         shell: bash
         run: |
+          sudo mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"
+          sudo chown -R "$(id -u):$(id -g)" "$PLAYWRIGHT_BROWSERS_PATH"
           cd ui/apps/everest
           npx playwright install chromium
 

--- a/.github/workflows/good-first-issue.yml
+++ b/.github/workflows/good-first-issue.yml
@@ -13,6 +13,8 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
@@ -20,7 +22,7 @@ jobs:
           project-url: https://github.com/orgs/openeverest/projects/2
           
           # The secret name you will create in Step 2
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}
           
           # Filter for your specific label
           labeled: good first issue

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -229,7 +229,7 @@ jobs:
           tags: ${{ steps.everest_meta.outputs.tags }}
 
       - name: Everest - attest Everest image
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-name: ${{ env.IMAGE_PREFIX }}/${{ env.EVEREST_SERVER_DEV_IMAGE_NAME }}
           subject-digest: ${{ steps.everest_push.outputs.digest }}
@@ -237,10 +237,59 @@ jobs:
 
       - name: Everest - attest Everest prod image
         if: env.IS_RC == 0
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-name: ${{ env.IMAGE_PREFIX }}/${{ env.EVEREST_SERVER_IMAGE_NAME }}
           subject-digest: ${{ steps.everest_push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Everest - generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ env.IMAGE_PREFIX }}/${{ env.EVEREST_SERVER_DEV_IMAGE_NAME }}@${{ steps.everest_push.outputs.digest }}
+          format: spdx-json
+          output-file: everest-sbom-${{ matrix.arch }}.spdx.json
+
+      - name: Everest - attest SBOM
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}/${{ env.EVEREST_SERVER_DEV_IMAGE_NAME }}
+          subject-digest: ${{ steps.everest_push.outputs.digest }}
+          sbom-path: everest-sbom-${{ matrix.arch }}.spdx.json
+          push-to-registry: true
+
+      - name: Everest - attest prod SBOM
+        if: env.IS_RC == 0
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}/${{ env.EVEREST_SERVER_IMAGE_NAME }}
+          subject-digest: ${{ steps.everest_push.outputs.digest }}
+          sbom-path: everest-sbom-${{ matrix.arch }}.spdx.json
+          push-to-registry: true
+
+      - name: Everest - generate source SBOM
+        if: matrix.arch == 'amd64'
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          format: spdx-json
+          output-file: everest-source-sbom.spdx.json
+
+      - name: Everest - attest source SBOM
+        if: matrix.arch == 'amd64'
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}/${{ env.EVEREST_SERVER_DEV_IMAGE_NAME }}
+          subject-digest: ${{ steps.everest_push.outputs.digest }}
+          sbom-path: everest-source-sbom.spdx.json
+          push-to-registry: true
+
+      - name: Everest - attest prod source SBOM
+        if: matrix.arch == 'amd64' && env.IS_RC == 0
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}/${{ env.EVEREST_SERVER_IMAGE_NAME }}
+          subject-digest: ${{ steps.everest_push.outputs.digest }}
+          sbom-path: everest-source-sbom.spdx.json
           push-to-registry: true
 
 
@@ -251,6 +300,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     
     env:
       REGISTRY: ghcr.io
@@ -296,3 +347,21 @@ jobs:
               $IMAGE_PREFIX/$EVEREST_IMAGE:$FLOATING_TAG-amd64 \
               $IMAGE_PREFIX/$EVEREST_IMAGE:$FLOATING_TAG-arm64
           fi
+
+      - name: Get multi-arch manifest digest
+        id: manifest_digest
+        run: |
+          if [[ "$IS_RC" == "true" ]]; then
+            EVEREST_IMAGE="openeverest-dev"
+          else
+            EVEREST_IMAGE="openeverest"
+          fi
+          echo "everest_image=$EVEREST_IMAGE" >> $GITHUB_OUTPUT
+          echo "everest_digest=$(docker buildx imagetools inspect $IMAGE_PREFIX/$EVEREST_IMAGE:$VERSION --format '{{.Manifest.Digest}}')" >> $GITHUB_OUTPUT
+
+      - name: Everest - attest multi-arch manifest
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}/${{ steps.manifest_digest.outputs.everest_image }}
+          subject-digest: ${{ steps.manifest_digest.outputs.everest_digest }}
+          push-to-registry: true


### PR DESCRIPTION
## What

Three workflow changes that landed on `main` and were never ported.

### 1. SBOM generation and attestation in `release-v2.yml` (#2421)

`release-v2.yml` produced build-provenance attestations only — `grep -ci sbom` returned **0** on this branch versus **14** on `main`. v2 would have gone GA without an SBOM on any artifact, a supply-chain regression relative to what v1.16 already ships, and visible to OpenSSF Scorecard / CLOMonitor.

Switches `actions/attest-build-provenance` → `actions/attest`, then:

- generates a per-architecture image SBOM (`anchore/sbom-action`, spdx-json) and attests it against the dev and prod image digests;
- generates a source SBOM once (amd64 leg only) and attests it likewise;
- adds `id-token`/`attestations` write permissions to `create-manifests` and attests the assembled multi-arch manifest.

**Pinned to `actions/attest@v4.2.1`, not the `v4.1.0` the upstream PR landed with** — that is what `main` carries today after #2715, so this doesn't land an already-stale pin on `release-2.0`.

### 2. `PLAYWRIGHT_BROWSERS_PATH` in `dev-fe-e2e.yaml`

Installing Chromium onto the runner's root volume intermittently fails with `ENOSPC`; `/mnt` has substantially more free space. This hunk reached `main` as part of #2461, whose *product* change is v1-only — which is presumably why the CI half was never noticed as portable.

### 3. `secrets.PROJECT_TOKEN` in `good-first-issue.yml` (#2065)

The workflow still referenced `secrets.ADD_TO_PROJECT_PAT`, which was replaced by `PROJECT_TOKEN`. No effect today, because `issues:`-triggered workflows run from the default branch — but it breaks silently the moment `release-2.0` becomes the default branch. Also carries over `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`. `good-first-issue.yml` is now byte-identical to `main`.

## Why now

Found while auditing everything merged to `main` since `release-2.0` diverged (merge base `1233c71`) that never got ported — the same class of gap as #2766 / #2769.

## Notes for the reviewer

After these three commits, every remaining difference under `.github/` is deliberate or self-healing:

| Category | Files |
|---|---|
| `release-2.0` legitimately ahead | `install-kubernetes-tools` (chainsaw input), `dev-be-ci` (controller integration tests), `cli-tests` / `dev-fe-e2e` (controller binary, v2 namespaces), `release-v2.yml` (arch check also covers `bin/manager`), `dev-fe-browser-tests` + `dev-fe-visual` (added here by #2548, never existed on `main`) |
| v2 file layout | `dev-build`, `feature-build`, `release-helmtools` — `build/package/…/Dockerfile` vs root `Dockerfile.*` |
| Dependabot pin lag | `codeql`, `scorecard`, `storybook`, `feature-build-v2` — zero non-pin differences; Dependabot now watches this branch |
| `main` is behind | `copyright.yml` — `main` has a one-space indentation regression this branch doesn't |

**Deliberately not touched: `release.yml`.** It is a stale copy of the v1 pipeline on this branch and cannot run here — its Everest server image step is `context: .` with no `file:`, i.e. it expects `./Dockerfile`, which does not exist on `release-2.0` (v2 moved it to `build/package/server/Dockerfile`); the rest builds the v1 operator/bundle/catalog from the sibling repos. Porting ~45 lines of SBOM steps into a workflow that fails before reaching them seemed worse than leaving it. Whether it should be repaired or deleted from this branch is worth deciding separately.

## Testing

All three files parse as YAML. `release-v2.yml` SBOM step count now matches `main` exactly.
