### PR TITLE
Fix: Validate TELEMETRY_INTERVAL at startup to prevent DoS loop

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -19,7 +19,9 @@ package config
 
 import (
 	"crypto/aes"
+	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 )
@@ -63,6 +65,22 @@ type EverestConfig struct {
 	TLSCertsPath string `envconfig:"TLS_CERTS_PATH"`
 }
 
+// validateTelemetryInterval parses s as a time.Duration and rejects
+// non-positive values. An empty string is allowed (telemetry will not run).
+func validateTelemetryInterval(s string) error {
+	if s == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("invalid TELEMETRY_INTERVAL %q: %w", s, err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("TELEMETRY_INTERVAL must be greater than 0, got %q", s)
+	}
+	return nil
+}
+
 // ParseConfig parses env vars and fills EverestConfig.
 func ParseConfig() (*EverestConfig, error) {
 	c := &EverestConfig{}
@@ -76,6 +94,10 @@ func ParseConfig() (*EverestConfig, error) {
 	}
 	if c.TelemetryInterval == "" {
 		c.TelemetryInterval = TelemetryInterval
+	}
+
+	if err := validateTelemetryInterval(c.TelemetryInterval); err != nil {
+		return nil, err
 	}
 
 	if c.TLSCertsPath != "" {

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTelemetryInterval(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "valid: 24h",
+			input: "24h",
+		},
+		{
+			name:  "valid: 1h",
+			input: "1h",
+		},
+		{
+			name:  "valid: 10s",
+			input: "10s",
+		},
+		{
+			name:  "valid: empty string",
+			input: "",
+		},
+		{
+			name:    "invalid: zero duration",
+			input:   "0s",
+			wantErr: true,
+			errMsg:  "must be greater than 0",
+		},
+		{
+			name:    "invalid: negative duration",
+			input:   "-1m",
+			wantErr: true,
+			errMsg:  "must be greater than 0",
+		},
+		{
+			name:    "invalid: negative hours",
+			input:   "-24h",
+			wantErr: true,
+			errMsg:  "must be greater than 0",
+		},
+		{
+			name:    "invalid: typo",
+			input:   "5mn",
+			wantErr: true,
+			errMsg:  "invalid TELEMETRY_INTERVAL",
+		},
+		{
+			name:    "invalid: garbage",
+			input:   "abc",
+			wantErr: true,
+			errMsg:  "invalid TELEMETRY_INTERVAL",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateTelemetryInterval(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR fixes a bug where providing a zero (`0s`), negative, or unparseable `TELEMETRY_INTERVAL` would cause the telemetry background job to enter a tight loop, leading to an API server DoS and rapid log exhaustion.

Per discussion in #2831 and guidance from @recharte in PR #2225, this fix is intentionally scoped to the configuration parsing layer (`cmd/config/config.go`) rather than modifying the telemetry runner logic, ensuring we fail fast at startup for bad configurations without colliding with other telemetry refactors.

## Changes
- Extracted a `validateTelemetryInterval()` helper that rejects non-positive durations (`<= 0`) and unparseable strings.
- Added a validation call in `ParseConfig()` right after the environment variable / ldflags fallback logic.
- An empty string (`""`) remains valid (acting as a no-op / disabled telemetry) to prevent breaking dev builds that don't set ldflags.
- Added comprehensive table-driven tests (`cmd/config/config_test.go`) covering valid, zero, negative, and malformed inputs.

## Validation
- [x] Local `make check` (golangci-lint) passes.
- [x] Local `make test` (with `-race`) passes for `cmd/config`.
- [x] `make copyright-check` passes for the new test file.
- [x] Tested that `ParseConfig` correctly surfaces `fmt.Errorf` on invalid intervals.

Fixes #2831