### PR TITLE
chore: reset dev version and update helm chart after 2.0.0-dev.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REPO_ROOT=$(shell dirname "$(realpath $(firstword $(MAKEFILE_LIST)))")
-RELEASE_VERSION ?= v2.0.0-dev.2
+RELEASE_VERSION ?= v0.0.0-$(shell git rev-parse --short HEAD)
 RELEASE_FULLCOMMIT ?= $(shell git rev-parse HEAD)
 IMAGE_PREFIX ?= ghcr.io/openeverest
 EVEREST_SERVER_DEV_IMAGE_NAME ?= openeverest-dev

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.1.0
 	github.com/oapi-codegen/runtime v1.6.0
-	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260813093106-7bf8deefa324
+	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260814140616-eceba292c94a
 	github.com/operator-framework/api v0.45.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20260429065444-70caa52c384a
 	github.com/rodaine/table v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -847,8 +847,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260813093106-7bf8deefa324 h1:dynOsbXXNK7IAPc4aEjn0BHTlrQzBzKjaVyigugfR3U=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260813093106-7bf8deefa324/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260814140616-eceba292c94a h1:IXGOPvdPH1wdBLDkThfGqrar1TYERstfburM3FmOfH8=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260814140616-eceba292c94a/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
 github.com/operator-framework/api v0.45.0 h1:hkROwtsLH3oszp4IW+WsXEFSDgveSahHI7DKStOtrUI=
 github.com/operator-framework/api v0.45.0/go.mod h1:IQ4uuISTiIhV09oAurJSGD4KabayhY5nV6k1XmA235M=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=


### PR DESCRIPTION
Restores `release-2.0` CI to a working state after the `v2.0.0-dev.2` release cut.

### Problem

The release-cut commit (`c9002768`, "update version tag") left `RELEASE_VERSION ?= v2.0.0-dev.2` on the branch, so every PR into `release-2.0` now fails `dev-be-ci` (first seen on #2930, which only touches a dispatch-only workflow):

- **Check** — "Check the Makefile references dev version" requires `RELEASE_VERSION ?= v0.0.0`
- **API Integration Tests** — `version.spec.ts` expects `v0.0.0-<short-sha>`, gets `v2.0.0-dev.2`
- **CLI Integration Tests** — same assertion on `everestctl version` output

(The `Test` job failure on #2930 is a separate flaky concurrency test, `TestHub_ConcurrentPublishReconnectNoGapsNoDuplicates`, 999/1000 events on reconnect.)

### Changes

- Reset `RELEASE_VERSION` to the `v0.0.0-$(git rev-parse --short HEAD)` form used on `main`.
- `make update-dev-chart`: bump `github.com/openeverest/helm-charts/charts/everest` to v2 HEAD (`eceba29`), picking up the multi-arch `ghcr.io/openeverest/openeverest-helmtools` hooks image from openeverest/helm-charts#89 — this also keeps the "dev Helm chart is up-to-date" check green now that #89 is merged.

Longer term the release workflow should probably reset the version itself after tagging so the branch never lingers in this state.
