### PR TITLE
fix(rbac): check informer initialization and wrap watcher error

### DIFF
--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -20,6 +20,7 @@ package rbac
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -118,7 +119,7 @@ func refreshEnforcerInBackground(
 		informer.Watches(&corev1.ConfigMap{}, common.SystemNamespace),
 	)
 	if err != nil {
-		return errors.Join(err, errors.New("failed to create RBAC ConfigMap informer"))
+		return fmt.Errorf("failed to initialize ConfigMap informer: %w", err)
 	}
 
 	inf.OnUpdate(func(_, newObj any) {
@@ -149,7 +150,7 @@ func refreshEnforcerInBackground(
 	})
 
 	if err := inf.Start(ctx, &corev1.ConfigMap{}); err != nil {
-		return errors.Join(err, errors.New("failed to watch RBAC ConfigMap"))
+		return fmt.Errorf("failed to watch RBAC ConfigMap: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
### Summary

Fixes #2922

### Problem

- The error from `informer.New(...)` was wrapped with `errors.Join`, which puts the raw error before the context message in logs — making it harder to read in production.
- When `inf.Start(...)` failed, the same `errors.Join` pattern discarded the proper error context ordering.

### Solution

- Replaced `errors.Join(err, errors.New("..."))` with `fmt.Errorf("...: %w", err)` for both `informer.New` and `inf.Start` error paths in `refreshEnforcerInBackground`.
- This ensures the human-readable context appears first in logs, followed by the root cause (e.g. `403 Forbidden` / bad kubeconfig).

### Testing

- `go vet ./pkg/rbac/...` — no warnings.
- `go test ./pkg/rbac/...` — all tests pass.