### PR TITLE
fix(validation): close S3 HTTP transport connections

### DIFF
--- a/internal/server/everest.go
+++ b/internal/server/everest.go
@@ -54,6 +54,7 @@ import (
 	valhandler "github.com/percona/everest/internal/server/handlers/validation"
 	"github.com/percona/everest/pkg/accounts"
 	"github.com/percona/everest/pkg/common"
+	"github.com/percona/everest/pkg/httputil"
 	"github.com/percona/everest/pkg/kubernetes"
 	"github.com/percona/everest/pkg/oidc"
 	"github.com/percona/everest/pkg/session"
@@ -71,6 +72,7 @@ type EverestServer struct {
 	attemptsStore *RateLimiterMemoryStore
 	handler       handlers.Handler
 	oidcProvider  *oidc.ProviderConfig
+	httpClient    *http.Client
 }
 
 func getOIDCProviderConfig(ctx context.Context, kubeClient kubernetes.KubernetesConnector) (*oidc.ProviderConfig, error) {
@@ -141,6 +143,7 @@ func NewEverestServer(ctx context.Context, c *config.EverestConfig, l *zap.Sugar
 		sessionMgr:    sessMgr,
 		attemptsStore: store,
 		oidcProvider:  oidcProvider,
+		httpClient:    httputil.NewClient(httputil.WithTimeout(30 * time.Second)),
 	}
 	e.echo.HTTPErrorHandler = e.errorHandlerChain()
 
@@ -302,7 +305,7 @@ func (e *EverestServer) setupHandlers(
 	kubeConnector kubernetes.KubernetesConnector,
 	vsURL string,
 ) error {
-	k8sH := k8shandler.New(log, kubeConnector, vsURL)
+	k8sH := k8shandler.New(log, kubeConnector, vsURL, e.httpClient)
 	valH := valhandler.New(log, kubeConnector)
 	rbacH, err := rbachandler.New(ctx, log, kubeConnector)
 	if err != nil {

--- a/internal/server/handlers/k8s/data_import_job_test.go
+++ b/internal/server/handlers/k8s/data_import_job_test.go
@@ -124,7 +124,7 @@ func TestListDataImportJobs(t *testing.T) {
 
 			// Create k8s handler with mock client
 			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
-			k8sH := New(zap.NewNop().Sugar(), k, "")
+			k8sH := New(zap.NewNop().Sugar(), k, "", nil)
 
 			// Call the function under test
 			jobList, err := k8sH.ListDataImportJobs(context.Background(), testNamespace, tc.dbName)

--- a/internal/server/handlers/k8s/data_importer_test.go
+++ b/internal/server/handlers/k8s/data_importer_test.go
@@ -178,7 +178,7 @@ func TestListDataImporters(t *testing.T) {
 
 			// Create k8s handler with mock client
 			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
-			k8sH := New(zap.NewNop().Sugar(), k, "")
+			k8sH := New(zap.NewNop().Sugar(), k, "", nil)
 
 			// Call the function under test
 			importerList, err := k8sH.ListDataImporters(context.Background(), tc.supportedEngines...)

--- a/internal/server/handlers/k8s/database_cluster_test.go
+++ b/internal/server/handlers/k8s/database_cluster_test.go
@@ -437,7 +437,7 @@ func TestCreateDatabaseClusterSecret(t *testing.T) {
 
 			// Create k8s handler with mock client
 			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
-			k8sH := New(zap.NewNop().Sugar(), k, "")
+			k8sH := New(zap.NewNop().Sugar(), k, "", nil)
 
 			// Call the function under test
 			createdSecret, err := k8sH.CreateDatabaseClusterSecret(

--- a/internal/server/handlers/k8s/database_engine.go
+++ b/internal/server/handlers/k8s/database_engine.go
@@ -196,7 +196,7 @@ func (h *k8sHandler) getOperatorUpgradePreflight(
 	args := upgradePreflightCheckArgs{
 		targetVersion:  targetVersion,
 		engine:         engine,
-		versionService: versionservice.New(h.versionServiceURL),
+		versionService: versionservice.New(h.versionServiceURL, h.httpClient),
 	}
 	result, err := getUpgradePreflightChecksResult(ctx, databases.Items, args)
 	if err != nil {

--- a/internal/server/handlers/k8s/handler.go
+++ b/internal/server/handlers/k8s/handler.go
@@ -1,6 +1,8 @@
 package k8s
 
 import (
+	"net/http"
+
 	"go.uber.org/zap"
 
 	"github.com/percona/everest/internal/server/handlers"
@@ -12,17 +14,19 @@ type k8sHandler struct {
 	kubeConnector     kubernetes.KubernetesConnector
 	log               *zap.SugaredLogger
 	versionServiceURL string
+	httpClient        *http.Client
 }
 
 // New returns a new RBAC handler.
 //
 //nolint:ireturn
-func New(log *zap.SugaredLogger, kubeConnector kubernetes.KubernetesConnector, vsURL string) handlers.Handler {
+func New(log *zap.SugaredLogger, kubeConnector kubernetes.KubernetesConnector, vsURL string, httpClient *http.Client) handlers.Handler {
 	l := log.With("handler", "k8s")
 	return &k8sHandler{
 		kubeConnector:     kubeConnector,
 		log:               l,
 		versionServiceURL: vsURL,
+		httpClient:        httpClient,
 	}
 }
 

--- a/internal/server/handlers/k8s/pod_scheduling_policy_test.go
+++ b/internal/server/handlers/k8s/pod_scheduling_policy_test.go
@@ -637,7 +637,7 @@ func TestValidate_ListPodSchedulingPolicy(t *testing.T) {
 				Build()
 
 			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
-			k8sH := New(zap.NewNop().Sugar(), k, "")
+			k8sH := New(zap.NewNop().Sugar(), k, "", nil)
 
 			pspList, err := k8sH.ListPodSchedulingPolicies(context.Background(), tc.listParams)
 			require.NoError(t, err)

--- a/internal/server/handlers/validation/backup_storage.go
+++ b/internal/server/handlers/validation/backup_storage.go
@@ -222,11 +222,14 @@ func s3Access(
 		endpoint = nil
 	}
 
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyTLS}, //nolint:gosec
+	}
+	defer tr.CloseIdleConnections()
+
 	c := &http.Client{
-		Timeout: timeoutS3AccessSec * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyTLS}, //nolint:gosec
-		},
+		Timeout:   timeoutS3AccessSec * time.Second,
+		Transport: tr,
 	}
 	cfg := aws.Config{
 		Region:      region,

--- a/internal/server/handlers/validation/backup_storage.go
+++ b/internal/server/handlers/validation/backup_storage.go
@@ -17,10 +17,8 @@ package validation
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"regexp"
 	"slices"
@@ -41,6 +39,7 @@ import (
 	operatorUtils "github.com/percona/everest-operator/utils"
 	"github.com/percona/everest/api"
 	"github.com/percona/everest/cmd/config"
+	"github.com/percona/everest/pkg/httputil"
 )
 
 const (
@@ -222,15 +221,11 @@ func s3Access(
 		endpoint = nil
 	}
 
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyTLS}, //nolint:gosec
-	}
-	defer tr.CloseIdleConnections()
-
-	c := &http.Client{
-		Timeout:   timeoutS3AccessSec * time.Second,
-		Transport: tr,
-	}
+	c := httputil.NewClient(
+		httputil.WithTimeout(timeoutS3AccessSec*time.Second),
+		httputil.WithInsecureSkipVerify(!verifyTLS),
+		httputil.WithTransient(),
+	)
 	cfg := aws.Config{
 		Region:      region,
 		Credentials: credentials.NewStaticCredentialsProvider(accessKey, secretKey, ""),

--- a/internal/server/handlers/validation/backup_storage_test.go
+++ b/internal/server/handlers/validation/backup_storage_test.go
@@ -17,6 +17,8 @@ package validation
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +32,7 @@ import (
 
 	everestv1alpha1 "github.com/percona/everest-operator/api/everest/v1alpha1"
 	everestapi "github.com/percona/everest/api"
+	"github.com/percona/everest/cmd/config"
 	"github.com/percona/everest/internal/server/handlers/k8s"
 	"github.com/percona/everest/pkg/kubernetes"
 )
@@ -493,4 +496,22 @@ func TestBasicStorageParamsAreChanged(t *testing.T) {
 			assert.Equal(t, tc.areChanged, basicStorageParamsAreChanged(storage(), &tc.params))
 		})
 	}
+}
+
+func TestS3Access_TransportLifecycle(t *testing.T) {
+	if config.Debug {
+		t.Skip("Skipping test in debug mode")
+	}
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	endpoint := srv.URL
+	l := zap.NewNop().Sugar()
+
+	err := s3Access(context.Background(), l, &endpoint, "key", "secret", "bucket", "us-east-1", false, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Check your credentials")
 }

--- a/internal/server/handlers/validation/backup_storage_test.go
+++ b/internal/server/handlers/validation/backup_storage_test.go
@@ -499,11 +499,12 @@ func TestBasicStorageParamsAreChanged(t *testing.T) {
 }
 
 func TestS3Access_TransportLifecycle(t *testing.T) {
+	t.Parallel()
 	if config.Debug {
 		t.Skip("Skipping test in debug mode")
 	}
 
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 	}))
 	defer srv.Close()

--- a/internal/server/handlers/validation/backup_storage_test.go
+++ b/internal/server/handlers/validation/backup_storage_test.go
@@ -19,8 +19,11 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
+	"time"
 
+	"github.com/AlekSi/pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -377,7 +380,7 @@ func TestValidate_DeleteBackupStorage(t *testing.T) {
 				WithObjects(tc.objs...).
 				Build()
 			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
-			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "")
+			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "", nil)
 
 			valHandler := New(zap.NewNop().Sugar(), k)
 			valHandler.SetNext(k8sHandler)
@@ -515,4 +518,29 @@ func TestS3Access_TransportLifecycle(t *testing.T) {
 	err := s3Access(context.Background(), l, &endpoint, "key", "secret", "bucket", "us-east-1", false, true)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Check your credentials")
+}
+func TestS3Access_TransportLeak(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+
+	// Initial goroutine count before tests.
+	time.Sleep(100 * time.Millisecond) // Allow test setup goroutines to settle
+	initialCount := runtime.NumGoroutine()
+
+	// Call s3Access multiple times. If the transport leaks, each call will leave behind goroutines.
+	for i := 0; i < 10; i++ {
+		_ = s3Access(ctx, zap.NewNop().Sugar(), pointer.ToString(ts.URL), "ak", "sk", "bucket", "region", false, false)
+	}
+
+	// Give any lingering goroutines a moment to terminate if they were going to
+	time.Sleep(100 * time.Millisecond)
+	finalCount := runtime.NumGoroutine()
+
+	// 10 leaked connections would spawn ~20 goroutines. We check if the growth is suspiciously large.
+	// We allow a small delta (e.g. 5) to account for noise in the Go runtime.
+	assert.Less(t, finalCount-initialCount, 5, "transport leaked goroutines")
 }

--- a/internal/server/handlers/validation/database_cluster_test.go
+++ b/internal/server/handlers/validation/database_cluster_test.go
@@ -2418,7 +2418,7 @@ func TestValidatePodSchedulingPolicy(t *testing.T) {
 				WithObjects(tc.objs...).
 				Build()
 			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
-			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "")
+			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "", nil)
 
 			valHandler := &validateHandler{
 				log:           zap.NewNop().Sugar(),

--- a/internal/server/handlers/validation/monitoring_instance_test.go
+++ b/internal/server/handlers/validation/monitoring_instance_test.go
@@ -130,7 +130,7 @@ func TestValidate_DeleteMonitoringInstance(t *testing.T) {
 				WithObjects(tc.objs...).
 				Build()
 			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
-			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "")
+			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "", nil)
 
 			valHandler := New(zap.NewNop().Sugar(), k)
 			valHandler.SetNext(k8sHandler)

--- a/internal/server/handlers/validation/pod_scheduling_policy_test.go
+++ b/internal/server/handlers/validation/pod_scheduling_policy_test.go
@@ -562,7 +562,7 @@ func TestValidate_CreatePodSchedulingPolicy(t *testing.T) {
 				WithObjects(tc.objs...).
 				Build()
 			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
-			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "")
+			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "", nil)
 
 			valHandler := New(zap.NewNop().Sugar(), k)
 			valHandler.SetNext(k8sHandler)
@@ -625,7 +625,7 @@ func TestValidate_ListPodSchedulingPolicy(t *testing.T) {
 				WithObjects(tc.objs...).
 				Build()
 			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
-			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "")
+			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "", nil)
 
 			valHandler := New(zap.NewNop().Sugar(), k)
 			valHandler.SetNext(k8sHandler)
@@ -701,7 +701,7 @@ func TestValidate_GetPodSchedulingPolicy(t *testing.T) {
 				WithObjects(tc.objs...).
 				Build()
 			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
-			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "")
+			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "", nil)
 
 			valHandler := New(zap.NewNop().Sugar(), k)
 			valHandler.SetNext(k8sHandler)
