### PR TITLE
fix(monitoring): wrap dropped errors in monitoring instance handler

### DIFF
--- a/internal/server/handlers/k8s/monitoring_instance.go
+++ b/internal/server/handlers/k8s/monitoring_instance.go
@@ -16,6 +16,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/AlekSi/pointer"
@@ -109,7 +110,7 @@ func (h *k8sHandler) UpdateMonitoringInstance(ctx context.Context, namespace, na
 			StringData: h.monitoringConfigSecretData(apiKey),
 		})
 		if err != nil {
-			return nil, fmt.Errorf("could not update k8s secret %s", name)
+			return nil, fmt.Errorf("could not update k8s secret %s: %w", name, err)
 		}
 	}
 	if req.Url != "" {
@@ -154,10 +155,10 @@ func (h *k8sHandler) createMonitoringK8sResources(
 		if k8serrors.IsAlreadyExists(err) {
 			_, err = h.kubeConnector.UpdateSecret(c, secret)
 			if err != nil {
-				return nil, fmt.Errorf("could not update k8s secret %s", params.Name)
+				return nil, fmt.Errorf("could not update k8s secret %s: %w", params.Name, err)
 			}
 		} else {
-			return nil, fmt.Errorf("failed creating secret in the Kubernetes cluster")
+			return nil, fmt.Errorf("failed creating secret in the Kubernetes cluster: %w", err)
 		}
 	}
 	created, err := h.kubeConnector.CreateMonitoringConfig(c, &everestv1alpha1.MonitoringConfig{
@@ -182,7 +183,7 @@ func (h *k8sHandler) createMonitoringK8sResources(
 			},
 		}
 		if dErr := h.kubeConnector.DeleteSecret(c, delObj); dErr != nil {
-			return nil, fmt.Errorf("failed cleaning up the secret because failed creating monitoring instance")
+			return nil, fmt.Errorf("failed cleaning up secret after failed monitoring instance creation: %w", errors.Join(err, dErr))
 		}
 		return nil, err
 	}


### PR DESCRIPTION
### Summary

Fixes #2942

### Problem

Four `fmt.Errorf` calls in `internal/server/handlers/k8s/monitoring_instance.go` were silently discarding the underlying error:

- Line 112 (`UpdateMonitoringInstance`): secret update error dropped
- Line 157 (`createMonitoringK8sResources`): secret update error dropped
- Line 160 (`createMonitoringK8sResources`): secret create error dropped
- Lines 184–186 (`createMonitoringK8sResources`): both the cleanup error (`dErr`) and the original `CreateMonitoringConfig` error (`err`) were dropped

This makes it impossible to see the real Kubernetes API failure (e.g. RBAC denial, timeout) in logs or error chains.

### Solution

- Added `%w` to all four error sites to preserve the root cause.
- For the dual-error cleanup case, used `errors.Join(err, dErr)` wrapped in `fmt.Errorf` so both the original failure and the cleanup failure are surfaced.
- Added `"errors"` import.

### Testing

- `go vet ./internal/server/handlers/k8s/...` — no warnings.
- `go test ./internal/server/handlers/k8s/...` — all tests pass.