### PR TITLE
Fixes #2908: Remove IncreaseTimeout call from DeleteSession

### DIFF
--- a/internal/server/session.go
+++ b/internal/server/session.go
@@ -69,7 +69,6 @@ func (e *EverestServer) CreateSession(ctx echo.Context) error {
 
 // DeleteSession invalidates the user token by adding it to the blocklist.
 func (e *EverestServer) DeleteSession(ctx echo.Context) error {
-	e.attemptsStore.IncreaseTimeout(ctx.RealIP())
 	c := ctx.Request().Context()
 	token, err := common.ExtractToken(c)
 	if err != nil {


### PR DESCRIPTION
Fixes #2908 

**What is the issue?**
Currently, `DeleteSession` unconditionally calls `e.attemptsStore.IncreaseTimeout(ctx.RealIP())` on every logout. Because this shares the same IP-keyed rate limiter as failed logins, repeated logouts from a shared IP (like a corporate proxy or NAT) will quickly push the timeout window to its limit, completely blocking all logins from that IP for hours despite having zero failed attempts. 

**What does this PR do?**
This PR removes the `IncreaseTimeout` call from `DeleteSession` entirely, ensuring that timeouts only increase upon actual failed login attempts within `CreateSession`. 
