### PR TITLE
fix: remove obsolete uninstall environment detection

### DIFF
--- a/commands/uninstall.go
+++ b/commands/uninstall.go
@@ -47,6 +47,7 @@ func init() {
 	uninstallCmd.Flags().BoolVarP(&uninstallCfg.AssumeYes, "assume-yes", "y", false, "Assume yes to all questions")
 	uninstallCmd.Flags().BoolVarP(&uninstallCfg.Force, "force", "f", false, "Force removal in case there are database clusters running")
 	uninstallCmd.Flags().BoolVar(&uninstallCfg.SkipEnvDetection, cli.FlagSkipEnvDetection, false, "Skip detecting Kubernetes environment where Everest is installed")
+	_ = uninstallCmd.Flags().MarkDeprecated(cli.FlagSkipEnvDetection, "no longer has any effect")
 }
 
 func uninstallPreRun(_ *cobra.Command, _ []string) {

--- a/commands/uninstall_test.go
+++ b/commands/uninstall_test.go
@@ -1,0 +1,45 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/percona/everest/pkg/cli"
+)
+
+// TestUninstallCmdSkipEnvDetectionDeprecated is a regression test for
+// issue #2888: --skip-env-detection must remain accepted by `everestctl
+// uninstall` (so existing scripts don't fail with an "unknown flag" error),
+// but must now be treated as a deprecated no-op.
+//
+//nolint:paralleltest
+func TestUninstallCmdSkipEnvDetectionDeprecated(t *testing.T) {
+	// Still parses without error, preserving compatibility with existing
+	// invocations of --skip-env-detection.
+	err := uninstallCmd.ParseFlags([]string{"--" + cli.FlagSkipEnvDetection})
+	require.NoError(t, err)
+	assert.True(t, uninstallCfg.SkipEnvDetection)
+
+	// The flag is marked deprecated, so cobra will print a warning on use
+	// and omit it from `--help` output.
+	flag := uninstallCmd.Flags().Lookup(cli.FlagSkipEnvDetection)
+	require.NotNil(t, flag)
+	assert.NotEmpty(t, flag.Deprecated, "--skip-env-detection should be marked deprecated")
+}

--- a/pkg/cli/uninstall/uninstall.go
+++ b/pkg/cli/uninstall/uninstall.go
@@ -46,7 +46,6 @@ type Uninstall struct {
 	config        Config
 	kubeConnector kubernetes.KubernetesConnector
 	l             *zap.SugaredLogger
-	clusterType   kubernetes.ClusterType
 }
 
 // Config stores configuration for the Uninstall command.
@@ -57,7 +56,8 @@ type Config struct {
 	AssumeYes bool
 	// Force is true when we shall not prompt for removal.
 	Force bool
-	// SkipEnvDetection skips detecting the Kubernetes environment.
+	// SkipEnvDetection is deprecated and no longer has any effect.
+	// Kubernetes environment detection is not needed by the uninstall flow.
 	SkipEnvDetection bool
 	// If set, we will print the pretty output.
 	Pretty bool
@@ -100,10 +100,6 @@ func (u *Uninstall) Run(ctx context.Context) error {
 		}
 	}
 
-	if err := u.setKubernetesEnv(ctx); err != nil {
-		return fmt.Errorf("failed to detect Kubernetes environment: %w", err)
-	}
-
 	dbsExist, err := u.kubeConnector.DatabasesExist(ctx)
 	if err != nil {
 		return errors.Join(err, errors.New("failed to check if databases exist"))
@@ -137,19 +133,6 @@ func (u *Uninstall) Run(ctx context.Context) error {
 
 	u.l.Infof("Everest has been uninstalled successfully")
 	_, _ = fmt.Fprintln(out, "Everest has been uninstalled successfully")
-	return nil
-}
-
-func (u *Uninstall) setKubernetesEnv(ctx context.Context) error {
-	if !u.config.SkipEnvDetection {
-		return nil
-	}
-	t, err := u.kubeConnector.GetClusterType(ctx)
-	if err != nil {
-		return err
-	}
-	u.clusterType = t
-	u.l.Infof("Detected Kubernetes environment: %s", t)
 	return nil
 }
 

--- a/pkg/cli/uninstall/uninstall_test.go
+++ b/pkg/cli/uninstall/uninstall_test.go
@@ -1,0 +1,49 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uninstall
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUninstallHasNoClusterTypeState is a regression guard for issue #2888:
+// the uninstall flow used to run Kubernetes environment detection (behind an
+// inverted --skip-env-detection check) whose result, u.clusterType, was never
+// consumed anywhere in the package. Both the detection call and the field
+// that stored its result have been removed; this asserts the field does not
+// silently reappear.
+func TestUninstallHasNoClusterTypeState(t *testing.T) {
+	t.Parallel()
+
+	_, ok := reflect.TypeFor[Uninstall]().FieldByName("clusterType")
+	assert.False(t, ok, "Uninstall must not carry an unused clusterType field")
+}
+
+// TestConfigSkipEnvDetectionRemainsSettable ensures Config.SkipEnvDetection
+// is kept for backward compatibility with existing --skip-env-detection
+// invocations, even though the uninstall flow no longer reads it.
+func TestConfigSkipEnvDetectionRemainsSettable(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{SkipEnvDetection: true}
+	assert.True(t, cfg.SkipEnvDetection)
+
+	cfg = Config{SkipEnvDetection: false}
+	assert.False(t, cfg.SkipEnvDetection)
+}


### PR DESCRIPTION
## Summary

Fixes #2888 by removing the obsolete Kubernetes environment detection logic from `everestctl uninstall`!

The uninstall flow no longer requires Kubernetes environment detection, so the unused detection path has been removed while keeping `--skip-env-detection` registered as a deprecated no-op for backward compatibility..

## Changes

- Removed the unused `clusterType` field from the uninstall configuration
- Removed the obsolete Kubernetes environment detection and `setKubernetesEnv` logic
- Kept `--skip-env-detection` as a deprecated no-op for backward compatibility
- Added regression tests for the uninstall configuration and deprecated flag behavior

## Verification

- `gofmt` passes
- `go build` passes
- `go vet` passes
- Focused uninstall and command tests pass
- Full relevant package tests pass
- `golangci-lint` passes on the affected packages

This PR applies the same fix to `main` as the corresponding `release-2.0` change..!