### PR TITLE
fix: use v2 Backup/Restore kinds in the event stream

### DIFF
--- a/pkg/events/normalizer.go
+++ b/pkg/events/normalizer.go
@@ -26,7 +26,7 @@ import (
 	"github.com/openeverest/openeverest/v2/pkg/common"
 )
 
-// NormalizeBackup converts a kube watch event on a DatabaseClusterBackup.
+// NormalizeBackup converts a kube watch event on a Backup.
 func NormalizeBackup(we watch.Event, old *backupv1alpha1.Backup) []Event {
 	obj, ok := we.Object.(*backupv1alpha1.Backup)
 	if !ok {
@@ -34,7 +34,7 @@ func NormalizeBackup(we watch.Event, old *backupv1alpha1.Backup) []Event {
 	}
 
 	ref := ResourceRef{
-		Kind: "DatabaseClusterBackup",
+		Kind: "Backup",
 		Name: obj.Name,
 		UID:  string(obj.UID),
 	}
@@ -93,7 +93,7 @@ func NormalizeBackup(we watch.Event, old *backupv1alpha1.Backup) []Event {
 	return out
 }
 
-// NormalizeRestore converts a kube watch event on a DatabaseClusterRestore.
+// NormalizeRestore converts a kube watch event on a Restore.
 func NormalizeRestore(we watch.Event, old *backupv1alpha1.Restore) []Event {
 	obj, ok := we.Object.(*backupv1alpha1.Restore)
 	if !ok {
@@ -101,7 +101,7 @@ func NormalizeRestore(we watch.Event, old *backupv1alpha1.Restore) []Event {
 	}
 
 	ref := ResourceRef{
-		Kind: "DatabaseClusterRestore",
+		Kind: "Restore",
 		Name: obj.Name,
 		UID:  string(obj.UID),
 	}

--- a/pkg/events/normalizer_test.go
+++ b/pkg/events/normalizer_test.go
@@ -17,6 +17,8 @@ package events
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -93,7 +95,7 @@ func TestNormalizeBackup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := NormalizeBackup(watch.Event{Type: tt.eventType, Object: tt.obj}, tt.old)
-			assertNormalizeEnvelope(t, got, tt.wantEmpty, tt.wantType, kind)
+			assertNormalizeEnvelope(t, got, tt.wantEmpty, tt.wantType, kind, name, ns, uid)
 		})
 	}
 }
@@ -167,26 +169,21 @@ func TestNormalizeRestore(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := NormalizeRestore(watch.Event{Type: tt.eventType, Object: tt.obj}, tt.old)
-			assertNormalizeEnvelope(t, got, tt.wantEmpty, tt.wantType, kind)
+			assertNormalizeEnvelope(t, got, tt.wantEmpty, tt.wantType, kind, name, ns, uid)
 		})
 	}
 }
 
-func assertNormalizeEnvelope(t *testing.T, got []Event, wantEmpty bool, wantType Type, wantKind string) {
+func assertNormalizeEnvelope(t *testing.T, got []Event, wantEmpty bool, wantType Type, wantKind, wantName, wantNS, wantUID string) {
 	t.Helper()
 	if wantEmpty {
-		if len(got) != 0 {
-			t.Fatalf("expected no events, got %d (%s)", len(got), got[0].Type)
-		}
+		assert.Empty(t, got)
 		return
 	}
-	if len(got) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(got))
-	}
-	if got[0].Type != wantType {
-		t.Fatalf("Type: got %s, want %s", got[0].Type, wantType)
-	}
-	if got[0].Resource.Kind != wantKind {
-		t.Fatalf("Resource.Kind: got %q, want %q", got[0].Resource.Kind, wantKind)
-	}
+	require.Len(t, got, 1)
+	assert.Equal(t, wantType, got[0].Type)
+	assert.Equal(t, wantKind, got[0].Resource.Kind)
+	assert.Equal(t, wantName, got[0].Resource.Name)
+	assert.Equal(t, wantUID, got[0].Resource.UID)
+	assert.Equal(t, wantNS, got[0].Namespace)
 }