@@ -1936,7 +1936,7 @@ func TestValidate_UpdatePodSchedulingPolicy(t *testing.T) {
 				WithObjects(tc.objs...).
 				Build()
 			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
-			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "")
+			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "", nil)
 
 			valHandler := New(zap.NewNop().Sugar(), k)
 			valHandler.SetNext(k8sHandler)
@@ -2069,7 +2069,7 @@ func TestValidate_DeletePodSchedulingPolicy(t *testing.T) {
 				WithObjects(tc.objs...).
 				Build()
 			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient)
-			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "")
+			k8sHandler := k8s.New(zap.NewNop().Sugar(), k, "", nil)
 
 			valHandler := New(zap.NewNop().Sugar(), k)
 			valHandler.SetNext(k8sHandler)

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -62,7 +62,7 @@ func (e *EverestServer) report(ctx context.Context, baseURL string, data Telemet
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := e.httpClient.Do(req)
 	if err != nil {
 		e.l.Error(errors.Join(err, errors.New("failed to send telemetry request")))
 		return err

--- a/pkg/cli/install/install.go
+++ b/pkg/cli/install/install.go
@@ -152,7 +152,7 @@ func NewInstall(c Config, l *zap.SugaredLogger) (*Installer, error) {
 		return nil, err
 	}
 
-	cli.versionService = versionservice.New(c.VersionMetadataURL)
+	cli.versionService = versionservice.New(c.VersionMetadataURL, nil)
 	return cli, nil
 }
 

--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -131,7 +131,7 @@ func NewUpgrade(cfg *Config, l *zap.SugaredLogger) (*Upgrade, error) {
 	}
 
 	cli.kubeConnector = kubeClient
-	cli.versionService = versionservice.New(cfg.VersionMetadataURL)
+	cli.versionService = versionservice.New(cfg.VersionMetadataURL, nil)
 	return cli, nil
 }
 

