### PR TITLE
Fix/supported version psmdb typo

### DIFF
--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -453,7 +453,7 @@ func (u *Upgrade) checkOperatorRequirements(ctx context.Context, supVer *common.
 	cfg := []requirementsCheck{
 		{common.MySQLOperatorName, supVer.PXCOperator},
 		{common.PostgreSQLOperatorName, supVer.PGOperator},
-		{common.MongoDBOperatorName, supVer.PSMBDOperator},
+		{common.MongoDBOperatorName, supVer.PSMDBOperator},
 	}
 	for _, ns := range nss.Items {
 		u.l.Infof("Checking operator requirements in namespace %s", ns)

--- a/pkg/cli/upgrade/upgrade_test.go
+++ b/pkg/cli/upgrade/upgrade_test.go
@@ -303,7 +303,7 @@ func TestUpgrade_checkOperatorRequirements(t *testing.T) {
 	supVer := &common.SupportedVersion{
 		PXCOperator:   pxcConstraint,
 		PGOperator:    pgConstraint,
-		PSMBDOperator: psmdbConstraint,
+		PSMDBOperator: psmdbConstraint,
 	}
 
 	tests := []struct {

--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (
@@ -16,7 +30,7 @@ type SupportedVersion struct {
 	Olm           goversion.Constraints
 	PGOperator    goversion.Constraints
 	PXCOperator   goversion.Constraints
-	PSMBDOperator goversion.Constraints
+	PSMDBOperator goversion.Constraints
 }
 
 type version interface {
@@ -83,7 +97,7 @@ func NewSupportedVersion(meta *versionpb.MetadataVersion) (*SupportedVersion, er
 		"kubernetes":    &supVer.Kubernetes,
 		"pgOperator":    &supVer.PGOperator,
 		"pxcOperator":   &supVer.PXCOperator,
-		"psmdbOperator": &supVer.PSMBDOperator,
+		"psmdbOperator": &supVer.PSMDBOperator,
 	}
 	for key, ref := range config {
 		if s, ok := meta.GetSupported()[key]; ok {

--- a/pkg/common/version_test.go
+++ b/pkg/common/version_test.go
@@ -1,10 +1,26 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (
 	"testing"
 
+	versionpb "github.com/Percona-Lab/percona-version-service/versionpb"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompareVersions(t *testing.T) {
@@ -36,4 +52,31 @@ func TestCheckConstraints(t *testing.T) {
 	assert.True(t, CheckConstraint("1.2.1-rc1", "~> 1.2.0"))
 	assert.False(t, CheckConstraint("1.3.1-rc1", "~> 1.2.0"))
 	assert.True(t, CheckConstraint("1.3.1-rc1", "> 1.2.0"))
+}
+
+func TestNewSupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	meta := &versionpb.MetadataVersion{
+		Supported: map[string]string{
+			"cli":           ">= 1.0.0",
+			"olm":           ">= 0.20.0",
+			"catalog":       ">= 1.0.0",
+			"kubernetes":    ">= 1.22.0",
+			"pgOperator":    ">= 2.4.0",
+			"pxcOperator":   ">= 1.10.0",
+			"psmdbOperator": ">= 1.15.0",
+		},
+	}
+
+	supVer, err := NewSupportedVersion(meta)
+	require.NoError(t, err)
+
+	assert.True(t, supVer.Cli.Check(goversion.Must(goversion.NewVersion("1.0.0"))))
+	assert.True(t, supVer.Olm.Check(goversion.Must(goversion.NewVersion("0.20.0"))))
+	assert.True(t, supVer.Catalog.Check(goversion.Must(goversion.NewVersion("1.0.0"))))
+	assert.True(t, supVer.Kubernetes.Check(goversion.Must(goversion.NewVersion("1.22.0"))))
+	assert.True(t, supVer.PGOperator.Check(goversion.Must(goversion.NewVersion("2.4.0"))))
+	assert.True(t, supVer.PXCOperator.Check(goversion.Must(goversion.NewVersion("1.10.0"))))
+	assert.True(t, supVer.PSMDBOperator.Check(goversion.Must(goversion.NewVersion("1.15.0"))))
 }


### PR DESCRIPTION
## Summary of Changes

Renamed `PSMBDOperator` typo to `PSMDBOperator` in `pkg/common/version.go` and updated all referencing packages.

**Root Cause:**
In `pkg/common/version.go`, the struct field for PSMDB (Percona Server for MongoDB) operator constraints was defined as `PSMBDOperator` (`BD` instead of `DB`).

**Fix:**
1. Updated `SupportedVersion.PSMBDOperator` to `SupportedVersion.PSMDBOperator` in `pkg/common/version.go`.
2. Updated string map assignment key reference `psmdbOperator` in `NewSupportedVersion`.
3. Updated call sites in `pkg/cli/upgrade/upgrade.go` and `pkg/cli/upgrade/upgrade_test.go`.
4. Added `TestNewSupportedVersion` unit test in `pkg/common/version_test.go` to test parsing of `SupportedVersion` constraints.

## Issue Reference

Fixes #2860

## Testing

Executed unit tests:

```bash
go test -v ./pkg/common/... ./pkg/cli/upgrade/...
```

All tests pass successfully.
