### PR TITLE
fix: enforce RBAC before validation to prevent SSRF via backup storag…

### DIFF
--- a/internal/server/everest.go
+++ b/internal/server/everest.go
@@ -308,7 +308,7 @@ func (e *EverestServer) setupHandlers(
 	if err != nil {
 		return errors.Join(err, errors.New("could not create rbac handler"))
 	}
-	e.setHandlers(valH, rbacH, k8sH)
+	e.setHandlers(rbacH, valH, k8sH) // rbac first, closes the SSRF hole
 	return nil
 }
 

--- a/internal/server/everest.go
+++ b/internal/server/everest.go
@@ -308,7 +308,8 @@ func (e *EverestServer) setupHandlers(
 	if err != nil {
 		return errors.Join(err, errors.New("could not create rbac handler"))
 	}
-	e.setHandlers(rbacH, valH, k8sH) // rbac first, closes the SSRF hole
+	// RBAC runs first: the validation handler dials request-supplied endpoints with request-supplied credentials.
+	e.setHandlers(rbacH, valH, k8sH)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Fixes #2907 — the API server's handler chain was wired as
`validation → rbac → k8s`, which let unauthorized requests trigger
real outbound network calls before authorization was checked.

## Problem

`CreateBackupStorage`/`UpdateBackupStorage` in the validation handler
call `s3Access`/`azureAccess` directly — issuing real `HeadBucket`/
`PutObject`/`ListObjects` requests to a URL and credentials taken
straight from the request body — **before** the request ever reaches
the RBAC handler's `enforce()` call.

This means any authenticated user, even one with **zero**
backup-storage RBAC grants, could:

1. `POST /backup-storages` with an attacker-controlled endpoint URL
2. Have the server make a real outbound request to that URL
   (potentially probing internal infrastructure, e.g. cloud metadata
   endpoints, using the server's network position and credentials)
3. Only receive `403 Forbidden` *after* the outbound call already fired

## Fix

Reorder the handler chain in `setupHandlers()`
(`internal/server/everest.go`) from `valH, rbacH, k8sH` to
`rbacH, valH, k8sH`, so RBAC enforcement runs first for every
resource type, not just backup storage.

```diff
- e.setHandlers(valH, rbacH, k8sH)
+ e.setHandlers(rbacH, valH, k8sH)
```

## Why this is safe

Verified that no `enforce()` call in `internal/server/handlers/rbac/*.go`
depends on data the validation handler computes, defaults, or mutates —
every call reads `namespace`/`name`/object fields directly from the raw
incoming request or path parameters. No other code references
`setHandlers`/`setupHandlers`/`newHandlerChain`, and no test pins the
old ordering, so this reorder doesn't require changes anywhere else.

## Impact

- Unauthorized `CreateBackupStorage`/`UpdateBackupStorage` requests
  now return `403` immediately, before any outbound S3/Azure call is
  made.
- This is a defense-in-depth fix: authorization is now enforced before
  *any* business logic runs, across all resource types, not just
  backup storage.

## Testing

- [ ] Manual repro of the original steps in #2907 confirms no outbound
      traffic reaches the attacker-controlled URL before `403` is
      returned
- [ ] Existing test suite passes (`go test ./internal/server/...`)
- [ ] (optional) Add a regression test asserting no outbound HTTP call
      is made for an unauthorized backup-storage create/update

## Related

- Closes #2907