### PR TITLE
fix(session): fix data race between Allow and IncreaseTimeout in rate limiter

### DIFF
--- a/internal/server/session_failures_storage.go
+++ b/internal/server/session_failures_storage.go
@@ -89,13 +89,14 @@ func (store *RateLimiterMemoryStore) Allow(identifier string) (bool, error) {
 	}
 	now := store.timeNow()
 	sinceLastFailure := now.Sub(limiter.lastSeen)
+	timeout := limiter.timeout
 
 	limiter.lastSeen = now
 	if now.Sub(store.lastCleanup) > store.expiresIn {
 		store.cleanupStaleVisitors()
 	}
 	store.mutex.Unlock()
-	return limiter.AllowN(store.timeNow(), 1) && sinceLastFailure > limiter.timeout, nil
+	return limiter.AllowN(store.timeNow(), 1) && sinceLastFailure > timeout, nil
 }
 
 // CleanupVisitor removes the data about previous failures. To be used when a successful opetation was performed.

--- a/internal/server/session_failures_storage_test.go
+++ b/internal/server/session_failures_storage_test.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"sync"
+	"testing"
+
+	"golang.org/x/time/rate"
+)
+
+// TestRateLimiterMemoryStore_ConcurrentAllowAndIncreaseTimeout guards against a data race
+// between Allow reading Visitor.timeout and IncreaseTimeout writing it. Run with -race.
+func TestRateLimiterMemoryStore_ConcurrentAllowAndIncreaseTimeout(t *testing.T) {
+	t.Parallel()
+
+	store := NewRateLimiterMemoryStoreWithConfig(RateLimiterMemoryStoreConfig{
+		Rate: rate.Limit(1000),
+	})
+
+	const identifier = "1.2.3.4"
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_, _ = store.Allow(identifier)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			store.IncreaseTimeout(identifier)
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Fixes a data race in the login rate-limiter: `RateLimiterMemoryStore.Allow()` read `Visitor.timeout` after releasing `store.mutex`, while `IncreaseTimeout()` writes that same field under the lock from a concurrent goroutine. Both are hit per-request on `/v1/session`, so this was an unsynchronized read/write race in the login brute-force throttle, confirmed with `go test -race`. Not caught by `go build` or `go vet`.

Fixes #2879

## Changes

- `internal/server/session_failures_storage.go` — capture `timeout := limiter.timeout` while still holding `store.mutex` in `Allow()`, and use the local copy after unlock, instead of reading the shared field post-unlock.
- `internal/server/session_failures_storage_test.go` — adds `TestRateLimiterMemoryStore_ConcurrentAllowAndIncreaseTimeout`, which runs `Allow` and `IncreaseTimeout` concurrently under `-race`. Fails on pre-fix code, passes on the fix.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make copyright-check`
- [x] `make format` / `go mod tidy` - no diff
- [x] `go tool golangci-lint run --new-from-rev=main` - 0 issues
- [x] `make test` (`go test -race ./...`, full repo) - all packages pass
- [x] Verified the new test reproduces the race on unpatched code (reverted the fix locally, confirmed `-race` fails with the expected read/write trace on `session_failures_storage.go:98` / `:113`, then restored the fix)
