### PR TITLE
fix(monitoring): wrap dropped error in UpdateMonitoringConfig secret update [v2 backport]

### DIFF
--- a/internal/server/handlers/k8s/monitoring_config.go
+++ b/internal/server/handlers/k8s/monitoring_config.go
@@ -189,7 +189,7 @@ func (h *k8sHandler) UpdateMonitoringConfig(ctx context.Context, cluster, namesp
 			secret := newMonitoringConfigSecret(name, namespace, apiKey)
 
 			if _, err = h.kubeConnector.UpdateSecret(ctx, secret); err != nil {
-				return nil, fmt.Errorf("could not update k8s secret %s", name)
+				return nil, fmt.Errorf("could not update k8s secret %s: %w", name, err)
 			}
 		}
 	}


### PR DESCRIPTION
### Summary

Backport fix for #2942 targeting `release-2.0`.

As identified by @recharte, `internal/server/handlers/k8s/monitoring_config.go:192` on `release-2.0` drops the underlying Kubernetes error on secret update failure:

```go
// before
return nil, fmt.Errorf("could not update k8s secret %s", name)

// after
return nil, fmt.Errorf("could not update k8s secret %s: %w", name, err)
```

### Why it matters

`everestErrorHandler` unwraps the error chain to map Kubernetes status codes to HTTP responses (`IsForbidden` → 403, `IsConflict` → 409, etc.). Without `%w`, the chain is broken and all these failures fall through to the default 500 arm. This fix restores correct HTTP status code mapping on `release-2.0`.

The companion fix for `main` is in #2943.

### Testing

- `go vet ./internal/server/handlers/k8s/...` — no warnings.
- `go test ./internal/server/handlers/k8s/...` — all tests pass.