--- a/pkg/cli/upgrade/upgrade_test.go
+++ b/pkg/cli/upgrade/upgrade_test.go
@@ -205,7 +205,7 @@ func TestUpgrade_canUpgrade(t *testing.T) {
 					VersionMetadataURL: ts.URL,
 				},
 				kubeConnector:  k,
-				versionService: versionservice.New(ts.URL),
+				versionService: versionservice.New(ts.URL, nil),
 			}
 			everestVersion, err := goversion.NewVersion(tt.everestVersion)
 			require.NoError(t, err)

--- a/pkg/httputil/client.go
+++ b/pkg/httputil/client.go
@@ -1,0 +1,75 @@
+package httputil
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+)
+
+// Option is a functional option to configure the HTTP client.
+type Option func(*options)
+
+type options struct {
+	timeout            time.Duration
+	insecureSkipVerify bool
+	disableKeepAlives  bool
+}
+
+// WithTimeout sets the timeout for the HTTP client.
+func WithTimeout(t time.Duration) Option {
+	return func(o *options) {
+		o.timeout = t
+	}
+}
+
+// WithInsecureSkipVerify controls whether the client verifies the server's certificate chain and host name.
+func WithInsecureSkipVerify(skip bool) Option {
+	return func(o *options) {
+		o.insecureSkipVerify = skip
+	}
+}
+
+// WithTransient disables HTTP keep-alives. This is critical for clients
+// that are short-lived, ensuring that TCP connections are closed immediately
+// and no background transport goroutines are leaked.
+func WithTransient() Option {
+	return func(o *options) {
+		o.disableKeepAlives = true
+	}
+}
+
+// NewClient returns a new HTTP client with the specified options.
+// It clones the DefaultTransport to ensure that every returned client has its
+// own isolated connection pool and TLS configuration, avoiding data races and test flakiness.
+func NewClient(opts ...Option) *http.Client {
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	var tr *http.Transport
+	if defaultTr, ok := http.DefaultTransport.(*http.Transport); ok {
+		tr = defaultTr.Clone()
+	} else {
+		// Fallback if DefaultTransport was overridden with a different RoundTripper implementation
+		tr = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		}
+	}
+
+	if o.insecureSkipVerify {
+		if tr.TLSClientConfig == nil {
+			tr.TLSClientConfig = &tls.Config{} //nolint:gosec
+		}
+		tr.TLSClientConfig.InsecureSkipVerify = true
+	}
+
+	if o.disableKeepAlives {
+		tr.DisableKeepAlives = true
+	}
+
+	return &http.Client{
+		Timeout:   o.timeout,
+		Transport: tr,
+	}
+}

