### PR TITLE
Add regression test for tokenStore.Add update failure

### DIFF
--- a/pkg/session/blocklist_test.go
+++ b/pkg/session/blocklist_test.go
@@ -28,8 +28,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/percona/everest/pkg/common"
 	"github.com/percona/everest/pkg/kubernetes"
@@ -435,6 +437,73 @@ func TestBlocklist_IsBlocked(t *testing.T) {
 			assert.Equal(t, tc.blocked, blocked)
 		})
 	}
+}
+
+// TestTokenStore_Add_UpdateFailure asserts the invariant that Add reports
+// success only when the token is genuinely blocklisted. When the underlying
+// Secret update fails, Add must return the error rather than swallow it, and
+// the token must not be persisted to the blocklist Secret.
+//
+// The fix is already present on main (#2086); this closes the coverage gap that
+// let the original bug (#2085) ship and its missing backport to release-2.0 go
+// unnoticed (#2766). It mirrors the regression test added on release-2.0 in
+// #2769. On the unfixed code Add returns the nil `err` from the earlier
+// GetSecret instead of the update error, so a failed write is reported as
+// success and the token is never blocklisted.
+func TestTokenStore_Add_UpdateFailure(t *testing.T) {
+	t.Parallel()
+
+	l := zap.NewNop().Sugar()
+	ctx := context.Background()
+
+	//nolint:gosec // test token ID, not a credential
+	const shortenedToken = "9d1c1f98-a479-41e3-8939-c7cb3e049a331743679478"
+
+	// Fail every Secret update to simulate a transient write error (e.g. a 409
+	// conflict from concurrent logouts). Reads and the init-time create still
+	// succeed, so Add reaches the update and fails there.
+	mockClient := fakeclient.NewClientBuilder().
+		WithScheme(kubernetes.CreateScheme()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(
+				ctx context.Context,
+				c ctrlclient.WithWatch,
+				obj ctrlclient.Object,
+				opts ...ctrlclient.UpdateOption,
+			) error {
+				if _, ok := obj.(*corev1.Secret); ok {
+					return k8serrors.NewConflict(
+						schema.GroupResource{Resource: "secrets"},
+						obj.GetName(),
+						errors.New("simulated conflict"),
+					)
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		})
+	k := kubernetes.NewEmpty(l).WithKubernetesClient(mockClient.Build())
+
+	store, err := newTokenStore(ctx, k, l)
+	require.NoError(t, err)
+
+	// The Secret write fails, so Add must surface the error and not report
+	// success. The defect returned the wrong error variable, so pin that the
+	// surfaced error is the UpdateSecret conflict rather than merely "an error":
+	// kubernetes.UpdateSecret returns the client error unwrapped.
+	err = store.Add(ctx, shortenedToken)
+	require.Error(t, err)
+	assert.True(t, k8serrors.IsConflict(err), "Add must surface the UpdateSecret error, got %v", err)
+
+	// Read-back invariant: because the write failed, the token must not have
+	// reached the Secret. As in TestBlocklist_Block, the fake client does not do
+	// the StringData -> Data transformation the real API server does, so the
+	// assertion has to be on StringData.
+	secret, err := k.GetSecret(ctx, ctrlclient.ObjectKey{
+		Name:      common.EverestBlocklistSecretName,
+		Namespace: common.SystemNamespace,
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, secret.StringData[dataKey], shortenedToken)
 }
 
 func mockNewBlocklist(ctx context.Context, logger *zap.SugaredLogger, mockClient TokenStoreClient) (Blocklist, error) {


### PR DESCRIPTION
This is the follow-up to #2769 that we discussed in #2766.

The fix for this bug is already on main (it went in with #2086), so there's no code change here. The actual gap was on the test side: pkg/session never had a case where the blocklist Secret update fails, so the fake client's writes always succeeded and the suite stayed green. That's how the original bug shipped, and also how the missing backport to release-2.0 went unnoticed for a while. This just adds the test so main is covered too.

The test makes the Secret update return a conflict, then checks two things: that Add returns that error instead of swallowing it, and that the token didn't actually make it into the Secret. It reads the Secret back through StringData because the fake client doesn't do the StringData -> Data conversion the real API server does (same reason TestBlocklist_Block checks it that way).

Ran go test ./pkg/session/... and go test -race ./pkg/session/... locally, both pass.

Part of #2766. The release-2.0 side (the fix plus this same test) is in #2769.