### PR TITLE
fix(accounts): resolve read-modify-write race condition in account management (release-2.0)

### DIFF
--- a/pkg/cli/backupstorage/delete_test.go
+++ b/pkg/cli/backupstorage/delete_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -356,7 +357,11 @@ func TestDelete_WaitTimesOut(t *testing.T) {
 	d := NewDeleter(Config{}, zap.NewNop().Sugar())
 	err := d.Run(context.Background(), opts, cfgPath)
 	require.Error(t, err)
-	require.ErrorIs(t, err, wait.ErrTimeout)
+	// Tolerate occasional "CloseIdleConnections called" from parallel httptest tear-downs
+	// closing http.DefaultTransport connections.
+	if !strings.Contains(err.Error(), "CloseIdleConnections") {
+		require.ErrorIs(t, err, wait.ErrTimeout)
+	}
 }
 
 // TestDelete_IgnoreNotFound_AlreadyGone_JSONOutput proves the short-circuit

--- a/pkg/cli/backupstorage/delete_test.go
+++ b/pkg/cli/backupstorage/delete_test.go
@@ -23,7 +23,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -357,11 +356,7 @@ func TestDelete_WaitTimesOut(t *testing.T) {
 	d := NewDeleter(Config{}, zap.NewNop().Sugar())
 	err := d.Run(context.Background(), opts, cfgPath)
 	require.Error(t, err)
-	// Tolerate occasional "CloseIdleConnections called" from parallel httptest tear-downs
-	// closing http.DefaultTransport connections.
-	if !strings.Contains(err.Error(), "CloseIdleConnections") {
-		require.ErrorIs(t, err, wait.ErrTimeout)
-	}
+	require.ErrorIs(t, err, wait.ErrTimeout)
 }
 
 // TestDelete_IgnoreNotFound_AlreadyGone_JSONOutput proves the short-circuit

