### PR TITLE
fix(provider-runtime): don't skip Sync/Status when only backup config is invalid

### DIFF
--- a/provider-runtime/reconciler/backup_limits_sync_test.go
+++ b/provider-runtime/reconciler/backup_limits_sync_test.go
@@ -54,6 +54,26 @@ func (p *syncTrackingProvider) Status(*controller.Context) (controller.Status, e
 	return controller.Ready(), nil
 }
 
+// The four methods below satisfy controller.BackupProvider so that the
+// reconciler's "skip clearing BackupConfigured on a live violation" guard —
+// which only applies to BackupProvider implementations — is actually
+// exercised by this test instead of being a no-op type assertion.
+func (p *syncTrackingProvider) SyncBackup(*controller.Context, *backupv1alpha1.Backup) (controller.BackupExecutionStatus, error) {
+	return controller.BackupExecutionStatus{}, nil
+}
+
+func (p *syncTrackingProvider) SyncRestore(*controller.Context, *backupv1alpha1.Restore) (controller.RestoreExecutionStatus, error) {
+	return controller.RestoreExecutionStatus{}, nil
+}
+
+func (p *syncTrackingProvider) CleanupBackup(*controller.Context, *backupv1alpha1.Backup) (bool, error) {
+	return true, nil
+}
+
+func (p *syncTrackingProvider) CleanupRestore(*controller.Context, *backupv1alpha1.Restore) (bool, error) {
+	return true, nil
+}
+
 func TestReconcile_BackupLimitsViolation_StillRunsSync(t *testing.T) {
 	t.Parallel()
 	scheme := newTestScheme()

--- a/provider-runtime/reconciler/backup_limits_sync_test.go
+++ b/provider-runtime/reconciler/backup_limits_sync_test.go
@@ -1,0 +1,139 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	backupv1alpha1 "github.com/openeverest/openeverest/v2/api/backup/v1alpha1"
+	common "github.com/openeverest/openeverest/v2/api/common/v1alpha1"
+	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
+)
+
+// syncTrackingProvider is a providerAdapter stub that records whether Sync
+// and Status were invoked, so tests can assert the reconciler still
+// converges the engine even when backup config validation fails.
+type syncTrackingProvider struct {
+	syncCalled   bool
+	statusCalled bool
+}
+
+func (p *syncTrackingProvider) Name() string                       { return "test-provider" }
+func (p *syncTrackingProvider) Types() func(*runtime.Scheme) error { return nil }
+func (p *syncTrackingProvider) Validate(*controller.Context) error { return nil }
+func (p *syncTrackingProvider) Cleanup(*controller.Context) error  { return nil }
+func (p *syncTrackingProvider) Sync(*controller.Context) error {
+	p.syncCalled = true
+	return nil
+}
+
+func (p *syncTrackingProvider) Status(*controller.Context) (controller.Status, error) {
+	p.statusCalled = true
+	return controller.Ready(), nil
+}
+
+func TestReconcile_BackupLimitsViolation_StillRunsSync(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme()
+
+	maxStorages := int32(1)
+	backupClass := &backupv1alpha1.BackupClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-class"},
+		Spec: backupv1alpha1.BackupClassSpec{
+			ExecutionMode: backupv1alpha1.BackupExecutionModeProviderManaged,
+			ProviderManaged: &backupv1alpha1.ProviderManagedSpec{
+				Limits: &backupv1alpha1.BackupClassLimits{
+					MaxStorages: &maxStorages,
+				},
+			},
+		},
+	}
+
+	provider := &corev1alpha1.Provider{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-provider"},
+	}
+
+	// Two storages violates the class's MaxStorages: 1 limit. The finalizer
+	// and provider label are pre-set so Reconcile runs the real validate/
+	// sync/status logic on the first call, instead of only adding them and
+	// requeuing (its behavior for a brand new Instance).
+	instance := &corev1alpha1.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "my-instance",
+			Namespace:  "default",
+			Finalizers: []string{finalizerName},
+			Labels:     map[string]string{controller.ProviderLabel: "test-provider"},
+		},
+		Spec: corev1alpha1.InstanceSpec{
+			ProviderRef: common.ObjectRef{Name: "test-provider"},
+			Backup: &corev1alpha1.InstanceBackupSpec{
+				Enabled:  true,
+				ClassRef: common.ObjectRef{Name: "test-class"},
+				Storages: []corev1alpha1.InstanceBackupStorage{
+					{StorageRef: common.ObjectRef{Name: "storage-a"}},
+					{StorageRef: common.ObjectRef{Name: "storage-b"}},
+				},
+			},
+		},
+	}
+
+	// Reconcile writes status via the Status subresource client, which the
+	// fake client only serves correctly for types registered via
+	// WithStatusSubresource — hence a local builder instead of the package's
+	// newFakeClient (whose existing callers never exercise that path).
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.Instance{}).
+		WithObjects(backupClass, provider, instance).
+		Build()
+	testProvider := &syncTrackingProvider{}
+	r := &ProviderReconciler{
+		provider: testProvider,
+		Client:   fakeClient,
+	}
+
+	req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(instance)}
+
+	_, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.True(t, testProvider.syncCalled,
+		"Sync() must still run when only the backup config is invalid — the engine itself is healthy")
+	assert.True(t, testProvider.statusCalled,
+		"Status() must still run when only the backup config is invalid")
+
+	var got corev1alpha1.Instance
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, &got))
+
+	found := false
+	for _, c := range got.Status.Conditions {
+		if c.Type == corev1alpha1.ConditionBackupConfigured {
+			found = true
+			assert.Equal(t, metav1.ConditionFalse, c.Status)
+			assert.Equal(t, controller.LimitsExceededReason, c.Reason)
+		}
+	}
+	assert.True(t, found, "BackupConfigured condition must be set to False, not silently dropped")
+}