--- a/pkg/events/normalizer_test.go
+++ b/pkg/events/normalizer_test.go
@@ -1,0 +1,192 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+
+	backupv1alpha1 "github.com/openeverest/openeverest/v2/api/backup/v1alpha1"
+)
+
+func TestNormalizeBackup(t *testing.T) {
+	t.Parallel()
+
+	const (
+		kind = "Backup"
+		name = "b1"
+		ns   = "team-a"
+		uid  = "backup-uid"
+	)
+
+	backup := func(state backupv1alpha1.BackupState) *backupv1alpha1.Backup {
+		return &backupv1alpha1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				UID:       types.UID(uid),
+			},
+			Status: backupv1alpha1.BackupStatus{State: state},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		eventType watch.EventType
+		obj       *backupv1alpha1.Backup
+		old       *backupv1alpha1.Backup
+		wantType  Type
+		wantEmpty bool
+	}{
+		{
+			name:      "Added emits backup.started",
+			eventType: watch.Added,
+			obj:       backup(backupv1alpha1.BackupStatePending),
+			wantType:  BackupStarted,
+		},
+		{
+			name:      "Modified into Succeeded emits backup.completed",
+			eventType: watch.Modified,
+			old:       backup(backupv1alpha1.BackupStateRunning),
+			obj:       backup(backupv1alpha1.BackupStateSucceeded),
+			wantType:  BackupCompleted,
+		},
+		{
+			name:      "repeated Succeeded emits nothing",
+			eventType: watch.Modified,
+			old:       backup(backupv1alpha1.BackupStateSucceeded),
+			obj:       backup(backupv1alpha1.BackupStateSucceeded),
+			wantEmpty: true,
+		},
+		{
+			name:      "Modified into Failed emits backup.failed",
+			eventType: watch.Modified,
+			old:       backup(backupv1alpha1.BackupStateRunning),
+			obj:       backup(backupv1alpha1.BackupStateFailed),
+			wantType:  BackupFailed,
+		},
+		{
+			name:      "repeated Failed emits nothing",
+			eventType: watch.Modified,
+			old:       backup(backupv1alpha1.BackupStateFailed),
+			obj:       backup(backupv1alpha1.BackupStateFailed),
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NormalizeBackup(watch.Event{Type: tt.eventType, Object: tt.obj}, tt.old)
+			assertNormalizeEnvelope(t, got, tt.wantEmpty, tt.wantType, kind)
+		})
+	}
+}
+
+func TestNormalizeRestore(t *testing.T) {
+	t.Parallel()
+
+	const (
+		kind = "Restore"
+		name = "r1"
+		ns   = "team-a"
+		uid  = "restore-uid"
+	)
+
+	restore := func(state backupv1alpha1.RestoreState) *backupv1alpha1.Restore {
+		return &backupv1alpha1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				UID:       types.UID(uid),
+			},
+			Status: backupv1alpha1.RestoreStatus{State: state},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		eventType watch.EventType
+		obj       *backupv1alpha1.Restore
+		old       *backupv1alpha1.Restore
+		wantType  Type
+		wantEmpty bool
+	}{
+		{
+			name:      "Added emits restore.started",
+			eventType: watch.Added,
+			obj:       restore(backupv1alpha1.RestoreStatePending),
+			wantType:  RestoreStarted,
+		},
+		{
+			name:      "Modified into Succeeded emits restore.completed",
+			eventType: watch.Modified,
+			old:       restore(backupv1alpha1.RestoreStateRunning),
+			obj:       restore(backupv1alpha1.RestoreStateSucceeded),
+			wantType:  RestoreCompleted,
+		},
+		{
+			name:      "repeated Succeeded emits nothing",
+			eventType: watch.Modified,
+			old:       restore(backupv1alpha1.RestoreStateSucceeded),
+			obj:       restore(backupv1alpha1.RestoreStateSucceeded),
+			wantEmpty: true,
+		},
+		{
+			name:      "Modified into Failed emits restore.failed",
+			eventType: watch.Modified,
+			old:       restore(backupv1alpha1.RestoreStateRunning),
+			obj:       restore(backupv1alpha1.RestoreStateFailed),
+			wantType:  RestoreFailed,
+		},
+		{
+			name:      "repeated Failed emits nothing",
+			eventType: watch.Modified,
+			old:       restore(backupv1alpha1.RestoreStateFailed),
+			obj:       restore(backupv1alpha1.RestoreStateFailed),
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NormalizeRestore(watch.Event{Type: tt.eventType, Object: tt.obj}, tt.old)
+			assertNormalizeEnvelope(t, got, tt.wantEmpty, tt.wantType, kind)
+		})
+	}
+}
+
+func assertNormalizeEnvelope(t *testing.T, got []Event, wantEmpty bool, wantType Type, wantKind string) {
+	t.Helper()
+	if wantEmpty {
+		if len(got) != 0 {
+			t.Fatalf("expected no events, got %d (%s)", len(got), got[0].Type)
+		}
+		return
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(got))
+	}
+	if got[0].Type != wantType {
+		t.Fatalf("Type: got %s, want %s", got[0].Type, wantType)
+	}
+	if got[0].Resource.Kind != wantKind {
+		t.Fatalf("Resource.Kind: got %q, want %q", got[0].Resource.Kind, wantKind)
+	}
+}

