### PR TITLE
fix(cli): isolate auth transport connections

### DIFF
--- a/pkg/cli/auth/transport.go
+++ b/pkg/cli/auth/transport.go
@@ -81,6 +81,10 @@ type authTransport struct {
 	base   http.RoundTripper
 }
 
+func newDefaultTransport() *http.Transport {
+	return http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert
+}
+
 func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	tok, err := t.source.token(req.Context())
 	if err != nil {
@@ -144,7 +148,7 @@ func NewAPIClient(cfg Config, l *zap.SugaredLogger, cfgPath, contextName string)
 	c, err := client.NewClientWithResponses(
 		cli.NormalizeServerURL(sess.Server.URL),
 		client.WithHTTPClient(&http.Client{
-			Transport: &authTransport{source: ts, base: http.DefaultTransport},
+			Transport: &authTransport{source: ts, base: newDefaultTransport()},
 		}),
 	)
 	if err != nil {

--- a/pkg/cli/auth/transport_test.go
+++ b/pkg/cli/auth/transport_test.go
@@ -60,6 +60,13 @@ func loadTokenSource(t *testing.T, cfgPath string, l *Login) *tokenSource {
 	}
 }
 
+func newTestAuthTransport(t *testing.T, source *tokenSource) *authTransport {
+	t.Helper()
+	base := newDefaultTransport()
+	t.Cleanup(base.CloseIdleConnections)
+	return &authTransport{source: source, base: base}
+}
+
 func TestTransport_InjectsBearerToken(t *testing.T) {
 	t.Parallel()
 
@@ -74,7 +81,7 @@ func TestTransport_InjectsBearerToken(t *testing.T) {
 	require.NoError(t, newTransportConfig(srv.URL).Save(cfgPath))
 
 	ts := loadTokenSource(t, cfgPath, NewLogin(Config{}, zap.NewNop().Sugar()))
-	tr := &authTransport{source: ts, base: http.DefaultTransport}
+	tr := newTestAuthTransport(t, ts)
 
 	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
@@ -111,7 +118,7 @@ func TestTransport_ProactiveRefresh(t *testing.T) {
 	require.NoError(t, cfg.Save(cfgPath))
 
 	ts := loadTokenSource(t, cfgPath, NewLogin(Config{}, zap.NewNop().Sugar()))
-	tr := &authTransport{source: ts, base: http.DefaultTransport}
+	tr := newTestAuthTransport(t, ts)
 
 	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
@@ -150,7 +157,7 @@ func TestTransport_On401_RefreshAndRetry(t *testing.T) {
 	require.NoError(t, newTransportConfig(srv.URL).Save(cfgPath))
 
 	ts := loadTokenSource(t, cfgPath, NewLogin(Config{}, zap.NewNop().Sugar()))
-	tr := &authTransport{source: ts, base: http.DefaultTransport}
+	tr := newTestAuthTransport(t, ts)
 
 	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
@@ -176,7 +183,7 @@ func TestTransport_On401_RefreshFails_ReturnsErrTokenRefresh(t *testing.T) {
 	require.NoError(t, newTransportConfig(srv.URL).Save(cfgPath))
 
 	ts := loadTokenSource(t, cfgPath, NewLogin(Config{}, zap.NewNop().Sugar()))
-	tr := &authTransport{source: ts, base: http.DefaultTransport}
+	tr := newTestAuthTransport(t, ts)
 
 	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
@@ -218,7 +225,7 @@ func TestTransport_On401_RetryReplaysBody(t *testing.T) {
 	require.NoError(t, newTransportConfig(srv.URL).Save(cfgPath))
 
 	ts := loadTokenSource(t, cfgPath, NewLogin(Config{}, zap.NewNop().Sugar()))
-	tr := &authTransport{source: ts, base: http.DefaultTransport}
+	tr := newTestAuthTransport(t, ts)
 
 	payload := `{"metadata":{"name":"my-mongo"}}`
 	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/instances", bytes.NewReader([]byte(payload)))
@@ -244,4 +251,15 @@ func TestNewAPIClient_LoadsSession(t *testing.T) {
 	c, err := NewAPIClient(Config{}, zap.NewNop().Sugar(), cfgPath, "")
 	require.NoError(t, err)
 	require.NotNil(t, c)
+
+	generatedClient, ok := c.ClientInterface.(*client.Client)
+	require.True(t, ok)
+	httpClient, ok := generatedClient.Client.(*http.Client)
+	require.True(t, ok)
+	transport, ok := httpClient.Transport.(*authTransport)
+	require.True(t, ok)
+	base, ok := transport.base.(*http.Transport)
+	require.True(t, ok)
+	t.Cleanup(base.CloseIdleConnections)
+	require.NotSame(t, http.DefaultTransport, base)
 }


### PR DESCRIPTION
## Summary

Authentication transports previously shared the global `http.DefaultTransport`. That also shared connection pools between parallel tests and could cause intermittent failures.

This change clones the default transport for each API client and test transport. The regression coverage also verifies that `NewAPIClient` does not reuse the global transport.

Fixes #2884

## Testing

- `go test ./pkg/cli/auth -count=100`
- `go test ./pkg/cli/...`
- `go vet ./pkg/cli/auth`

## AI assistance

This contribution was made with AI assistance. I reviewed the implementation and verified all test results listed above before submitting it.