--- a/provider-runtime/reconciler/provider.go
+++ b/provider-runtime/reconciler/provider.go
@@ -388,21 +388,22 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		}
 		return reconcile.Result{}, err
 	}
-	if err := validateInstanceBackupConfig(ctx, r.Client, in); err != nil {
-		logger.Error(err, "Backup configuration validation failed")
-		// Surface the violation on the BackupConfigured condition without
-		// marking the Instance Failed: the engine itself is healthy and the
-		// user can fix the configuration without a full redeploy.
+	// Surface a backup configuration violation on the BackupConfigured
+	// condition without marking the Instance Failed and, critically,
+	// without skipping the rest of reconciliation: the engine itself is
+	// healthy and unrelated spec changes (scaling, upgrades, config, etc.)
+	// must keep converging even while backup config is invalid. Providers
+	// are expected to guard against acting on the violating config
+	// themselves inside Sync(), via Context.BackupClassLimits().
+	backupConfigErr := validateInstanceBackupConfig(ctx, r.Client, in)
+	if backupConfigErr != nil {
+		logger.Error(backupConfigErr, "Backup configuration validation failed")
 		reason := controller.LimitsExceededReason
-		if errors.Is(err, controller.ErrPITRConfigInvalid) {
+		if errors.Is(backupConfigErr, controller.ErrPITRConfigInvalid) {
 			reason = controller.PITRConfigInvalidReason
 		}
 		setCondition(in, v1alpha1.ConditionBackupConfigured, metav1.ConditionFalse,
-			reason, err.Error(), metav1.Now())
-		if updateErr := r.Client.Status().Update(ctx, in); updateErr != nil {
-			logger.Error(updateErr, "Failed to update status after backup config violation")
-		}
-		return reconcile.Result{}, nil
+			reason, backupConfigErr.Error(), metav1.Now())
 	}
 	if err := r.provider.Validate(inCtx); err != nil {
 		logger.Error(err, "Validation failed")
@@ -454,8 +455,10 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		logger.Error(err, "Sync failed")
 		return reconcile.Result{}, err
 	}
-	// Clear any stale BackupConfigured=False condition left from a previous failed Sync.
-	if _, ok := r.provider.(controller.BackupProvider); ok {
+	// Clear any stale BackupConfigured=False condition left from a previous
+	// failed Sync — but not when this reconcile's own limits check above
+	// found a live violation, or we would immediately mask it.
+	if _, ok := r.provider.(controller.BackupProvider); ok && backupConfigErr == nil {
 		setCondition(in, v1alpha1.ConditionBackupConfigured, metav1.ConditionTrue,
 			"Configured", "Backup configuration applied to engine", metav1.Now())
 	}

--- a/provider-runtime/reconciler/provider.go
+++ b/provider-runtime/reconciler/provider.go
@@ -404,6 +404,15 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		}
 		setCondition(in, v1alpha1.ConditionBackupConfigured, metav1.ConditionFalse,
 			reason, backupConfigErr.Error(), metav1.Now())
+		// Persist the condition now rather than relying on the final
+		// Status().Update() at the end of Reconcile: several return paths
+		// below (e.g. a WaitError from Sync) exit before reaching it, which
+		// would silently drop the condition. Update() also refreshes
+		// resourceVersion on in, so the later update in the happy path does
+		// not conflict.
+		if updateErr := r.Client.Status().Update(ctx, in); updateErr != nil {
+			logger.Error(updateErr, "Failed to update status after backup config violation")
+		}
 	}
 	if err := r.provider.Validate(inCtx); err != nil {
 		logger.Error(err, "Validation failed")


### PR DESCRIPTION
### What does this PR do?

`ProviderReconciler.Reconcile` (`provider-runtime/reconciler/provider.go`) returned early whenever an `Instance`'s backup configuration violated its `BackupClass` limits (`maxStorages`, `maxPITREnabledStorages`, `maxSchedulesPerStorage`) — before ever calling `provider.Sync()` or `provider.Status()`. This contradicted the code's own comment, which says the point of surfacing the violation on the `BackupConfigured` condition (instead of marking the Instance `Failed`) is that "the engine itself is healthy and the user can fix the configuration without a full redeploy." In practice, once an Instance tripped this check, **all** further engine reconciliation (scaling, upgrades, resource/config changes — not just backup wiring) silently stopped until the violation was resolved.

This is reachable without any change to the `Instance` itself: a `BackupClass` is cluster-scoped and shared, so tightening its limits after the fact freezes every previously-healthy `Instance` that now exceeds them, with no clear signal that engine-level reconciliation (not just backup config) is what's paused.

### Fix

- Stop returning early on a backup-config violation. The `BackupConfigured` condition is still set to `False` with the same reason/message as before, but `provider.Validate/Sync/Status` now still run afterward, so the engine keeps converging on the rest of its spec.
- The later step that unconditionally clears `BackupConfigured` back to `True` after a successful `Sync` now skips doing so when this reconcile's own limits check found a live violation — otherwise it would immediately mask the condition we just set.

No change to the validation rules themselves (`ValidateInstanceBackupAgainstClass`, `ValidateInstanceBackupPITRParameters`) or to the admission webhook path, which already correctly rejects a *new* violating write at admission time — this only affects reconciliation of an already-persisted `Instance` whose backup config becomes invalid out from under it (e.g. via a `BackupClass` policy change).

### Test plan

- [x] Added `TestReconcile_BackupLimitsViolation_StillRunsSync` (`provider-runtime/reconciler/backup_limits_sync_test.go`), using the existing fake-client test harness (`newTestScheme` from `cascade_delete_test.go`). Constructs an `Instance` with two backup storages against a `BackupClass` with `maxStorages: 1`, and asserts `Sync()`/`Status()` are still invoked despite the violation, and that the `BackupConfigured` condition is `False` with reason `LimitsExceeded`.
- [x] `go build ./provider-runtime/...`
- [x] `go test ./provider-runtime/...`
- [x] `go test -race ./provider-runtime/...`
- [x] `make copyright-check BASE_BRANCH=release-2.0`
- [x] `make format` / `go mod tidy` — no diff
- [x] `go tool golangci-lint run --new-from-rev=upstream/release-2.0`

No concrete provider implements this SDK yet (verified via `grep -r "BaseProvider"` / `grep -r "reconciler.New("` — zero hits outside `provider-runtime/` itself), so this was found and fixed by reading the reconcile control flow directly, not by reproducing against a running provider.

Fixes #2898

Signed-off-by: Bhupesh Nandardhane <nandardhanebhupesh@gmail.com>
