### PR TITLE
ci: build multi-arch helmtools image and publish to GHCR

### DIFF
--- a/.github/workflows/release-helmtools.yaml
+++ b/.github/workflows/release-helmtools.yaml
@@ -15,35 +15,55 @@ permissions:
 
 jobs:
   release:
-     env:
-      IMG_OWNER: percona
-      IMG_NAME: everest-helmtools
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE: ghcr.io/${{ github.repository_owner }}/openeverest-helmtools
       VERSION: ${{ github.event.inputs.version }}
       KUBECTL_VERSION: ${{ github.event.inputs.kubectl_version }}
-
-     runs-on: ubuntu-latest
-     steps:
+    steps:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: percona/everest
-          path: everest
-          token: ${{ secrets.ROBOT_TOKEN }}
           sparse-checkout: |
             Dockerfile.helmtools
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        name: Build & push Docker image
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build & push Docker image
+        id: push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: everest
+          context: .
           push: true
-          tags: ${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}:${{ env.VERSION }}
-          file: everest/Dockerfile.helmtools
+          provenance: false
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.IMAGE }}:${{ env.VERSION }}
+            ${{ env.IMAGE }}:latest
+          file: Dockerfile.helmtools
           build-args: |
             KUBECTL_VERSION=${{ env.KUBECTL_VERSION }}
+
+      - name: Attest image
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Follow-up to #2603 / #2605.

### Problem

#2605 fixed the arm64 builds of the server/operator/ctl images, but the helmtools image used by the Helm chart hook jobs was missed. `release-helmtools.yaml` still:

- builds only for the host arch (amd64), so `percona/everest-helmtools:0.0.1` ships no arm64 variant and the hook jobs (e.g. `everest-operators-installer`) fail on arm64 hosts with `exec format error` (see the follow-up comments on #2603);
- pushes to Docker Hub under the `percona` org, from a `percona/everest` checkout using `ROBOT_TOKEN`, unlike every other image which is published to `ghcr.io/openeverest`.

### Fix

- Build `linux/amd64,linux/arm64` in one buildx+QEMU job — `Dockerfile.helmtools` already selects the kubectl binary via `TARGETOS`/`TARGETARCH`, only the workflow was single-arch. No native runner matrix needed since nothing is compiled.
- Publish to `ghcr.io/openeverest/openeverest-helmtools` with `github.actor`/`GITHUB_TOKEN` (job-scoped `packages: write`), removing the `ROBOT_TOKEN` and `DOCKERHUB_*` secret dependencies and checking out this repo instead of `percona/everest`.
- Tag `<version>` + `latest` and attest build provenance, matching `release.yml` conventions.

### Follow-ups (separate PRs)

- helm-charts: bump the default `hooks.image` from `percona/everest-helmtools:0.0.1` to the new GHCR image once this workflow has been dispatched (v1 `main`: `hooks.image` string in `everest` and `everest-db-namespace`; `v2`: `hooks.image.repository`/`tag`, used by the pre-upgrade-checks hook).
- Until a chart release picks that up, 1.16.2 users can override without any new release, e.g. `everestctl install --helm.set 'hooks.image=ghcr.io/openeverest/openeverest-helmtools:<tag>'` (same for `namespaces add/update` and `upgrade`).
