### PR TITLE
ci: build multi-arch helmtools image and publish to GHCR (release-2.0)

### DIFF
--- a/.github/workflows/release-helmtools.yaml
+++ b/.github/workflows/release-helmtools.yaml
@@ -15,35 +15,55 @@ permissions:
 
 jobs:
   release:
-     env:
-      IMG_OWNER: percona
-      IMG_NAME: everest-helmtools
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE: ghcr.io/${{ github.repository_owner }}/openeverest-helmtools
       VERSION: ${{ github.event.inputs.version }}
       KUBECTL_VERSION: ${{ github.event.inputs.kubectl_version }}
-
-     runs-on: ubuntu-latest
-     steps:
+    steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: percona/everest
-          path: everest
-          token: ${{ secrets.ROBOT_TOKEN }}
           sparse-checkout: |
             build/package/helmtools/Dockerfile
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
-        name: Build & push Docker image
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build & push Docker image
+        id: push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          context: everest
+          context: .
           push: true
-          tags: ${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}:${{ env.VERSION }}
-          file: everest/build/package/helmtools/Dockerfile
+          provenance: false
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.IMAGE }}:${{ env.VERSION }}
+            ${{ env.IMAGE }}:latest
+          file: build/package/helmtools/Dockerfile
           build-args: |
             KUBECTL_VERSION=${{ env.KUBECTL_VERSION }}
+
+      - name: Attest image
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Port of #2929 to `release-2.0` (cherry-pick doesn't apply: this branch keeps the Dockerfile at `build/package/helmtools/Dockerfile` and uses older action pins).

Same fix as #2929: build `linux/amd64,linux/arm64` via buildx+QEMU, publish to `ghcr.io/openeverest/openeverest-helmtools` with `GITHUB_TOKEN` (dropping `ROBOT_TOKEN`/`DOCKERHUB_*` and the `percona/everest` checkout), tag `<version>` + `latest`, attest provenance.

Differences from the main version, matching this branch's release.yml conventions:
- `file`/`sparse-checkout`: `build/package/helmtools/Dockerfile` instead of `Dockerfile.helmtools`
- action pins: checkout v6.0.2, login v3.7.0, qemu v3.7.0, buildx v4.0.0, build-push v6.19.2, `actions/attest-build-provenance` v4.1.0 (main uses the unified `actions/attest`)
