### PR TITLE
fix(api): include ConnectionUrl for PXC clusters

### DIFF
--- a/internal/server/handlers/k8s/database_cluster.go
+++ b/internal/server/handlers/k8s/database_cluster.go
@@ -124,6 +124,7 @@ func (h *k8sHandler) GetDatabaseClusterCredentials(ctx context.Context, namespac
 	case everestv1alpha1.DatabaseEnginePXC:
 		response.Username = new("root")
 		response.Password = new(string(secret.Data["root"]))
+		response.ConnectionUrl = h.connectionURL(ctx, databaseCluster, *response.Username, *response.Password)
 	case everestv1alpha1.DatabaseEnginePSMDB:
 		response.Username = new(string(secret.Data["MONGODB_DATABASE_ADMIN_USER"]))
 		response.Password = new(string(secret.Data["MONGODB_DATABASE_ADMIN_PASSWORD"]))

--- a/internal/server/handlers/k8s/database_cluster_test.go
+++ b/internal/server/handlers/k8s/database_cluster_test.go
@@ -454,3 +454,52 @@ func TestCreateDatabaseClusterSecret(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDatabaseClusterCredentials(t *testing.T) {
+	t.Parallel()
+
+	db := &everestv1alpha1.DatabaseCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pxc-cluster",
+			Namespace: "test-ns",
+		},
+		Spec: everestv1alpha1.DatabaseClusterSpec{
+			Engine: everestv1alpha1.Engine{
+				Type:            everestv1alpha1.DatabaseEnginePXC,
+				UserSecretsName: "pxc-secret",
+			},
+		},
+		Status: everestv1alpha1.DatabaseClusterStatus{
+			Hostname: "pxc-host",
+			Port:     3306,
+		},
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pxc-secret",
+			Namespace: "test-ns",
+		},
+		Data: map[string][]byte{
+			"root": []byte("test-password"),
+		},
+	}
+
+	mockClient := fakeclient.NewClientBuilder().
+		WithScheme(kubernetes.CreateScheme()).
+		WithObjects(db, secret).
+		Build()
+
+	k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
+	h := &k8sHandler{kubeConnector: k}
+
+	creds, err := h.GetDatabaseClusterCredentials(context.Background(), "test-ns", "pxc-cluster")
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	require.NotNil(t, creds.Username)
+	require.Equal(t, "root", *creds.Username)
+	require.NotNil(t, creds.Password)
+	require.Equal(t, "test-password", *creds.Password)
+	require.NotNil(t, creds.ConnectionUrl)
+	require.Equal(t, "jdbc:mysql://root:test-password@pxc-host:3306", *creds.ConnectionUrl)
+}


### PR DESCRIPTION
Fixes #2911

### Description
This PR fixes a bug where the API response for Percona XtraDB Clusters (MySQL) was missing the `ConnectionUrl` property, unlike PostgreSQL and MongoDB. The fix ensures that the pre-existing `connectionURL` helper is correctly called and assigned for the PXC engine case.

### Verification
I have run the API tests locally, and the `k8s` handlers package tests pass successfully! 

<details>
<summary>Test Output</summary>

```
    --- PASS: TestValidate_ListPodSchedulingPolicy/empty_policies_hasRules_filter (0.00s)
    --- PASS: TestValidate_ListPodSchedulingPolicy/empty_policies_PSMDB_hasRules_filters (0.00s)
    --- PASS: TestValidate_ListPodSchedulingPolicy/default_policies_PSMDB_hasRules_filters (0.00s)
    --- PASS: TestValidate_ListPodSchedulingPolicy/default_policies_PXC_hasRules_filters (0.00s)
    --- PASS: TestValidate_ListPodSchedulingPolicy/empty_policies_PostgreSQL_filter (0.00s)
    --- PASS: TestValidate_ListPodSchedulingPolicy/default_policies_PXC_filter (0.00s)
    --- PASS: TestValidate_ListPodSchedulingPolicy/empty_policies_PostgreSQL_hasRules_filters (0.00s)
    --- PASS: TestValidate_ListPodSchedulingPolicy/default_policies_PSMDB_filter (0.00s)
    --- PASS: TestValidate_ListPodSchedulingPolicy/default_policies_without_filter (0.00s)
    --- PASS: TestValidate_ListPodSchedulingPolicy/default_policies_hasRules_filter (0.00s)
    --- PASS: TestValidate_ListPodSchedulingPolicy/empty_policies (0.00s)
    --- PASS: TestValidate_ListPodSchedulingPolicy/empty_policies_PSMDB_filter (0.00s)
    --- PASS: TestValidate_ListPodSchedulingPolicy/empty_policies_PXC_hasRules_filters (0.00s)
PASS
ok  	github.com/percona/everest/internal/server/handlers/k8s	1.176s
```
</details>