--- a/pkg/kubernetes/kubernetes_interface.gen.go
+++ b/pkg/kubernetes/kubernetes_interface.gen.go
@@ -6,12 +6,6 @@ import (
 	"context"
 
 	goversion "github.com/hashicorp/go-version"
-	backupv1alpha1 "github.com/openeverest/openeverest/v2/api/backup/v1alpha1"
-	"github.com/openeverest/openeverest/v2/api/core/v1alpha1"
-	extensionsv1alpha1 "github.com/openeverest/openeverest/v2/api/extensions/v1alpha1"
-	monitoringv1alpha1 "github.com/openeverest/openeverest/v2/api/monitoring/v1alpha1"
-	"github.com/openeverest/openeverest/v2/pkg/accounts"
-	"github.com/openeverest/openeverest/v2/pkg/common"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	enginefeaturesv1alpha1 "github.com/percona/everest-operator/api/enginefeatures.everest/v1alpha1"
 	everestv1alpha1 "github.com/percona/everest-operator/api/everest/v1alpha1"
@@ -24,6 +18,13 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	backupv1alpha1 "github.com/openeverest/openeverest/v2/api/backup/v1alpha1"
+	"github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	extensionsv1alpha1 "github.com/openeverest/openeverest/v2/api/extensions/v1alpha1"
+	monitoringv1alpha1 "github.com/openeverest/openeverest/v2/api/monitoring/v1alpha1"
+	"github.com/openeverest/openeverest/v2/pkg/accounts"
+	"github.com/openeverest/openeverest/v2/pkg/common"
 )
 
 // KubernetesConnector ...

--- a/pkg/kubernetes/kubernetes_interface.gen.go
+++ b/pkg/kubernetes/kubernetes_interface.gen.go
@@ -6,6 +6,12 @@ import (
 	"context"
 
 	goversion "github.com/hashicorp/go-version"
+	backupv1alpha1 "github.com/openeverest/openeverest/v2/api/backup/v1alpha1"
+	"github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	extensionsv1alpha1 "github.com/openeverest/openeverest/v2/api/extensions/v1alpha1"
+	monitoringv1alpha1 "github.com/openeverest/openeverest/v2/api/monitoring/v1alpha1"
+	"github.com/openeverest/openeverest/v2/pkg/accounts"
+	"github.com/openeverest/openeverest/v2/pkg/common"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	enginefeaturesv1alpha1 "github.com/percona/everest-operator/api/enginefeatures.everest/v1alpha1"
 	everestv1alpha1 "github.com/percona/everest-operator/api/everest/v1alpha1"
@@ -18,13 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	backupv1alpha1 "github.com/openeverest/openeverest/v2/api/backup/v1alpha1"
-	"github.com/openeverest/openeverest/v2/api/core/v1alpha1"
-	extensionsv1alpha1 "github.com/openeverest/openeverest/v2/api/extensions/v1alpha1"
-	monitoringv1alpha1 "github.com/openeverest/openeverest/v2/api/monitoring/v1alpha1"
-	"github.com/openeverest/openeverest/v2/pkg/accounts"
-	"github.com/openeverest/openeverest/v2/pkg/common"
 )
 
 // KubernetesConnector ...
@@ -374,10 +373,10 @@ type KubernetesConnector interface {
 	// GetInstancePreset returns instance preset that matches the criteria.
 	GetInstancePreset(ctx context.Context, key ctrlclient.ObjectKey) (*v1alpha1.InstancePreset, error)
 	// WatchBackups returns a watch.Interface that streams
-	// DatabaseClusterBackup events across all namespaces.
+	// Backup events across all namespaces.
 	WatchBackups(ctx context.Context) (watch.Interface, error)
 	// WatchRestores returns a watch.Interface that streams
-	// DatabaseClusterRestore events across all namespaces.
+	// Restore events across all namespaces.
 	WatchRestores(ctx context.Context) (watch.Interface, error)
 	// WatchInstances returns a watch.Interface that streams
 	// Instance events across all namespaces.

--- a/pkg/kubernetes/watch.go
+++ b/pkg/kubernetes/watch.go
@@ -29,13 +29,13 @@ import (
 )
 
 // WatchBackups returns a watch.Interface that streams
-// DatabaseClusterBackup events across all namespaces.
+// Backup events across all namespaces.
 func (k *Kubernetes) WatchBackups(ctx context.Context) (watch.Interface, error) {
 	return k.watchList(ctx, &backupv1alpha1.BackupList{})
 }
 
 // WatchRestores returns a watch.Interface that streams
-// DatabaseClusterRestore events across all namespaces.
+// Restore events across all namespaces.
 func (k *Kubernetes) WatchRestores(ctx context.Context) (watch.Interface, error) {
 	return k.watchList(ctx, &backupv1alpha1.RestoreList{})
 }


### PR DESCRIPTION
## Summary
- ``NormalizeBackup`` / ``NormalizeRestore`` watched v2 Backup/Restore CRs but stamped ``resource.kind`` as ``DatabaseClusterBackup`` / ``DatabaseClusterRestore``.
- Set kind to ``Backup`` / ``Restore`` (same pattern as ``Instance``).
## Test plan
- [ ] CI green on ``release-2.0``
- [ ] Confirm backup/restore events carry ``resource.kind`` of ``Backup`` / ``Restore``
Fixes #2909 