### PR TITLE
chore: update helm chart to pick up multi-arch helmtools image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,8 @@ dev-destroy: dev-down k3d-cluster-down-dev ## Stop Tilt and destroy the k3d clus
 CHART_BRANCH ?= main
 .PHONY: update-dev-chart
 update-dev-chart: ## Update dependency to Everest Helm chart to the latest version from the specified branch (default main).
-	go get -u github.com/openeverest/helm-charts/charts/everest@${CHART_BRANCH}
+	COMMIT=$$(git ls-remote https://github.com/openeverest/helm-charts refs/heads/$(CHART_BRANCH) | cut -f1) && \
+	go get -u github.com/openeverest/helm-charts/charts/everest@$$COMMIT
 	go mod tidy
 
 EVEREST_OPERATOR_BRANCH ?= main

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.1.0
 	github.com/oapi-codegen/runtime v1.6.0
-	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260802124756-1d1f7f019a90
+	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260814143245-c6c176451253
 	github.com/operator-framework/api v0.45.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20260802124914-e2aa472c7107
 	github.com/rodaine/table v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -824,8 +824,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260802124756-1d1f7f019a90 h1:utSb8JfNU6LA7bViN3D8dgrSSmi5xWj1tFFBWVj+Ut4=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260802124756-1d1f7f019a90/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260814143245-c6c176451253 h1:MxeRB2VdgTDoKaH/r2w0/lV/2rCb1mNiCNHZV1d5pQQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260814143245-c6c176451253/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
 github.com/operator-framework/api v0.45.0 h1:hkROwtsLH3oszp4IW+WsXEFSDgveSahHI7DKStOtrUI=
 github.com/operator-framework/api v0.45.0/go.mod h1:IQ4uuISTiIhV09oAurJSGD4KabayhY5nV6k1XmA235M=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=


### PR DESCRIPTION
Bumps `github.com/openeverest/helm-charts/charts/everest` to helm-charts `main` HEAD (`c6c1764`), picking up openeverest/helm-charts#88: the chart hooks default is now the multi-arch (amd64+arm64) `ghcr.io/openeverest/openeverest-helmtools:0.0.1` image instead of the amd64-only `percona/everest-helmtools:0.0.1`.

Counterpart of the release-2.0 bump in #2931. Follow-up to #2603/#2929.

Also fixes `make update-dev-chart` to resolve the branch head via `git ls-remote` and `go get` the explicit commit, as release-2.0 already does. The previous `go get @main` goes through the Go module proxy's cached branch resolution (~30 min TTL), which right after a merge still serves the pre-merge commit — it made the initial bump here a no-op and then failed the "dev Helm chart is up-to-date" CI check by downgrading the freshly pinned version.