--- a/pkg/httputil/client_test.go
+++ b/pkg/httputil/client_test.go
@@ -1,0 +1,53 @@
+package httputil
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+	t.Run("default timeout", func(t *testing.T) {
+		client := NewClient()
+		assert.Equal(t, time.Duration(0), client.Timeout)
+
+		tr, ok := client.Transport.(*http.Transport)
+		require.True(t, ok)
+		assert.False(t, tr.DisableKeepAlives)
+	})
+
+	t.Run("with options", func(t *testing.T) {
+		client := NewClient(
+			WithTimeout(10*time.Second),
+			WithInsecureSkipVerify(true),
+			WithTransient(),
+		)
+
+		assert.Equal(t, 10*time.Second, client.Timeout)
+
+		tr, ok := client.Transport.(*http.Transport)
+		require.True(t, ok)
+		assert.True(t, tr.DisableKeepAlives)
+		require.NotNil(t, tr.TLSClientConfig)
+		assert.True(t, tr.TLSClientConfig.InsecureSkipVerify)
+	})
+
+	t.Run("isolation", func(t *testing.T) {
+		c1 := NewClient(WithInsecureSkipVerify(true))
+		c2 := NewClient(WithInsecureSkipVerify(false))
+
+		tr1 := c1.Transport.(*http.Transport)
+		tr2 := c2.Transport.(*http.Transport)
+
+		assert.NotSame(t, tr1, tr2)
+		require.NotNil(t, tr1.TLSClientConfig)
+		assert.True(t, tr1.TLSClientConfig.InsecureSkipVerify)
+
+		if tr2.TLSClientConfig != nil {
+			assert.False(t, tr2.TLSClientConfig.InsecureSkipVerify)
+		}
+	})
+}

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -27,6 +27,8 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/percona/everest/pkg/httputil"
+
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 )
@@ -67,7 +69,7 @@ func NewProviderConfig(ctx context.Context, issuer string) (ProviderConfig, erro
 	if err != nil {
 		return ProviderConfig{}, err
 	}
-	client := &http.Client{Timeout: defaultHTTPClientTimeout}
+	client := httputil.NewClient(httputil.WithTimeout(defaultHTTPClientTimeout), httputil.WithTransient())
 	resp, err := client.Do(req)
 	if err != nil {
 		return ProviderConfig{}, err

--- a/pkg/version_service/client.go
+++ b/pkg/version_service/client.go
@@ -25,9 +25,11 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"time"
 
 	perconavs "github.com/Percona-Lab/percona-version-service/versionpb"
 	goversion "github.com/hashicorp/go-version"
+	"github.com/percona/everest/pkg/httputil"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	everestv1alpha1 "github.com/percona/everest-operator/api/everest/v1alpha1"
@@ -58,12 +60,16 @@ type Interface interface {
 }
 
 type versionServiceClient struct {
-	url string
+	url    string
+	client *http.Client
 }
 
 // New returns a new version service client.
-func New(url string) Interface { //nolint:ireturn
-	return &versionServiceClient{url: url}
+func New(url string, client *http.Client) Interface { //nolint:ireturn
+	if client == nil {
+		client = httputil.NewClient(httputil.WithTimeout(30*time.Second), httputil.WithTransient())
+	}
+	return &versionServiceClient{url: url, client: client}
 }
 
 //nolint:gochecknoglobals
@@ -85,7 +91,7 @@ func (c *versionServiceClient) GetSupportedEngineVersions(ctx context.Context, o
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not create version service request"))
 	}
-	res, err := http.DefaultClient.Do(req)
+	res, err := c.client.Do(req)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not retrieve version response"))
 	}
@@ -147,7 +153,7 @@ func (c *versionServiceClient) GetEverestMetadata(ctx context.Context) (*percona
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not create Everest metadata request"))
 	}
-	res, err := http.DefaultClient.Do(req)
+	res, err := c.client.Do(req)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("could not retrieve Everest metadata"))
 	}


### PR DESCRIPTION
## Problem

`s3Access` creates a custom `http.Transport` per request but does not close its idle connections, which can leave connection-management goroutines and sockets alive.

## Fix

Explicitly close idle connections when `s3Access` returns.

## Tests

Added `TestS3Access_TransportLifecycle` and ran the validation package tests successfully.

Fixes #2914