--- a/pkg/kubernetes/accounts.go
+++ b/pkg/kubernetes/accounts.go
@@ -27,7 +27,9 @@ import (
 
 	"golang.org/x/crypto/pbkdf2"
 	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/openeverest/openeverest/v2/pkg/accounts"
 	"github.com/openeverest/openeverest/v2/pkg/common"
@@ -72,14 +74,6 @@ func (a *configMapsClient) List(ctx context.Context) (map[string]*accounts.Accou
 
 // Create a new user account.
 func (a *configMapsClient) Create(ctx context.Context, username, password string) error {
-	// Ensure that the user does not already exist.
-	_, err := a.Get(ctx, username)
-	if err != nil && !errors.Is(err, accounts.ErrAccountNotFound) {
-		return errors.Join(err, errors.New("failed to check if account already exists"))
-	} else if err == nil {
-		return accounts.ErrUserAlreadyExists
-	}
-
 	if password == "" {
 		return errors.New("password cannot be empty")
 	}
@@ -90,58 +84,48 @@ func (a *configMapsClient) Create(ctx context.Context, username, password string
 		return errors.Join(err, errors.New("failed to compute hash"))
 	}
 
-	account := &accounts.Account{
-		Enabled:       true,
-		Capabilities:  []accounts.AccountCapability{accounts.AccountCapabilityLogin},
-		PasswordMtime: time.Now().Format(time.RFC3339),
-		PasswordHash:  hash,
-	}
-	return a.insertOrUpdateAccount(ctx, username, account, true)
+	return a.insertOrUpdateAccount(ctx, username, true, func(existing *accounts.Account) (*accounts.Account, error) {
+		if existing != nil {
+			return nil, accounts.ErrUserAlreadyExists
+		}
+		return &accounts.Account{
+			Enabled:       true,
+			Capabilities:  []accounts.AccountCapability{accounts.AccountCapabilityLogin},
+			PasswordMtime: time.Now().Format(time.RFC3339),
+			PasswordHash:  hash,
+		}, nil
+	})
 }
 
 // SetPassword sets a new password for an existing user account.
 func (a *configMapsClient) SetPassword(ctx context.Context, username, newPassword string, secure bool) error {
-	user, err := a.Get(ctx, username)
-	if err != nil {
-		return err
-	}
-	user.PasswordHash = newPassword
-	if secure {
-		pwHash, err := a.computePasswordHash(ctx, newPassword)
-		if err != nil {
-			return err
+	return a.insertOrUpdateAccount(ctx, username, secure, func(existing *accounts.Account) (*accounts.Account, error) {
+		if existing == nil {
+			return nil, accounts.ErrAccountNotFound
 		}
-		user.PasswordHash = pwHash
-	}
-	user.PasswordMtime = time.Now().Format(time.RFC3339)
-	return a.insertOrUpdateAccount(ctx, username, user, secure)
+		existing.PasswordHash = newPassword
+		if secure {
+			pwHash, err := a.computePasswordHash(ctx, newPassword)
+			if err != nil {
+				return nil, err
+			}
+			existing.PasswordHash = pwHash
+		}
+		existing.PasswordMtime = time.Now().Format(time.RFC3339)
+		return existing, nil
+	})
 }
 
 // Delete an existing user account specified by username.
 func (a *configMapsClient) Delete(ctx context.Context, username string) error {
-	users, err := a.listAllAccounts(ctx)
-	if err != nil {
-		return err
-	}
+	return a.updateAccounts(ctx, func(_ *corev1.Secret, users map[string]*accounts.Account) error {
+		if _, found := users[username]; !found {
+			return accounts.ErrAccountNotFound
+		}
 
-	if _, found := users[username]; !found {
-		return accounts.ErrAccountNotFound
-	}
-
-	delete(users, username)
-	secret, err := a.k.GetSecret(ctx, types.NamespacedName{Namespace: a.k.Namespace(), Name: common.EverestAccountsSecretName})
-	if err != nil {
-		return err
-	}
-	data, err := yaml.Marshal(users)
-	if err != nil {
-		return err
-	}
-	secret.Data[common.EverestAccountsFileName] = data
-	if _, err := a.k.UpdateSecret(ctx, secret); err != nil {
-		return err
-	}
-	return nil
+		delete(users, username)
+		return nil
+	})
 }
 
 func (a *configMapsClient) Verify(ctx context.Context, username, password string) error {
@@ -215,47 +199,67 @@ func (a *configMapsClient) listAllAccounts(ctx context.Context) (map[string]*acc
 	return result, nil
 }
 
+func (a *configMapsClient) updateAccounts(
+	ctx context.Context,
+	mutateFn func(secret *corev1.Secret, accountsMap map[string]*accounts.Account) error,
+) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		secret, err := a.k.GetSecret(ctx, types.NamespacedName{Namespace: a.k.Namespace(), Name: common.EverestAccountsSecretName})
+		if err != nil {
+			return err
+		}
+
+		accountsMap := make(map[string]*accounts.Account)
+		if err := yaml.Unmarshal(secret.Data[common.EverestAccountsFileName], &accountsMap); err != nil {
+			return err
+		}
+
+		if err := mutateFn(secret, accountsMap); err != nil {
+			return err
+		}
+
+		data, err := yaml.Marshal(accountsMap)
+		if err != nil {
+			return err
+		}
+
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte)
+		}
+		secret.Data[common.EverestAccountsFileName] = data
+
+		if _, err := a.k.UpdateSecret(ctx, secret); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
 func (a *configMapsClient) insertOrUpdateAccount(
 	ctx context.Context,
 	username string,
-	account *accounts.Account,
 	secure bool,
+	mutateFn func(existing *accounts.Account) (*accounts.Account, error),
 ) error {
-	secret, err := a.k.GetSecret(ctx, types.NamespacedName{Namespace: a.k.Namespace(), Name: common.EverestAccountsSecretName})
-	if err != nil {
-		return err
-	}
+	return a.updateAccounts(ctx, func(secret *corev1.Secret, accountsMap map[string]*accounts.Account) error {
+		updated, err := mutateFn(accountsMap[username])
+		if err != nil {
+			return err
+		}
 
-	accounts := make(map[string]*accounts.Account)
-	if err := yaml.Unmarshal(secret.Data[common.EverestAccountsFileName], &accounts); err != nil {
-		return err
-	}
+		accountsMap[username] = updated
 
-	accounts[username] = account
-	data, err := yaml.Marshal(accounts)
-	if err != nil {
-		return err
-	}
-
-	if secret.Data == nil {
-		secret.Data = make(map[string][]byte)
-	}
-	secret.Data[common.EverestAccountsFileName] = data
-
-	annotations := secret.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	delete(annotations, fmt.Sprintf(insecurePasswordAnnotation, username))
-	if !secure {
-		annotations[fmt.Sprintf(insecurePasswordAnnotation, username)] = insecurePasswordValueTrue
-	}
-	secret.SetAnnotations(annotations)
-
-	if _, err := a.k.UpdateSecret(ctx, secret); err != nil {
-		return err
-	}
-	return nil
+		annotations := secret.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		delete(annotations, fmt.Sprintf(insecurePasswordAnnotation, username))
+		if !secure {
+			annotations[fmt.Sprintf(insecurePasswordAnnotation, username)] = insecurePasswordValueTrue
+		}
+		secret.SetAnnotations(annotations)
+		return nil
+	})
 }
 
 func (a *configMapsClient) salt(ctx context.Context) ([]byte, error) {

--- a/pkg/kubernetes/accounts_test.go
+++ b/pkg/kubernetes/accounts_test.go
@@ -17,17 +17,25 @@
 package kubernetes
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openeverest/openeverest/v2/pkg/accounts"
 	"github.com/openeverest/openeverest/v2/pkg/common"
 )
+
+const testNamespace = "test-ns"
 
 func TestAccounts(t *testing.T) {
 	t.Parallel()
@@ -48,4 +56,187 @@ func TestAccounts(t *testing.T) {
 	mockClient.WithObjects(objs...)
 	k := NewEmpty(zap.NewNop().Sugar(), "test-ns").WithKubernetesClient(mockClient.Build())
 	accounts.Tests(t, k.Accounts())
+}
+
+// conflictClient wraps a ctrlclient.Client and injects a Conflict error
+// on the first Update call, simulating a concurrent modification.
+// On that first call it also mutates the underlying secret using the provided
+// mutate function, so the retry must re-read fresh data.
+type conflictClient struct {
+	ctrlclient.Client
+
+	attempt atomic.Int32
+	mutate  func(*corev1.Secret)
+}
+
+func (c *conflictClient) Update(ctx context.Context, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+	if c.attempt.Add(1) == 1 {
+		// Simulate a concurrent writer that adds a new user.
+		sec := &corev1.Secret{}
+		if err := c.Get(ctx, types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      common.EverestAccountsSecretName,
+		}, sec); err != nil {
+			return err
+		}
+
+		c.mutate(sec)
+
+		if err := c.Client.Update(ctx, sec); err != nil {
+			return err
+		}
+
+		// Return a Conflict error so RetryOnConflict triggers a retry.
+		return apierrors.NewConflict(
+			schema.GroupResource{Resource: "secrets"},
+			common.EverestAccountsSecretName,
+			nil,
+		)
+	}
+
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func TestAccounts_DeleteConflict(t *testing.T) {
+	t.Parallel()
+
+	objs := []ctrlclient.Object{
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            common.EverestAccountsSecretName,
+				Namespace:       testNamespace,
+				ResourceVersion: "1",
+			},
+			Data: map[string][]byte{
+				common.EverestAccountsFileName: []byte("admin:\n  enabled: true\n"),
+			},
+		},
+	}
+
+	mockClient := fakeclient.NewClientBuilder().
+		WithScheme(CreateScheme()).
+		WithObjects(objs...).
+		Build()
+
+	k := NewEmpty(zap.NewNop().Sugar(), testNamespace).WithKubernetesClient(&conflictClient{
+		Client: mockClient,
+		mutate: func(sec *corev1.Secret) {
+			sec.Data[common.EverestAccountsFileName] = []byte("admin:\n  enabled: true\nconcurrent-user:\n  enabled: true\n")
+		},
+	})
+	err := k.Accounts().Delete(context.Background(), "admin")
+	require.NoError(t, err)
+
+	accs, err := k.Accounts().List(context.Background())
+	require.NoError(t, err)
+	require.NotContains(t, accs, "admin")
+	require.Contains(t, accs, "concurrent-user")
+}
+
+func TestAccounts_CreateConflict(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		mutateFn      func(sec *corev1.Secret)
+		expectedError error
+		expectedUsers []string
+	}{
+		{
+			name: "concurrent writer adds an unrelated user",
+			mutateFn: func(sec *corev1.Secret) {
+				sec.Data[common.EverestAccountsFileName] = []byte("admin:\n  enabled: true\nunrelated-user:\n  enabled: true\n")
+			},
+			expectedError: nil,
+			expectedUsers: []string{"newuser", "unrelated-user"},
+		},
+		{
+			name: "concurrent writer adds the same user",
+			mutateFn: func(sec *corev1.Secret) {
+				sec.Data[common.EverestAccountsFileName] = []byte("admin:\n  enabled: true\nnewuser:\n  enabled: true\n")
+			},
+			expectedError: accounts.ErrUserAlreadyExists,
+			expectedUsers: []string{"newuser"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			objs := []ctrlclient.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            common.EverestAccountsSecretName,
+						Namespace:       testNamespace,
+						ResourceVersion: "1",
+					},
+					Data: map[string][]byte{
+						common.EverestAccountsFileName: []byte("admin:\n  enabled: true\n"),
+					},
+				},
+			}
+
+			mockClient := fakeclient.NewClientBuilder().
+				WithScheme(CreateScheme()).
+				WithObjects(objs...).
+				Build()
+
+			k := NewEmpty(zap.NewNop().Sugar(), testNamespace).WithKubernetesClient(&conflictClient{
+				Client: mockClient,
+				mutate: tt.mutateFn,
+			})
+			err := k.Accounts().Create(context.Background(), "newuser", "password")
+
+			if tt.expectedError != nil {
+				require.ErrorIs(t, err, tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+
+			accs, err := k.Accounts().List(context.Background())
+			require.NoError(t, err)
+			for _, u := range tt.expectedUsers {
+				require.Contains(t, accs, u)
+			}
+		})
+	}
+}
+
+func TestAccounts_Errors(t *testing.T) {
+	t.Parallel()
+
+	objs := []ctrlclient.Object{
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.EverestAccountsSecretName,
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				common.EverestAccountsFileName: []byte("admin:\n  enabled: true\n"),
+			},
+		},
+	}
+
+	mockClient := fakeclient.NewClientBuilder().
+		WithScheme(CreateScheme()).
+		WithObjects(objs...).
+		Build()
+
+	k := NewEmpty(zap.NewNop().Sugar(), testNamespace).WithKubernetesClient(mockClient)
+
+	err := k.Accounts().Create(context.Background(), "admin", "password")
+	require.ErrorIs(t, err, accounts.ErrUserAlreadyExists)
+
+	err = k.Accounts().SetPassword(context.Background(), "missing", "password", true)
+	require.ErrorIs(t, err, accounts.ErrAccountNotFound)
 }


### PR DESCRIPTION
Fixes #2833.

This PR ports the fix for the Read-Modify-Write race condition in `accounts.Delete()` from `main` (PR #2836) to the `release-2.0` branch. 

**Changes:**
- Removed the double-read anti-pattern in `pkg/kubernetes/accounts.go`.
- `Delete()` now fetches the `everest-accounts` secret exactly once and unmarshals the accounts directly from that fresh copy.
- It writes the modifications back to the same secret object, ensuring the original `ResourceVersion` is preserved so Kubernetes' Optimistic Concurrency Control (OCC) can properly reject conflicting concurrent writes instead of silently discarding them.
