### PR TITLE
chore(labels): add triage/duplicate and triage/not-reproducible outcome labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -19,6 +19,14 @@
   color: fbca04
   description: Blocked waiting for more information from the reporter
 
+- name: triage/duplicate
+  color: cfd3d7
+  description: Duplicate of an earlier report — the earliest report is canonical
+
+- name: triage/not-reproducible
+  color: d455d0
+  description: Could not be reproduced as reported
+
 - name: lifecycle/frozen
   color: d3d3d3
   description: Exempt from automatic unassignment; work expected to take a while

--- a/.github/workflows/triage-labels.yml
+++ b/.github/workflows/triage-labels.yml
@@ -3,8 +3,8 @@ name: Triage labels
 # Keeps exactly one triage label on every open issue, so "has anybody looked at
 # this?" is always answerable from the label list. `needs-triage` goes on at
 # creation and comes off only when a maintainer records a decision by applying
-# `triage/accepted` or `triage/needs-information` — and goes back on if the
-# decision label is later removed.
+# one of the `triage/*` decision labels — and goes back on if the decision
+# label is later removed.
 #
 # Label events raised by this workflow use GITHUB_TOKEN, which does not start
 # another workflow run, so this cannot loop.
@@ -28,7 +28,12 @@ jobs:
             if (issue.state !== 'open') return;
 
             const NEEDS_TRIAGE = 'needs-triage';
-            const DECISIONS = ['triage/accepted', 'triage/needs-information'];
+            const DECISIONS = [
+              'triage/accepted',
+              'triage/needs-information',
+              'triage/duplicate',
+              'triage/not-reproducible',
+            ];
 
             const labels = (issue.labels || []).map((l) => l.name);
             const decided = DECISIONS.some((d) => labels.includes(d));

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,10 +49,12 @@ Labels tell you where an issue stands:
 | `needs-triage` | Nobody has looked at it yet. Added automatically when the issue is opened. |
 | `triage/needs-information` | We're waiting on the reporter before deciding. |
 | `triage/accepted` | We agree this should be done. |
+| `triage/duplicate` | Already reported — the earliest report is canonical, follow that one. |
+| `triage/not-reproducible` | We couldn't reproduce it as reported. A working reproduction reopens the conversation. |
 | [`help wanted`](https://github.com/openeverest/openeverest/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+no%3Aassignee) | Accepted, and we'd welcome community help. **Claim these yourself with `/assign`.** |
 | [`good first issue`](https://github.com/openeverest/openeverest/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee) | A `help wanted` issue that needs no deep background. Ideal if this is your first contribution here. |
 
-**The triage labels are maintained by a bot, so they are always current.** `needs-triage` is applied to every issue as it is opened, and is removed only when a maintainer records a decision by applying `triage/accepted` or `triage/needs-information`. If a decision label is later taken off, `needs-triage` comes back. Exactly one of the three is on every open issue, so "has anybody looked at this yet?" is answerable at a glance.
+**The triage labels are maintained by a bot, so they are always current.** `needs-triage` is applied to every issue as it is opened, and is removed only when a maintainer records a decision by applying one of the `triage/*` labels. If a decision label is later taken off, `needs-triage` comes back. Exactly one triage label is on every open issue, so "has anybody looked at this yet?" is answerable at a glance.
 
 They describe where our thinking has got to, not what you are allowed to do. An issue sitting at `needs-triage` means we might decide it isn't a bug, or that we don't want it fixed the way it proposes — which is worth knowing before you spend a weekend on it, and is the only reason to wait.
 


### PR DESCRIPTION
Mirrors #2904 onto `release-2.0` to keep `.github/labels.yml`, `.github/workflows/triage-labels.yml`, and the CONTRIBUTING.md triage section identical across the two product lines. The live label sync and issue-event workflows run from `main`, so this PR has no runtime effect — it only prevents the branch copies from drifting.