### PR TITLE
Test/2829 OIDC unit tests

### DIFF
--- a/internal/server/everest.go
+++ b/internal/server/everest.go
@@ -308,7 +308,7 @@ func (e *EverestServer) setupHandlers(
 	if err != nil {
 		return errors.Join(err, errors.New("could not create rbac handler"))
 	}
-	e.setHandlers(valH, rbacH, k8sH)
+	e.setHandlers(rbacH, valH, k8sH) // rbac first, closes the SSRF hole
 	return nil
 }
 

--- a/pkg/oidc/configure_test.go
+++ b/pkg/oidc/configure_test.go
@@ -1,0 +1,60 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oidc_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/percona/everest/pkg/oidc"
+)
+
+func TestValidateURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{name: "empty", url: "", wantErr: true},
+		// url.ParseRequestURI accepts scheme-relative and relative-looking
+		// strings that ValidateURL's explicit scheme/host checks are there
+		// to reject (this is the behavior the maintainer specifically
+		// flagged as worth covering).
+		{name: "missing scheme", url: "example.com/issuer", wantErr: true},
+		{name: "scheme only, no host", url: "https://", wantErr: true},
+		{name: "path only, no scheme or host", url: "/just/a/path", wantErr: true},
+		{name: "valid https URL", url: "https://accounts.example.com", wantErr: false},
+		{name: "valid https URL with path", url: "https://login.microsoftonline.com/tenant/v2.0", wantErr: false},
+		{name: "valid http URL", url: "http://localhost:8080", wantErr: false},
+		{name: "not a URL at all", url: "not a url", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := oidc.ValidateURL(tt.url)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/oidc/oidc_test.go
+++ b/pkg/oidc/oidc_test.go
@@ -1,0 +1,253 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oidc_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/stretchr/testify/require"
+
+	"github.com/percona/everest/pkg/oidc"
+)
+
+// wellKnownServer starts an httptest server that serves the given body as
+// JSON at oidc.WellKnownPath, and anything else with the given status code.
+func wellKnownServer(t *testing.T, status int, body any) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(oidc.WellKnownPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		if body != nil {
+			require.NoError(t, json.NewEncoder(w).Encode(body))
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestNewProviderConfig_OriginalIssuerDiffersFromResponseIssuer(t *testing.T) {
+	t.Parallel()
+
+	// This models the Microsoft Entra case: the issuer the admin configures
+	// (the server URL below) is not the same as the issuer advertised in the
+	// well-known document. internal/server/middlewares.go only adds the
+	// second CSP connect-src entry when OriginalIssuer != Issuer, so this is
+	// the behavior most worth locking down.
+	const advertisedIssuer = "https://login.microsoftonline.com/some-tenant-id/v2.0"
+
+	srv := wellKnownServer(t, http.StatusOK, map[string]any{
+		"issuer":                 advertisedIssuer,
+		"authorization_endpoint": advertisedIssuer + "/oauth2/v2.0/authorize",
+		"token_endpoint":         advertisedIssuer + "/oauth2/v2.0/token",
+		"jwks_uri":               advertisedIssuer + "/discovery/v2.0/keys",
+	})
+
+	cfg, err := oidc.NewProviderConfig(context.Background(), srv.URL)
+	require.NoError(t, err)
+
+	// OriginalIssuer must be the URL the caller passed in...
+	require.Equal(t, srv.URL, cfg.OriginalIssuer)
+	// ...while Issuer must be whatever the provider's own document advertised.
+	require.Equal(t, advertisedIssuer, cfg.Issuer)
+	require.NotEqual(t, cfg.OriginalIssuer, cfg.Issuer)
+}
+
+func TestNewProviderConfig_OriginalIssuerMatchesWhenProviderAgrees(t *testing.T) {
+	t.Parallel()
+
+	// The common case: the provider's well-known document echoes back the
+	// same issuer the caller configured. OriginalIssuer and Issuer should
+	// then be equal, so middlewares.go does not add a redundant CSP entry.
+	// The handler needs to know its own URL to echo it back as "issuer",
+	// which isn't available until after the server starts, so build the
+	// server directly here instead of via the wellKnownServer helper.
+	mux := http.NewServeMux()
+	mux.HandleFunc(oidc.WellKnownPath, func(w http.ResponseWriter, r *http.Request) {
+		issuer := "http://" + r.Host
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":   issuer,
+			"jwks_uri": issuer + "/keys",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cfg, err := oidc.NewProviderConfig(context.Background(), srv.URL)
+	require.NoError(t, err)
+	require.Equal(t, srv.URL, cfg.OriginalIssuer)
+	require.Equal(t, cfg.OriginalIssuer, cfg.Issuer)
+}
+
+func TestNewProviderConfig_NonOKStatusReturnsUnexpectedStatusCode(t *testing.T) {
+	t.Parallel()
+
+	srv := wellKnownServer(t, http.StatusInternalServerError, nil)
+
+	_, err := oidc.NewProviderConfig(context.Background(), srv.URL)
+	require.Error(t, err)
+	// getOIDCProviderConfigureSteps (pkg/oidc/configure.go) branches on this
+	// specific sentinel to give the user a distinct message, so the wrapping
+	// must be preserved.
+	require.ErrorIs(t, err, oidc.ErrUnexpectedSatusCode)
+}
+
+func TestNewProviderConfig_UnreachableIssuerReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Nothing is listening on this address.
+	_, err := oidc.NewProviderConfig(context.Background(), "http://127.0.0.1:0")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, oidc.ErrUnexpectedSatusCode)
+}
+
+// ---- NewKeyFunc ----
+
+func TestNewKeyFunc_NoJWKSURI(t *testing.T) {
+	t.Parallel()
+
+	cfg := &oidc.ProviderConfig{} // JWKSURL left empty
+	_, err := cfg.NewKeyFunc(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "jwks_uri")
+}
+
+func TestNewKeyFunc_MalformedJWKSURLFailsOnFirstUse(t *testing.T) {
+	t.Parallel()
+
+	// httprc's queue.Register (v1.0.6, jwk.Cache's underlying implementation)
+	// does not parse or otherwise validate the URL string at all -- it is
+	// simply stored as a map key, and Register() only returns an error for
+	// unrelated reasons (e.g. an explicit RefreshInterval option smaller than
+	// the cache's refresh window). Since NewKeyFunc calls Register with no
+	// options, registration cannot fail for a malformed URL in this version.
+	// The failure instead surfaces on first use, when the returned Keyfunc
+	// calls keyCache.Get and the queue actually attempts to build/issue the
+	// HTTP request for the malformed URL.
+	cfg := &oidc.ProviderConfig{JWKSURL: "://not-a-valid-url"}
+
+	keyFunc, err := cfg.NewKeyFunc(context.Background())
+	require.NoError(t, err, "registration itself does not validate the URL")
+
+	tok := &jwt.Token{Header: map[string]any{"kid": "any"}}
+	_, err = keyFunc(tok)
+	require.Error(t, err, "fetching the malformed URL should fail on first use")
+}
+
+// rsaJWKS starts a server that publishes a single RSA public key under the
+// given kid, and returns the private key so tests can build tokens.
+func rsaJWKS(t *testing.T, kid string) (*httptest.Server, *rsa.PrivateKey) {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pubJWK, err := jwk.FromRaw(priv.Public())
+	require.NoError(t, err)
+	require.NoError(t, pubJWK.Set(jwk.KeyIDKey, kid))
+	require.NoError(t, pubJWK.Set(jwk.AlgorithmKey, "RS256"))
+
+	set := jwk.NewSet()
+	require.NoError(t, set.AddKey(pubJWK))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(set))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, priv
+}
+
+func TestNewKeyFunc_TokenMissingKid(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := rsaJWKS(t, "key-1")
+	cfg := &oidc.ProviderConfig{JWKSURL: srv.URL}
+
+	keyFunc, err := cfg.NewKeyFunc(context.Background())
+	require.NoError(t, err)
+
+	tok := &jwt.Token{Header: map[string]any{}} // no "kid"
+	_, err = keyFunc(tok)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "kid")
+}
+
+func TestNewKeyFunc_KidNotInKeySet(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := rsaJWKS(t, "key-1")
+	cfg := &oidc.ProviderConfig{JWKSURL: srv.URL}
+
+	keyFunc, err := cfg.NewKeyFunc(context.Background())
+	require.NoError(t, err)
+
+	tok := &jwt.Token{Header: map[string]any{"kid": "does-not-exist"}}
+	_, err = keyFunc(tok)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unable to find key")
+}
+
+func TestNewKeyFunc_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	srv, priv := rsaJWKS(t, "key-1")
+	cfg := &oidc.ProviderConfig{JWKSURL: srv.URL}
+
+	keyFunc, err := cfg.NewKeyFunc(context.Background())
+	require.NoError(t, err)
+
+	tok := &jwt.Token{Header: map[string]any{"kid": "key-1"}}
+	got, err := keyFunc(tok)
+	require.NoError(t, err)
+
+	gotPub, ok := got.(*rsa.PublicKey)
+	require.True(t, ok, "expected *rsa.PublicKey, got %T", got)
+	require.True(t, priv.PublicKey.Equal(gotPub))
+}
+
+func TestNewKeyFunc_KeySetFailsToUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	// Serve a JWKS document where the one key's "n" field is not valid
+	// base64url, so the whole set fails to parse when the cache fetches it.
+	// This surfaces at keyCache.Get() inside the returned jwt.Keyfunc, distinct
+	// from the "kid not found" and "missing kid" cases above.
+	malformed := `{"keys":[{"kty":"RSA","kid":"key-1","alg":"RS256","n":"not-valid-base64!!!","e":"AQAB"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, malformed)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := &oidc.ProviderConfig{JWKSURL: srv.URL}
+	keyFunc, err := cfg.NewKeyFunc(context.Background())
+	require.NoError(t, err) // registration itself succeeds; the URL is valid
+
+	tok := &jwt.Token{Header: map[string]any{"kid": "key-1"}}
+	_, err = keyFunc(tok)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Adds unit test coverage for `pkg/oidc`, per the scope accepted by
@recharte on #2829.

## What's covered

**`NewProviderConfig`** (`pkg/oidc/oidc.go`)
- `OriginalIssuer` is set from the issuer the *caller* passed, not the
  one in the provider's response — tested for both the divergent case
  (models the Microsoft Entra scenario from `fc4f947`, where the
  well-known document advertises a different issuer than the
  configured URL) and the common case where they agree.
- A non-200 response from the well-known endpoint returns an error
  satisfying `errors.Is(err, ErrUnexpectedSatusCode)`, since
  `getOIDCProviderConfigureSteps` branches on this to give the user a
  distinct message.
- An unreachable issuer returns a plain error (not
  `ErrUnexpectedSatusCode`).

**`NewKeyFunc`** (`pkg/oidc/oidc.go`)
- Empty `JWKSURL` (no `jwks_uri` in the provider config).
- Malformed `JWKSURL` — see note below on what this actually exercises.
- A token with no `kid` in its header.
- A `kid` that isn't present in the fetched key set.
- A JWKS response that fails to unmarshal (malformed key data).
- Happy path: valid RSA key served, correct `kid`, returns the
  matching `*rsa.PublicKey`.

**`ValidateURL`** (`pkg/oidc/configure.go`)
- Empty string, missing scheme, scheme with no host, path with no
  scheme, and several valid URLs — covers the explicit scheme/host
  checks that exist because `url.ParseRequestURI` alone is more
  permissive than we want.

`ValidateClientID` and `ValidateScopes` are intentionally **not**
tested, per @recharte's scope note — they're a one-line emptiness
check and a single `slices.ContainsFunc`, so a test would just restate
the implementation.

## A finding along the way

While writing the "cache registration failure" case for `NewKeyFunc`,
I traced the actual call chain (`jwk.Cache.Register` →
`httprc.Cache.Register` → `httprc` `queue.Register`, in
`httprc@v1.0.6/queue.go`) and confirmed that `Register()` does **no
URL validation at all** — it just stores the URL string as a map key.
The only way it returns an error is a `RefreshInterval` option smaller
than the cache's refresh window, which `NewKeyFunc` never passes.

So the error branch here:

```go
if err := keyCache.Register(c.JWKSURL); err != nil {
    return nil, errors.Join(err, errors.New("failed to register jwk cache"))
}
```

is currently unreachable as `NewKeyFunc` calls it. A malformed or
unreachable JWKS URL is accepted at registration and only surfaces an
error later, on first use, when the returned `jwt.Keyfunc` calls
`keyCache.Get()`. `TestNewKeyFunc_MalformedJWKSURLFailsOnFirstUse`
tests that real behavior instead of the originally-assumed one.

Not fixing this here since it's out of scope for #2829 — flagging in
case it's worth a small follow-up (e.g. validating `c.JWKSURL` with
`url.Parse` before calling `Register`, so misconfiguration fails fast
at setup instead of on the first incoming request).

## Sequencing note

#2835 (unbounded JWKS fetch / well-known response body) touches these
same two functions — adding a bounded `http.Client` to `Register` and
an `io.LimitReader` on the well-known body. These tests target
today's behavior; if #2835 lands first, `TestNewKeyFunc_HappyPath`,
`TestNewKeyFunc_KeySetFailsToUnmarshal`, and
`TestNewKeyFunc_MalformedJWKSURLFailsOnFirstUse` may need a small
follow-up (a size-cap test for the well-known body, and re-verifying
the malformed-URL behavior with a bounded client).

## Testing

Full suite passes locally:
go test ./pkg/oidc/... -v

12/12 tests pass.

## Related

Closes #2829