### PR TITLE
feat(providers): MinIO object-storage provider, proof of concept for #2255

### DIFF
--- a/providers/minio/README.md
+++ b/providers/minio/README.md
@@ -62,7 +62,7 @@ Against a real `kind` cluster with the MinIO Operator installed via Helm:
   distributed-pool topology, multiple component types, or per-pool
   configuration.
 - **Root credentials reused for the backup bridge**, instead of a dedicated
-  per-Instance IAM user/policy. Simpler for a PoC, not appropriate long
+  per-Instance IAM user/policy. Simpler for now, not appropriate long
   term — see "Future enhancements" below.
 - **No bucket/user/policy management surface.** `Instance` has no
   first-class concept of buckets or IAM beyond the one backup bucket this

--- a/providers/minio/README.md
+++ b/providers/minio/README.md
@@ -1,0 +1,150 @@
+# MinIO object storage provider (proof of concept)
+
+Tracks [openeverest/openeverest#2255](https://github.com/openeverest/openeverest/issues/2255)
+("Support for object storage engines (MinIO, SeaweedFS)"). This package is a
+proof-of-concept implementation of `provider-runtime`'s `ProviderInterface`
+(`provider-runtime/controller`) for MinIO, built to validate the design
+before proposing it as real scope.
+
+**Status: proof of concept, not production-ready.** It is functional and has
+been verified end-to-end against a real MinIO Operator install (see
+"Verified behavior" below), but several deliberate scope cuts (see "Known
+limitations") mean it is not a drop-in replacement for the `Expected
+Outcomes` listed on issue #2255 yet.
+
+## What it does
+
+- `Sync` renders a real MinIO Operator `Tenant` custom resource
+  (`minio.min.io/v2`) from an `Instance`'s `server` component
+  (`replicas`/`storage`/`version` map onto the Tenant's pool, storage
+  request, and image), and applies it.
+- It also creates the root-credentials `Secret` the Tenant requires
+  (`spec.configuration.name`) and declares a dedicated backup bucket on the
+  Tenant (`spec.buckets`).
+- `Status` reads the Tenant's `status.currentState`/`availableReplicas`
+  back onto the `Instance`, and — once the Tenant is `Initialized` —
+  registers it as a `BackupStorage` (`api/backup/v1alpha1`) so other
+  OpenEverest-managed databases can use it as a backup target, reusing the
+  existing `BackupStorage` mechanism rather than inventing a new one.
+- `Cleanup` is a no-op: every object this provider creates is owned by the
+  `Instance` (via `controller.Context.Apply`'s automatic owner reference),
+  so Kubernetes garbage collection handles teardown.
+
+It intentionally does not import `github.com/minio/operator`: that module
+predates Go's module graph pruning, so importing even its `pkg/apis`
+subpackage drags in the MinIO server binary's own dependency graph. Instead,
+`tenant_types.go` hand-declares the subset of the real `Tenant` CRD this
+provider needs, with field names/tags/group-version taken verbatim from the
+real CRD so the objects on the wire are indistinguishable from ones built
+with the upstream types.
+
+## Verified behavior
+
+Against a real `kind` cluster with the MinIO Operator installed via Helm:
+
+- `kubectl apply -f manifest/sample-instance.yaml` → the provider creates a
+  real `Tenant`, which reaches `Initialized`/`green` health.
+- `Instance.status.phase` correctly reaches `Ready`.
+- A real S3 client (`mc`) round-trips data (`mb`/`cp`/`ls`/`cat`) through
+  both the Tenant's primary bucket and the auto-created backup bucket.
+- The auto-registered `BackupStorage` is immediately usable by a real S3
+  client authenticating with its own (non-root-Secret) credentials
+  reference — i.e. it is a real, writable backup target, not just a
+  declared record.
+- `go test ./providers/minio/...` covers the same scenarios (Tenant
+  rendering with defaults and explicit overrides, credentials-secret
+  idempotency across repeated reconciles, and the Provisioning → Ready →
+  BackupStorage-registered status transitions) against a fake client.
+
+## Known limitations / open design questions
+
+- **Single `server` component, single pool.** No support yet for MinIO's
+  distributed-pool topology, multiple component types, or per-pool
+  configuration.
+- **Root credentials reused for the backup bridge**, instead of a dedicated
+  per-Instance IAM user/policy. Simpler for a PoC, not appropriate long
+  term — see "Future enhancements" below.
+- **No bucket/user/policy management surface.** `Instance` has no
+  first-class concept of buckets or IAM beyond the one backup bucket this
+  provider provisions for itself; `Instance.spec.parameters` (validated
+  against the Provider's `parametersSchema`) is the likely mechanism, not
+  yet implemented.
+- **No scaling/upgrade path tested.** Changing `Instance.spec.components.
+  server.replicas` or `.version` after initial creation and confirming the
+  Tenant reconciles cleanly has not been exercised.
+- **No watch on the owned `Tenant`.** Status only recomputes on the next
+  `Instance` change or the reconciler's periodic resync, not immediately
+  when the Tenant's own status changes — a real (if minor) latency gap.
+- **No real database has backed up through this `BackupStorage` via
+  OpenEverest's own backup path** — verified so far with a raw S3 client
+  standing in for one.
+- **Single provider (MinIO).** SeaweedFS, named alongside MinIO in issue
+  #2255, is unimplemented; nothing here has been checked for whether the
+  abstraction actually generalizes to a second, differently-shaped object
+  storage engine.
+
+## Future enhancements
+
+Roughly in the order they'd need to land to satisfy issue #2255's full
+scope:
+
+1. **Bucket and user/IAM management.** Model buckets and MinIO IAM
+   users/policies as either `Instance.spec.parameters` (validated against a
+   declared `parametersSchema` — the mechanism already exists and needs no
+   new CRDs) or dedicated namespaced CRDs reconciled by this same provider
+   binary (closer to how `Backup`/`Restore` relate to `Instance` today).
+   Either way, this replaces the current root-credential reuse in the
+   backup bridge with a dedicated, least-privilege service account per
+   `BackupStorage`.
+2. **Replication and access-policy configuration** through the same
+   `Instance.spec.parameters` mechanism, once (1) establishes the pattern.
+3. **Scaling and upgrade support**, exercised the same way the existing
+   pg/pxc/psmdb providers are: growing `replicas`/pool count and moving
+   between declared `Provider` version bundles without data loss, with
+   before/after verification against a real cluster.
+4. **A second provider (SeaweedFS)** — the strongest test of whether this
+   package's shape (a thin `ProviderInterface` implementation plus a
+   hand-declared CRD subset) actually generalizes, versus being
+   accidentally MinIO-specific.
+5. **A real backup-integration test**: an actual OpenEverest-managed
+   database (once one exists as a `provider-runtime`-based `Instance`, not
+   just the legacy `dbProvider`-based pg/pxc/psmdb) backing up through
+   OpenEverest's own backup path into a `BackupStorage` this provider
+   registered, not just a raw S3 client standing in for one.
+6. **Watch-based status propagation** on the owned `Tenant`
+   (`controller.WatchProvider`, already part of the SDK) instead of relying
+   on the reconciler's periodic resync.
+7. **UI/CLI/API surface**: exposing object-storage `Instance` creation,
+   status, and (once (1) lands) bucket/user management through the same
+   dashboard, `everestctl`, and REST API surface already used for managed
+   databases.
+8. **Production-hardening**: replace the pinned MinIO image tag with a
+   `Provider`-defined, upgradeable version catalog (the mechanism already
+   exists via `ProviderSpec.ComponentTypes`/`Versions`, just needs a
+   maintained set of entries), and revisit whether root-credential reuse in
+   (pre-1) code paths is acceptable even as an interim state.
+
+## Running it locally
+
+Prerequisites: a Kubernetes cluster (a local `kind` cluster works — MinIO
+Operator install docs assume nothing OpenEverest-specific), `kubectl`, and
+`helm`.
+
+```sh
+# Install the MinIO Operator (see https://min.io/docs/minio/kubernetes/upstream/operations/installation.html)
+helm repo add minio-operator https://operator.min.io
+helm install minio-operator minio-operator/operator -n minio-operator --create-namespace
+
+# Install the Provider/Instance/BackupStorage CRDs this provider depends on
+kubectl apply -f ../../config/crd/bases/core.openeverest.io_providers.yaml
+kubectl apply -f ../../config/crd/bases/core.openeverest.io_instances.yaml
+kubectl apply -f ../../config/crd/bases/backup.openeverest.io_backupstorages.yaml
+
+# Register the provider and run its controller
+kubectl apply -f manifest/provider.yaml
+go run ./cmd
+
+# In another terminal, create an Instance and watch it reconcile
+kubectl apply -f manifest/sample-instance.yaml
+kubectl get instance,tenant -n default
+```

--- a/providers/minio/cmd/main.go
+++ b/providers/minio/cmd/main.go
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Command main is the entrypoint for the minio provider (Phase 1 skeleton).
-// It follows spec 001's documented Provider Go SDK entry-point pattern.
+// Command main is the entrypoint for the minio provider.
 package main
 
 import (

--- a/providers/minio/cmd/main.go
+++ b/providers/minio/cmd/main.go
@@ -22,8 +22,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	minio "github.com/openeverest/openeverest/v2/providers/minio"
 	"github.com/openeverest/openeverest/v2/provider-runtime/reconciler"
+	minio "github.com/openeverest/openeverest/v2/providers/minio"
 )
 
 func main() {

--- a/providers/minio/cmd/main.go
+++ b/providers/minio/cmd/main.go
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command main is the entrypoint for the minio provider (Phase 1 skeleton).
+// It follows spec 001's documented Provider Go SDK entry-point pattern.
+package main
+
+import (
+	"os"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	minio "github.com/openeverest/openeverest/v2/providers/minio"
+	"github.com/openeverest/openeverest/v2/provider-runtime/reconciler"
+)
+
+func main() {
+	ctx := ctrl.SetupSignalHandler()
+
+	p := &minio.Provider{}
+
+	r, err := reconciler.New(ctx, p)
+	if err != nil {
+		log.Log.Error(err, "failed to create minio provider reconciler")
+		os.Exit(1)
+	}
+
+	if err := r.Start(ctx); err != nil {
+		log.Log.Error(err, "minio provider reconciler exited with error")
+		os.Exit(1)
+	}
+}

--- a/providers/minio/manifest/provider.yaml
+++ b/providers/minio/manifest/provider.yaml
@@ -1,0 +1,49 @@
+# Copyright (C) 2026 The OpenEverest Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Phase 2 Provider CR for the minio provider (LFX Term 3 PoC, upstream
+# issue openeverest#2255). Deliberately minimal: one "server"
+# component/componentType, one "standalone" topology, one default version
+# bundle. No parametersSchema yet — bucket/user/volumesPerServer modeling is
+# an open design question (see design-notes.md), correctly deferred past
+# Phase 1.
+#
+# Image tag corrected in Phase 2 (2026-08-12): the Phase 1 skeleton used a
+# placeholder tag, "RELEASE.2026-01-01T00-00-00Z", that doesn't exist on
+# quay.io — real deploys hit ErrImagePull. This tag is the one hand-verified
+# against a real MinIO Operator install in Phase 0 (see design-notes.md).
+apiVersion: core.openeverest.io/v1alpha1
+kind: Provider
+metadata:
+  name: minio
+spec:
+  componentTypes:
+    server:
+      versions:
+        - version: "RELEASE.2025-04-08T15-41-24Z"
+          image: "quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z"
+          default: true
+  components:
+    server:
+      type: server
+  topologies:
+    standalone:
+      components:
+        server:
+          optional: false
+  versions:
+    - name: "RELEASE.2025-04-08T15-41-24Z"
+      default: true
+      components:
+        server: "RELEASE.2025-04-08T15-41-24Z"

--- a/providers/minio/manifest/provider.yaml
+++ b/providers/minio/manifest/provider.yaml
@@ -12,17 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Phase 2 Provider CR for the minio provider (LFX Term 3 PoC, upstream
-# issue openeverest#2255). Deliberately minimal: one "server"
+# Provider CR for the minio provider. Deliberately minimal: one "server"
 # component/componentType, one "standalone" topology, one default version
 # bundle. No parametersSchema yet — bucket/user/volumesPerServer modeling is
-# an open design question (see design-notes.md), correctly deferred past
-# Phase 1.
-#
-# Image tag corrected in Phase 2 (2026-08-12): the Phase 1 skeleton used a
-# placeholder tag, "RELEASE.2026-01-01T00-00-00Z", that doesn't exist on
-# quay.io — real deploys hit ErrImagePull. This tag is the one hand-verified
-# against a real MinIO Operator install in Phase 0 (see design-notes.md).
+# an open design question, deferred for now.
 apiVersion: core.openeverest.io/v1alpha1
 kind: Provider
 metadata:

--- a/providers/minio/manifest/sample-instance.yaml
+++ b/providers/minio/manifest/sample-instance.yaml
@@ -1,0 +1,26 @@
+# Copyright (C) 2026 The OpenEverest Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Minimal Instance for exercising the Phase 1 minio provider skeleton: just
+# enough for providerRef (the only required Instance.spec field) to route
+# reconciliation to the running "minio" provider binary and produce a
+# visible reconcile-attempt log line.
+apiVersion: core.openeverest.io/v1alpha1
+kind: Instance
+metadata:
+  name: minio-poc
+  namespace: default
+spec:
+  providerRef:
+    name: minio

--- a/providers/minio/manifest/sample-instance.yaml
+++ b/providers/minio/manifest/sample-instance.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Minimal Instance for exercising the Phase 1 minio provider skeleton: just
-# enough for providerRef (the only required Instance.spec field) to route
+# Minimal Instance for exercising the minio provider: just enough for
+# providerRef (the only required Instance.spec field) to route
 # reconciliation to the running "minio" provider binary and produce a
 # visible reconcile-attempt log line.
 apiVersion: core.openeverest.io/v1alpha1

--- a/providers/minio/provider.go
+++ b/providers/minio/provider.go
@@ -57,7 +57,7 @@ const defaultMinIOImage = "minio/minio:RELEASE.2020-12-23T02-24-12Z"
 // defaultVolumeSize is used when the Instance's "server" component doesn't
 // specify storage. Matches the size hand-verified against a real kind
 // cluster in Phase 0.
-var defaultVolumeSize = resource.MustParse("1Gi")
+var defaultVolumeSize = resource.MustParse("1Gi") //nolint:gochecknoglobals // resource.Quantity has no const form; same pattern as internal/server/handlers/validation/errors.go's minStorageQuantity
 
 // rootUser is the MinIO root user name written into the generated
 // credentials Secret. MinIO accepts any value here; the operator itself has
@@ -71,7 +71,7 @@ const rootUser = "minio"
 // status.currentState == "empty tenant credentials" indefinitely if this
 // Secret (and the spec.configuration.name reference to it) is missing —
 // confirmed against a real Tenant applied without it, see design-notes.md.
-const configSecretSuffix = "-env-configuration"
+const configSecretSuffix = "-env-configuration" //nolint:gosec // this is a Secret *name* suffix, not a credential value
 
 // backupBucketSuffix names the bucket auto-provisioned on the Tenant for the
 // Phase 3 backup bridge: on Ready, this Instance's own Tenant is registered
@@ -84,7 +84,7 @@ const backupBucketSuffix = "-backups"
 // (config.env shell-export lines vs. AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY,
 // the keys BackupStorageS3Spec.CredentialsSecretRef documents and
 // controller.Context.BackupStorageCredentials reads).
-const backupCredsSecretSuffix = "-backup-credentials"
+const backupCredsSecretSuffix = "-backup-credentials" //nolint:gosec // this is a Secret *name* suffix, not a credential value
 
 // backupStorageRegion is a fixed placeholder: MinIO doesn't have regions,
 // but BackupStorageS3Spec.Region is required (S3-compatible SDKs need
@@ -95,16 +95,52 @@ const backupStorageRegion = "us-east-1"
 // Provider implements controller.ProviderInterface for MinIO.
 type Provider struct{}
 
-func (p *Provider) Name() string { return "minio" }
+// Name returns this provider's registered name, matching manifest/provider.yaml.
+func (p *Provider) Name() string { return "minio" } //nolint:goconst // the provider name and the MinIO root username (rootUser) are unrelated even though the literal value happens to coincide
 
 // Types registers this package's Tenant/TenantList scheme additions, needed
 // so the runtime's client can Get/Apply/own Tenant objects.
 func (p *Provider) Types() func(*runtime.Scheme) error { return AddToScheme }
 
-func (p *Provider) Validate(c *controller.Context) error {
+// Validate is a no-op for this PoC: there is no provider-specific admission
+// validation yet beyond what the Instance/Provider CRDs' own schemas enforce.
+func (p *Provider) Validate(c *controller.Context) error { //nolint:unparam // signature is fixed by controller.ProviderInterface
 	log.FromContext(c.Context()).Info("minio provider: Validate called",
 		"instance", c.Name(), "namespace", c.Namespace())
 	return nil
+}
+
+// serverComponent is the resolved shape of the Instance's "server"
+// component, defaulted where the Instance leaves fields unset.
+type serverComponent struct {
+	replicas     int32
+	size         resource.Quantity
+	storageClass *string
+	version      string
+}
+
+// resolveServerComponent reads the Instance's "server" component (if any),
+// applying this PoC's defaults (1 replica, defaultVolumeSize) where unset.
+func resolveServerComponent(c *controller.Context) serverComponent {
+	sc := serverComponent{replicas: 1, size: defaultVolumeSize}
+
+	servers := c.ComponentsOfType(serverComponentType)
+	if len(servers) == 0 {
+		return sc
+	}
+
+	server := servers[0]
+	sc.version = server.Version
+	if server.Replicas != nil {
+		sc.replicas = *server.Replicas
+	}
+	if server.Storage != nil {
+		if !server.Storage.Size.IsZero() {
+			sc.size = server.Storage.Size
+		}
+		sc.storageClass = server.Storage.StorageClass
+	}
+	return sc
 }
 
 // Sync renders a MinIO Operator Tenant CR from the Instance spec and applies
@@ -121,26 +157,8 @@ func (p *Provider) Sync(c *controller.Context) error {
 		return fmt.Errorf("minio provider: fetching provider spec: %w", err)
 	}
 
-	replicas := int32(1)
-	size := defaultVolumeSize
-	var storageClass *string
-	version := ""
-
-	if servers := c.ComponentsOfType(serverComponentType); len(servers) > 0 {
-		server := servers[0]
-		version = server.Version
-		if server.Replicas != nil {
-			replicas = *server.Replicas
-		}
-		if server.Storage != nil {
-			if !server.Storage.Size.IsZero() {
-				size = server.Storage.Size
-			}
-			storageClass = server.Storage.StorageClass
-		}
-	}
-
-	image := resolveServerImage(providerSpec, version)
+	server := resolveServerComponent(c)
+	image := resolveServerImage(providerSpec, server.version)
 
 	creds, err := ensureCredentialsSecret(c)
 	if err != nil {
@@ -161,16 +179,16 @@ func (p *Provider) Sync(c *controller.Context) error {
 			Pools: []Pool{
 				{
 					Name:             "pool-0",
-					Servers:          replicas,
+					Servers:          server.replicas,
 					VolumesPerServer: 1,
 					VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
 						ObjectMeta: metav1.ObjectMeta{Name: "data"},
 						Spec: corev1.PersistentVolumeClaimSpec{
 							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{corev1.ResourceStorage: size},
+								Requests: corev1.ResourceList{corev1.ResourceStorage: server.size},
 							},
-							StorageClassName: storageClass,
+							StorageClassName: server.storageClass,
 						},
 					},
 				},
@@ -339,15 +357,10 @@ func (p *Provider) Status(c *controller.Context) (controller.Status, error) {
 		return controller.Status{}, fmt.Errorf("minio provider: getting Tenant %q: %w", c.Name(), err)
 	}
 
-	desired := int32(1)
-	if servers := c.ComponentsOfType(serverComponentType); len(servers) > 0 && servers[0].Replicas != nil {
-		desired = *servers[0].Replicas
-	}
-
 	componentStatus := controller.ComponentStatus{
 		Name:  serverComponentType,
 		Ready: tenant.Status.AvailableReplicas,
-		Total: desired,
+		Total: resolveServerComponent(c).replicas,
 		State: tenant.Status.CurrentState,
 	}
 
@@ -366,7 +379,11 @@ func (p *Provider) Status(c *controller.Context) (controller.Status, error) {
 	return status, nil
 }
 
-func (p *Provider) Cleanup(c *controller.Context) error {
+// Cleanup is a no-op for this PoC: the Tenant, both credentials Secrets, and
+// the BackupStorage are all owned by the Instance (set via c.Apply), so
+// Kubernetes garbage collection removes them without any provider-side
+// action needed.
+func (p *Provider) Cleanup(c *controller.Context) error { //nolint:unparam // signature is fixed by controller.ProviderInterface
 	log.FromContext(c.Context()).Info("minio provider: Cleanup called",
 		"instance", c.Name(), "namespace", c.Namespace())
 	return nil

--- a/providers/minio/provider.go
+++ b/providers/minio/provider.go
@@ -13,13 +13,11 @@
 // limitations under the License.
 
 // Package minio implements a provider-runtime ProviderInterface for MinIO
-// object storage. This is a Phase 0-3 PoC (LFX Term 3, upstream issue
-// openeverest#2255): Sync renders and applies a real MinIO Operator Tenant
-// CR (minio.min.io/v1) from the Instance spec, and Status reads it back and,
+// object storage. Sync renders and applies a MinIO Operator Tenant CR
+// (minio.min.io/v2) from the Instance spec, and Status reads it back and,
 // once Ready, registers the Tenant as a BackupStorage other
-// OpenEverest-managed databases can use as a backup target. Dedicated
-// bucket/user/policy management (the open design question in
-// design-notes.md) is deliberately out of scope here.
+// OpenEverest-managed databases can use as a backup target. Bucket/user/
+// policy management is out of scope.
 package minio
 
 import (
@@ -40,42 +38,37 @@ import (
 	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
 )
 
-// serverComponentType is the only componentType this Phase 2 PoC knows
-// about, matching manifest/provider.yaml.
+// serverComponentType is the only componentType this provider knows about,
+// matching manifest/provider.yaml.
 const serverComponentType = "server"
 
 // tenantStatusInitialized is the MinIO Operator's Tenant.status.currentState
-// value once the Tenant is fully up. Verified directly against a running
-// operator during Phase 0/1 (see design-notes.md).
+// value once the Tenant is fully up.
 const tenantStatusInitialized = "Initialized"
 
-// defaultMinIOImage is the operator's own fallback image, used only if the
-// Provider CR somehow declares no default version for the "server"
-// componentType. Matches github.com/minio/operator/pkg/apis/minio.min.io/v1.DefaultMinIOImage.
+// defaultMinIOImage is used only if the Provider CR declares no default
+// version for the "server" componentType.
 const defaultMinIOImage = "minio/minio:RELEASE.2020-12-23T02-24-12Z"
 
 // defaultVolumeSize is used when the Instance's "server" component doesn't
-// specify storage. Matches the size hand-verified against a real kind
-// cluster in Phase 0.
+// specify storage.
 var defaultVolumeSize = resource.MustParse("1Gi") //nolint:gochecknoglobals // resource.Quantity has no const form; same pattern as internal/server/handlers/validation/errors.go's minStorageQuantity
 
 // rootUser is the MinIO root user name written into the generated
 // credentials Secret. MinIO accepts any value here; the operator itself has
-// no default, so a fixed name is used for this PoC (bucket/user management
-// is a deferred design question, see design-notes.md).
+// no default.
 const rootUser = "minio"
 
 // configSecretSuffix names the Secret holding the Tenant's root credentials,
-// referenced via Tenant.Spec.Configuration.Name. Discovered the hard way in
-// Phase 2: the MinIO Operator leaves a Tenant stuck at
-// status.currentState == "empty tenant credentials" indefinitely if this
-// Secret (and the spec.configuration.name reference to it) is missing —
-// confirmed against a real Tenant applied without it, see design-notes.md.
+// referenced via Tenant.Spec.Configuration.Name. The MinIO Operator leaves a
+// Tenant stuck at status.currentState == "empty tenant credentials"
+// indefinitely if this Secret (and the spec.configuration.name reference to
+// it) is missing.
 const configSecretSuffix = "-env-configuration" //nolint:gosec // this is a Secret *name* suffix, not a credential value
 
-// backupBucketSuffix names the bucket auto-provisioned on the Tenant for the
-// Phase 3 backup bridge: on Ready, this Instance's own Tenant is registered
-// as a BackupStorage other OpenEverest-managed databases can back up into.
+// backupBucketSuffix names the bucket auto-provisioned on the Tenant so it
+// can be registered as a BackupStorage other OpenEverest-managed databases
+// can back up into.
 const backupBucketSuffix = "-backups"
 
 // backupCredsSecretSuffix names the Secret backing the BackupStorage's
@@ -87,9 +80,9 @@ const backupBucketSuffix = "-backups"
 const backupCredsSecretSuffix = "-backup-credentials" //nolint:gosec // this is a Secret *name* suffix, not a credential value
 
 // backupStorageRegion is a fixed placeholder: MinIO doesn't have regions,
-// but BackupStorageS3Spec.Region is required (S3-compatible SDKs need
-// something in the field). Matches the convention already used for MinIO in
-// this repo's own dev/resources/backupstorage.yaml fixture.
+// but BackupStorageS3Spec.Region is required. Matches the convention already
+// used for MinIO in this repo's own dev/resources/backupstorage.yaml
+// fixture.
 const backupStorageRegion = "us-east-1"
 
 // Provider implements controller.ProviderInterface for MinIO.
@@ -102,8 +95,8 @@ func (p *Provider) Name() string { return "minio" } //nolint:goconst // the prov
 // so the runtime's client can Get/Apply/own Tenant objects.
 func (p *Provider) Types() func(*runtime.Scheme) error { return AddToScheme }
 
-// Validate is a no-op for this PoC: there is no provider-specific admission
-// validation yet beyond what the Instance/Provider CRDs' own schemas enforce.
+// Validate is a no-op: there is no provider-specific admission validation
+// yet beyond what the Instance/Provider CRDs' own schemas enforce.
 func (p *Provider) Validate(c *controller.Context) error { //nolint:unparam // signature is fixed by controller.ProviderInterface
 	log.FromContext(c.Context()).Info("minio provider: Validate called",
 		"instance", c.Name(), "namespace", c.Namespace())
@@ -120,7 +113,7 @@ type serverComponent struct {
 }
 
 // resolveServerComponent reads the Instance's "server" component (if any),
-// applying this PoC's defaults (1 replica, defaultVolumeSize) where unset.
+// applying defaults (1 replica, defaultVolumeSize) where unset.
 func resolveServerComponent(c *controller.Context) serverComponent {
 	sc := serverComponent{replicas: 1, size: defaultVolumeSize}
 
@@ -146,8 +139,7 @@ func resolveServerComponent(c *controller.Context) serverComponent {
 // Sync renders a MinIO Operator Tenant CR from the Instance spec and applies
 // it. The "server" component (if present) maps onto the Tenant's single
 // Pool: Replicas -> Pool.Servers, Storage -> Pool.VolumeClaimTemplate.
-// VolumesPerServer is hardcoded to 1 for this PoC (see design-notes.md's
-// open question on modeling it distinctly from replica count).
+// VolumesPerServer is hardcoded to 1.
 func (p *Provider) Sync(c *controller.Context) error {
 	logger := log.FromContext(c.Context())
 	logger.Info("minio provider: Sync called", "instance", c.Name(), "namespace", c.Namespace())
@@ -169,10 +161,9 @@ func (p *Provider) Sync(c *controller.Context) error {
 		ObjectMeta: c.ObjectMeta(c.Name()),
 		Spec: TenantSpec{
 			Image: image,
-			// false, not nil/true: the CRD declares no default for this
-			// field, and Phase 0's hand-verified working Tenant set it to
-			// false explicitly (avoids depending on cert-manager or the
-			// operator's own CSR-based autocert flow for this PoC).
+			// false, not nil: the CRD declares no default for this field;
+			// explicit false avoids depending on cert-manager or the
+			// operator's own CSR-based autocert flow.
 			RequestAutoCert: new(bool),
 			Configuration:   &corev1.LocalObjectReference{Name: creds.secretName},
 			Buckets:         []Bucket{{Name: c.Name() + backupBucketSuffix}},
@@ -217,10 +208,9 @@ type credentials struct {
 // which would overwrite the password on every reconcile and desync it from
 // whatever the MinIO server actually booted with (the operator only reads
 // this Secret once, at Tenant bootstrap). The plain "rootUser"/"rootPassword"
-// keys (alongside the config.env the Tenant itself needs) exist so callers
-// don't have to re-parse the shell-export format to recover the password —
-// used by ensureBackupStorage to mint S3-style credentials for the same
-// account.
+// keys, alongside the config.env the Tenant itself needs, let
+// ensureBackupStorage recover the password without re-parsing the
+// shell-export format.
 func ensureCredentialsSecret(c *controller.Context) (credentials, error) {
 	name := c.Name() + configSecretSuffix
 
@@ -257,11 +247,9 @@ func ensureCredentialsSecret(c *controller.Context) (credentials, error) {
 }
 
 // ensureBackupStorage registers this Instance's own Tenant as a
-// BackupStorage other OpenEverest-managed databases can back up into — the
-// Phase 3 "backup bridge" (see ROADMAP.md §4 Phase 3, design-notes.md). It
+// BackupStorage other OpenEverest-managed databases can back up into. It
 // reuses the Tenant's root credentials rather than minting a dedicated MinIO
-// user/policy: bucket/user/policy management is the open design question in
-// design-notes.md, deliberately deferred past this PoC.
+// user/policy; bucket/user/policy management is out of scope here.
 func ensureBackupStorage(c *controller.Context) error {
 	creds, err := ensureCredentialsSecret(c)
 	if err != nil {
@@ -290,9 +278,7 @@ func ensureBackupStorage(c *controller.Context) error {
 				Bucket: c.Name() + backupBucketSuffix,
 				Region: backupStorageRegion,
 				// In-cluster headless Service the MinIO Operator creates
-				// for every Tenant, named "<tenant>-hl", port 9000 — the
-				// same endpoint hand-verified with a real mc round-trip in
-				// Phase 2 (see design-notes.md).
+				// for every Tenant, named "<tenant>-hl", port 9000.
 				EndpointURL:          fmt.Sprintf("http://%s-hl.%s.svc.cluster.local:9000", c.Name(), c.Namespace()),
 				VerifyTLS:            &verifyTLS,
 				ForcePathStyle:       &forcePathStyle,
@@ -379,8 +365,8 @@ func (p *Provider) Status(c *controller.Context) (controller.Status, error) {
 	return status, nil
 }
 
-// Cleanup is a no-op for this PoC: the Tenant, both credentials Secrets, and
-// the BackupStorage are all owned by the Instance (set via c.Apply), so
+// Cleanup is a no-op: the Tenant, both credentials Secrets, and the
+// BackupStorage are all owned by the Instance (set via c.Apply), so
 // Kubernetes garbage collection removes them without any provider-side
 // action needed.
 func (p *Provider) Cleanup(c *controller.Context) error { //nolint:unparam // signature is fixed by controller.ProviderInterface

--- a/providers/minio/provider.go
+++ b/providers/minio/provider.go
@@ -1,0 +1,373 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package minio implements a provider-runtime ProviderInterface for MinIO
+// object storage. This is a Phase 0-3 PoC (LFX Term 3, upstream issue
+// openeverest#2255): Sync renders and applies a real MinIO Operator Tenant
+// CR (minio.min.io/v1) from the Instance spec, and Status reads it back and,
+// once Ready, registers the Tenant as a BackupStorage other
+// OpenEverest-managed databases can use as a backup target. Dedicated
+// bucket/user/policy management (the open design question in
+// design-notes.md) is deliberately out of scope here.
+package minio
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	backupv1alpha1 "github.com/openeverest/openeverest/v2/api/backup/v1alpha1"
+	commonv1alpha1 "github.com/openeverest/openeverest/v2/api/common/v1alpha1"
+	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
+)
+
+// serverComponentType is the only componentType this Phase 2 PoC knows
+// about, matching manifest/provider.yaml.
+const serverComponentType = "server"
+
+// tenantStatusInitialized is the MinIO Operator's Tenant.status.currentState
+// value once the Tenant is fully up. Verified directly against a running
+// operator during Phase 0/1 (see design-notes.md).
+const tenantStatusInitialized = "Initialized"
+
+// defaultMinIOImage is the operator's own fallback image, used only if the
+// Provider CR somehow declares no default version for the "server"
+// componentType. Matches github.com/minio/operator/pkg/apis/minio.min.io/v1.DefaultMinIOImage.
+const defaultMinIOImage = "minio/minio:RELEASE.2020-12-23T02-24-12Z"
+
+// defaultVolumeSize is used when the Instance's "server" component doesn't
+// specify storage. Matches the size hand-verified against a real kind
+// cluster in Phase 0.
+var defaultVolumeSize = resource.MustParse("1Gi")
+
+// rootUser is the MinIO root user name written into the generated
+// credentials Secret. MinIO accepts any value here; the operator itself has
+// no default, so a fixed name is used for this PoC (bucket/user management
+// is a deferred design question, see design-notes.md).
+const rootUser = "minio"
+
+// configSecretSuffix names the Secret holding the Tenant's root credentials,
+// referenced via Tenant.Spec.Configuration.Name. Discovered the hard way in
+// Phase 2: the MinIO Operator leaves a Tenant stuck at
+// status.currentState == "empty tenant credentials" indefinitely if this
+// Secret (and the spec.configuration.name reference to it) is missing —
+// confirmed against a real Tenant applied without it, see design-notes.md.
+const configSecretSuffix = "-env-configuration"
+
+// backupBucketSuffix names the bucket auto-provisioned on the Tenant for the
+// Phase 3 backup bridge: on Ready, this Instance's own Tenant is registered
+// as a BackupStorage other OpenEverest-managed databases can back up into.
+const backupBucketSuffix = "-backups"
+
+// backupCredsSecretSuffix names the Secret backing the BackupStorage's
+// CredentialsSecretRef. Kept separate from the Tenant's own
+// configSecretSuffix Secret because the two use different key conventions
+// (config.env shell-export lines vs. AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY,
+// the keys BackupStorageS3Spec.CredentialsSecretRef documents and
+// controller.Context.BackupStorageCredentials reads).
+const backupCredsSecretSuffix = "-backup-credentials"
+
+// backupStorageRegion is a fixed placeholder: MinIO doesn't have regions,
+// but BackupStorageS3Spec.Region is required (S3-compatible SDKs need
+// something in the field). Matches the convention already used for MinIO in
+// this repo's own dev/resources/backupstorage.yaml fixture.
+const backupStorageRegion = "us-east-1"
+
+// Provider implements controller.ProviderInterface for MinIO.
+type Provider struct{}
+
+func (p *Provider) Name() string { return "minio" }
+
+// Types registers this package's Tenant/TenantList scheme additions, needed
+// so the runtime's client can Get/Apply/own Tenant objects.
+func (p *Provider) Types() func(*runtime.Scheme) error { return AddToScheme }
+
+func (p *Provider) Validate(c *controller.Context) error {
+	log.FromContext(c.Context()).Info("minio provider: Validate called",
+		"instance", c.Name(), "namespace", c.Namespace())
+	return nil
+}
+
+// Sync renders a MinIO Operator Tenant CR from the Instance spec and applies
+// it. The "server" component (if present) maps onto the Tenant's single
+// Pool: Replicas -> Pool.Servers, Storage -> Pool.VolumeClaimTemplate.
+// VolumesPerServer is hardcoded to 1 for this PoC (see design-notes.md's
+// open question on modeling it distinctly from replica count).
+func (p *Provider) Sync(c *controller.Context) error {
+	logger := log.FromContext(c.Context())
+	logger.Info("minio provider: Sync called", "instance", c.Name(), "namespace", c.Namespace())
+
+	providerSpec, err := c.ProviderSpec()
+	if err != nil {
+		return fmt.Errorf("minio provider: fetching provider spec: %w", err)
+	}
+
+	replicas := int32(1)
+	size := defaultVolumeSize
+	var storageClass *string
+	version := ""
+
+	if servers := c.ComponentsOfType(serverComponentType); len(servers) > 0 {
+		server := servers[0]
+		version = server.Version
+		if server.Replicas != nil {
+			replicas = *server.Replicas
+		}
+		if server.Storage != nil {
+			if !server.Storage.Size.IsZero() {
+				size = server.Storage.Size
+			}
+			storageClass = server.Storage.StorageClass
+		}
+	}
+
+	image := resolveServerImage(providerSpec, version)
+
+	creds, err := ensureCredentialsSecret(c)
+	if err != nil {
+		return fmt.Errorf("minio provider: ensuring credentials secret: %w", err)
+	}
+
+	tenant := &Tenant{
+		ObjectMeta: c.ObjectMeta(c.Name()),
+		Spec: TenantSpec{
+			Image: image,
+			// false, not nil/true: the CRD declares no default for this
+			// field, and Phase 0's hand-verified working Tenant set it to
+			// false explicitly (avoids depending on cert-manager or the
+			// operator's own CSR-based autocert flow for this PoC).
+			RequestAutoCert: new(bool),
+			Configuration:   &corev1.LocalObjectReference{Name: creds.secretName},
+			Buckets:         []Bucket{{Name: c.Name() + backupBucketSuffix}},
+			Pools: []Pool{
+				{
+					Name:             "pool-0",
+					Servers:          replicas,
+					VolumesPerServer: 1,
+					VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{Name: "data"},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceStorage: size},
+							},
+							StorageClassName: storageClass,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := c.Apply(tenant); err != nil {
+		return fmt.Errorf("minio provider: applying Tenant %q: %w", tenant.Name, err)
+	}
+	return nil
+}
+
+// credentials is the resolved MinIO root user/password backing a Tenant's
+// credentials Secret, along with that Secret's own name.
+type credentials struct {
+	secretName   string
+	rootUser     string
+	rootPassword string
+}
+
+// ensureCredentialsSecret returns the credentials backing the Tenant's
+// spec.configuration.name, creating them with a freshly generated root
+// password if the Secret doesn't already exist. It deliberately does not
+// use c.Apply for the already-exists case: c.Apply always issues an Update,
+// which would overwrite the password on every reconcile and desync it from
+// whatever the MinIO server actually booted with (the operator only reads
+// this Secret once, at Tenant bootstrap). The plain "rootUser"/"rootPassword"
+// keys (alongside the config.env the Tenant itself needs) exist so callers
+// don't have to re-parse the shell-export format to recover the password —
+// used by ensureBackupStorage to mint S3-style credentials for the same
+// account.
+func ensureCredentialsSecret(c *controller.Context) (credentials, error) {
+	name := c.Name() + configSecretSuffix
+
+	existing := &corev1.Secret{}
+	exists, err := c.Exists(existing, name)
+	if err != nil {
+		return credentials{}, fmt.Errorf("checking for existing credentials secret %q: %w", name, err)
+	}
+	if exists {
+		return credentials{
+			secretName:   name,
+			rootUser:     string(existing.Data["rootUser"]),
+			rootPassword: string(existing.Data["rootPassword"]),
+		}, nil
+	}
+
+	password, err := randomHex(20)
+	if err != nil {
+		return credentials{}, fmt.Errorf("generating root password: %w", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: c.ObjectMeta(name),
+		Data: map[string][]byte{
+			"config.env":   fmt.Appendf(nil, "export MINIO_ROOT_USER=%q\nexport MINIO_ROOT_PASSWORD=%q\n", rootUser, password),
+			"rootUser":     []byte(rootUser),
+			"rootPassword": []byte(password),
+		},
+	}
+	if err := c.Apply(secret); err != nil {
+		return credentials{}, fmt.Errorf("creating credentials secret %q: %w", name, err)
+	}
+	return credentials{secretName: name, rootUser: rootUser, rootPassword: password}, nil
+}
+
+// ensureBackupStorage registers this Instance's own Tenant as a
+// BackupStorage other OpenEverest-managed databases can back up into — the
+// Phase 3 "backup bridge" (see ROADMAP.md §4 Phase 3, design-notes.md). It
+// reuses the Tenant's root credentials rather than minting a dedicated MinIO
+// user/policy: bucket/user/policy management is the open design question in
+// design-notes.md, deliberately deferred past this PoC.
+func ensureBackupStorage(c *controller.Context) error {
+	creds, err := ensureCredentialsSecret(c)
+	if err != nil {
+		return fmt.Errorf("resolving root credentials: %w", err)
+	}
+
+	backupSecretName := c.Name() + backupCredsSecretSuffix
+	backupSecret := &corev1.Secret{
+		ObjectMeta: c.ObjectMeta(backupSecretName),
+		Data: map[string][]byte{
+			"AWS_ACCESS_KEY_ID":     []byte(creds.rootUser),
+			"AWS_SECRET_ACCESS_KEY": []byte(creds.rootPassword),
+		},
+	}
+	if err := c.Apply(backupSecret); err != nil {
+		return fmt.Errorf("applying backup credentials secret %q: %w", backupSecretName, err)
+	}
+
+	verifyTLS := false
+	forcePathStyle := true
+	backupStorage := &backupv1alpha1.BackupStorage{
+		ObjectMeta: c.ObjectMeta(c.Name()),
+		Spec: backupv1alpha1.BackupStorageSpec{
+			Type: backupv1alpha1.BackupStorageTypeS3,
+			S3: &backupv1alpha1.BackupStorageS3Spec{
+				Bucket: c.Name() + backupBucketSuffix,
+				Region: backupStorageRegion,
+				// In-cluster headless Service the MinIO Operator creates
+				// for every Tenant, named "<tenant>-hl", port 9000 — the
+				// same endpoint hand-verified with a real mc round-trip in
+				// Phase 2 (see design-notes.md).
+				EndpointURL:          fmt.Sprintf("http://%s-hl.%s.svc.cluster.local:9000", c.Name(), c.Namespace()),
+				VerifyTLS:            &verifyTLS,
+				ForcePathStyle:       &forcePathStyle,
+				CredentialsSecretRef: commonv1alpha1.SecretRef{Name: backupSecretName},
+			},
+		},
+	}
+	if err := c.Apply(backupStorage); err != nil {
+		return fmt.Errorf("applying BackupStorage %q: %w", backupStorage.Name, err)
+	}
+	return nil
+}
+
+// randomHex returns a cryptographically random hex string of n bytes (2n
+// hex characters). Hex-only output is safe to embed unescaped inside the
+// double-quoted shell-export lines config.env requires.
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// resolveServerImage looks up the image for the given resolved component
+// version in the Provider's "server" componentType. Falls back to the
+// componentType's default version's image, then to the operator's own
+// built-in default image, if version is empty or unresolvable.
+func resolveServerImage(spec *corev1alpha1.ProviderSpec, version string) string {
+	ct, ok := spec.ComponentTypes[serverComponentType]
+	if !ok {
+		return defaultMinIOImage
+	}
+
+	var defaultImage string
+	for _, v := range ct.Versions {
+		if v.Version == version && version != "" {
+			return v.Image
+		}
+		if v.Default {
+			defaultImage = v.Image
+		}
+	}
+	if defaultImage != "" {
+		return defaultImage
+	}
+	return defaultMinIOImage
+}
+
+// Status reads the MinIO Operator Tenant's observed state back onto the
+// Instance. tenantStatusInitialized is treated as Ready; anything else
+// (including "not created yet") is Provisioning.
+func (p *Provider) Status(c *controller.Context) (controller.Status, error) {
+	logger := log.FromContext(c.Context())
+	logger.Info("minio provider: Status called", "instance", c.Name(), "namespace", c.Namespace())
+
+	tenant := &Tenant{}
+	if err := c.Get(tenant, c.Name()); err != nil {
+		if apierrors.IsNotFound(err) {
+			return controller.Provisioning("waiting for MinIO Tenant to be created"), nil
+		}
+		return controller.Status{}, fmt.Errorf("minio provider: getting Tenant %q: %w", c.Name(), err)
+	}
+
+	desired := int32(1)
+	if servers := c.ComponentsOfType(serverComponentType); len(servers) > 0 && servers[0].Replicas != nil {
+		desired = *servers[0].Replicas
+	}
+
+	componentStatus := controller.ComponentStatus{
+		Name:  serverComponentType,
+		Ready: tenant.Status.AvailableReplicas,
+		Total: desired,
+		State: tenant.Status.CurrentState,
+	}
+
+	if tenant.Status.CurrentState != tenantStatusInitialized {
+		status := controller.Provisioning(tenant.Status.CurrentState)
+		status.Components = []controller.ComponentStatus{componentStatus}
+		return status, nil
+	}
+
+	if err := ensureBackupStorage(c); err != nil {
+		return controller.Status{}, fmt.Errorf("minio provider: registering BackupStorage: %w", err)
+	}
+
+	status := controller.Ready()
+	status.Components = []controller.ComponentStatus{componentStatus}
+	return status, nil
+}
+
+func (p *Provider) Cleanup(c *controller.Context) error {
+	log.FromContext(c.Context()).Info("minio provider: Cleanup called",
+		"instance", c.Name(), "namespace", c.Namespace())
+	return nil
+}

--- a/providers/minio/provider_test.go
+++ b/providers/minio/provider_test.go
@@ -1,0 +1,288 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package minio
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	backupv1alpha1 "github.com/openeverest/openeverest/v2/api/backup/v1alpha1"
+	common "github.com/openeverest/openeverest/v2/api/common/v1alpha1"
+	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
+)
+
+// newTestScheme mirrors provider-runtime/reconciler's own newTestScheme
+// (cascade_delete_test.go): the real reconciler registers corev1,
+// corev1alpha1, and backupv1alpha1 by default (see reconciler/provider.go),
+// plus whatever the provider's own Types() adds.
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, corev1alpha1.AddToScheme(s))
+	require.NoError(t, backupv1alpha1.AddToScheme(s))
+	require.NoError(t, AddToScheme(s))
+	return s
+}
+
+// testProvider returns a Provider CR shaped like manifest/provider.yaml,
+// with one extra non-default version so version-resolution can be exercised.
+func testProvider() *corev1alpha1.Provider {
+	return &corev1alpha1.Provider{
+		ObjectMeta: metav1.ObjectMeta{Name: "minio"},
+		Spec: corev1alpha1.ProviderSpec{
+			ComponentTypes: map[string]corev1alpha1.ComponentType{
+				serverComponentType: {
+					Versions: []corev1alpha1.ComponentVersion{
+						{Version: "RELEASE.2025-04-08T15-41-24Z", Image: "quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z", Default: true},
+						{Version: "RELEASE.2024-01-01T00-00-00Z", Image: "quay.io/minio/minio:RELEASE.2024-01-01T00-00-00Z"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// testInstanceName is the name every test fixture Instance/Tenant/
+// BackupStorage in this file shares; each test builds its own isolated fake
+// client, so a shared name causes no cross-test interference.
+const testInstanceName = "minio-poc"
+
+func testInstance(mutate func(*corev1alpha1.Instance)) *corev1alpha1.Instance {
+	in := &corev1alpha1.Instance{
+		ObjectMeta: metav1.ObjectMeta{Name: testInstanceName, Namespace: "default"},
+		Spec: corev1alpha1.InstanceSpec{
+			ProviderRef: common.ObjectRef{Name: "minio"},
+		},
+	}
+	if mutate != nil {
+		mutate(in)
+	}
+	return in
+}
+
+func newTestContext(t *testing.T, c client.Client, in *corev1alpha1.Instance) *controller.Context {
+	t.Helper()
+	return controller.NewContext(context.Background(), c, in, "minio")
+}
+
+func TestResolveServerImage(t *testing.T) {
+	t.Parallel()
+
+	spec := &testProvider().Spec
+
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{"empty version resolves to the default bundle's image", "", "quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z"},
+		{"known non-default version resolves to its own image", "RELEASE.2024-01-01T00-00-00Z", "quay.io/minio/minio:RELEASE.2024-01-01T00-00-00Z"},
+		{"unknown version falls back to the default bundle's image", "RELEASE.9999-01-01T00-00-00Z", "quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, resolveServerImage(spec, tt.version))
+		})
+	}
+
+	t.Run("componentType missing entirely falls back to the operator's own default", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, defaultMinIOImage, resolveServerImage(&corev1alpha1.ProviderSpec{}, ""))
+	})
+}
+
+func TestSync_RendersTenantFromInstanceDefaults(t *testing.T) {
+	t.Parallel()
+
+	scheme := newTestScheme(t)
+	instance := testInstance(nil)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testProvider(), instance).Build()
+	ctx := newTestContext(t, c, instance)
+
+	p := &Provider{}
+	require.NoError(t, p.Sync(ctx))
+
+	tenant := &Tenant{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "minio-poc", Namespace: "default"}, tenant))
+
+	assert.Equal(t, "quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z", tenant.Spec.Image)
+	require.Len(t, tenant.Spec.Pools, 1)
+	assert.EqualValues(t, 1, tenant.Spec.Pools[0].Servers, "defaults to 1 replica when the Instance sets no server component")
+	assert.EqualValues(t, 1, tenant.Spec.Pools[0].VolumesPerServer)
+	require.NotNil(t, tenant.Spec.Pools[0].VolumeClaimTemplate)
+	assert.Equal(t, defaultVolumeSize, tenant.Spec.Pools[0].VolumeClaimTemplate.Spec.Resources.Requests[corev1.ResourceStorage])
+	require.NotNil(t, tenant.Spec.RequestAutoCert)
+	assert.False(t, *tenant.Spec.RequestAutoCert)
+	require.NotNil(t, tenant.Spec.Configuration)
+	assert.Equal(t, "minio-poc"+configSecretSuffix, tenant.Spec.Configuration.Name)
+	require.Len(t, tenant.Spec.Buckets, 1)
+	assert.Equal(t, "minio-poc"+backupBucketSuffix, tenant.Spec.Buckets[0].Name)
+
+	// The credentials Secret referenced by Configuration must actually
+	// exist, own a config.env the MinIO Operator can parse, and expose the
+	// plain rootUser/rootPassword keys ensureBackupStorage relies on.
+	secret := &corev1.Secret{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: tenant.Spec.Configuration.Name, Namespace: "default"}, secret))
+	assert.NotEmpty(t, secret.Data["config.env"])
+	assert.Equal(t, rootUser, string(secret.Data["rootUser"]))
+	assert.NotEmpty(t, secret.Data["rootPassword"])
+}
+
+func TestSync_HonorsExplicitReplicasAndStorage(t *testing.T) {
+	t.Parallel()
+
+	scheme := newTestScheme(t)
+	replicas := int32(4)
+	storageClass := "fast-ssd"
+	instance := testInstance(func(in *corev1alpha1.Instance) {
+		in.Spec.Components = map[string]corev1alpha1.ComponentSpec{
+			"server": {
+				Type:     serverComponentType,
+				Replicas: &replicas,
+				Storage: &corev1alpha1.Storage{
+					Size:         resource.MustParse("10Gi"),
+					StorageClass: &storageClass,
+				},
+			},
+		}
+	})
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testProvider(), instance).Build()
+	ctx := newTestContext(t, c, instance)
+
+	require.NoError(t, (&Provider{}).Sync(ctx))
+
+	tenant := &Tenant{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "minio-poc", Namespace: "default"}, tenant))
+
+	require.Len(t, tenant.Spec.Pools, 1)
+	assert.EqualValues(t, 4, tenant.Spec.Pools[0].Servers)
+	assert.Equal(t, resource.MustParse("10Gi"), tenant.Spec.Pools[0].VolumeClaimTemplate.Spec.Resources.Requests[corev1.ResourceStorage])
+	require.NotNil(t, tenant.Spec.Pools[0].VolumeClaimTemplate.Spec.StorageClassName)
+	assert.Equal(t, "fast-ssd", *tenant.Spec.Pools[0].VolumeClaimTemplate.Spec.StorageClassName)
+}
+
+// TestSync_CredentialsSecretIsStableAcrossReconciles is a regression test
+// for the Phase 2 bug (see design-notes.md): ensureCredentialsSecret must
+// only generate the root password once. Calling Sync again (as the
+// reconciler routinely does) must not desync the stored password from
+// whatever the MinIO server already booted with.
+func TestSync_CredentialsSecretIsStableAcrossReconciles(t *testing.T) {
+	t.Parallel()
+
+	scheme := newTestScheme(t)
+	instance := testInstance(nil)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testProvider(), instance).Build()
+	ctx := newTestContext(t, c, instance)
+
+	require.NoError(t, (&Provider{}).Sync(ctx))
+	first := &corev1.Secret{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "minio-poc" + configSecretSuffix, Namespace: "default"}, first))
+
+	require.NoError(t, (&Provider{}).Sync(ctx))
+	second := &corev1.Secret{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "minio-poc" + configSecretSuffix, Namespace: "default"}, second))
+
+	assert.Equal(t, first.Data["rootPassword"], second.Data["rootPassword"])
+	assert.Equal(t, first.Data["config.env"], second.Data["config.env"])
+}
+
+func TestStatus_TenantNotFound_ReturnsProvisioning(t *testing.T) {
+	t.Parallel()
+
+	scheme := newTestScheme(t)
+	instance := testInstance(nil)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testProvider(), instance).Build()
+	ctx := newTestContext(t, c, instance)
+
+	status, err := (&Provider{}).Status(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.InstancePhaseProvisioning, status.Phase)
+}
+
+func TestStatus_TenantNotInitialized_ReturnsProvisioning(t *testing.T) {
+	t.Parallel()
+
+	scheme := newTestScheme(t)
+	instance := testInstance(nil)
+	tenant := &Tenant{
+		ObjectMeta: metav1.ObjectMeta{Name: testInstanceName, Namespace: "default"},
+		Status:     TenantStatus{CurrentState: "empty tenant credentials"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testProvider(), instance, tenant).Build()
+	ctx := newTestContext(t, c, instance)
+
+	status, err := (&Provider{}).Status(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.InstancePhaseProvisioning, status.Phase)
+
+	// A not-yet-ready Tenant must not advertise a BackupStorage: nothing
+	// should reference a backup target that can't accept writes yet.
+	bs := &backupv1alpha1.BackupStorage{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "minio-poc", Namespace: "default"}, bs)
+	assert.Error(t, err, "no BackupStorage should be created before the Tenant is Initialized")
+}
+
+// TestStatus_TenantInitialized_ReturnsReadyAndRegistersBackupStorage is a
+// regression test for the Phase 3 backup bridge: once the Tenant is
+// Initialized, Status must both report Ready and register a BackupStorage
+// pointing at this Instance's own Tenant, reusing its root credentials.
+func TestStatus_TenantInitialized_ReturnsReadyAndRegistersBackupStorage(t *testing.T) {
+	t.Parallel()
+
+	scheme := newTestScheme(t)
+	instance := testInstance(nil)
+	credsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "minio-poc" + configSecretSuffix, Namespace: "default"},
+		Data: map[string][]byte{
+			"rootUser":     []byte("minio"),
+			"rootPassword": []byte("s3cr3t-test-password"),
+		},
+	}
+	tenant := &Tenant{
+		ObjectMeta: metav1.ObjectMeta{Name: testInstanceName, Namespace: "default"},
+		Status:     TenantStatus{CurrentState: tenantStatusInitialized, AvailableReplicas: 1},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testProvider(), instance, tenant, credsSecret).Build()
+	ctx := newTestContext(t, c, instance)
+
+	status, err := (&Provider{}).Status(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.InstancePhaseReady, status.Phase)
+
+	bs := &backupv1alpha1.BackupStorage{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "minio-poc", Namespace: "default"}, bs))
+	assert.Equal(t, backupv1alpha1.BackupStorageTypeS3, bs.Spec.Type)
+	require.NotNil(t, bs.Spec.S3)
+	assert.Equal(t, "minio-poc"+backupBucketSuffix, bs.Spec.S3.Bucket)
+	assert.Equal(t, "http://minio-poc-hl.default.svc.cluster.local:9000", bs.Spec.S3.EndpointURL)
+	assert.Equal(t, "minio-poc"+backupCredsSecretSuffix, bs.Spec.S3.CredentialsSecretRef.Name)
+
+	backupSecret := &corev1.Secret{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "minio-poc" + backupCredsSecretSuffix, Namespace: "default"}, backupSecret))
+	assert.Equal(t, "minio", string(backupSecret.Data["AWS_ACCESS_KEY_ID"]))
+	assert.Equal(t, "s3cr3t-test-password", string(backupSecret.Data["AWS_SECRET_ACCESS_KEY"]))
+}

--- a/providers/minio/provider_test.go
+++ b/providers/minio/provider_test.go
@@ -185,11 +185,10 @@ func TestSync_HonorsExplicitReplicasAndStorage(t *testing.T) {
 	assert.Equal(t, "fast-ssd", *tenant.Spec.Pools[0].VolumeClaimTemplate.Spec.StorageClassName)
 }
 
-// TestSync_CredentialsSecretIsStableAcrossReconciles is a regression test
-// for the Phase 2 bug (see design-notes.md): ensureCredentialsSecret must
-// only generate the root password once. Calling Sync again (as the
-// reconciler routinely does) must not desync the stored password from
-// whatever the MinIO server already booted with.
+// TestSync_CredentialsSecretIsStableAcrossReconciles is a regression test:
+// ensureCredentialsSecret must only generate the root password once.
+// Calling Sync again (as the reconciler routinely does) must not desync the
+// stored password from whatever the MinIO server already booted with.
 func TestSync_CredentialsSecretIsStableAcrossReconciles(t *testing.T) {
 	t.Parallel()
 
@@ -247,9 +246,9 @@ func TestStatus_TenantNotInitialized_ReturnsProvisioning(t *testing.T) {
 }
 
 // TestStatus_TenantInitialized_ReturnsReadyAndRegistersBackupStorage is a
-// regression test for the Phase 3 backup bridge: once the Tenant is
-// Initialized, Status must both report Ready and register a BackupStorage
-// pointing at this Instance's own Tenant, reusing its root credentials.
+// regression test for the backup bridge: once the Tenant is Initialized,
+// Status must both report Ready and register a BackupStorage pointing at
+// this Instance's own Tenant, reusing its root credentials.
 func TestStatus_TenantInitialized_ReturnsReadyAndRegistersBackupStorage(t *testing.T) {
 	t.Parallel()
 

--- a/providers/minio/tenant_types.go
+++ b/providers/minio/tenant_types.go
@@ -22,21 +22,18 @@ import (
 )
 
 // This file hand-declares the subset of the MinIO Operator's Tenant CRD
-// (group minio.min.io, version v1) that this provider needs to read and
+// (group minio.min.io, version v2) that this provider needs to read and
 // write. It intentionally does not import github.com/minio/operator: that
-// module predates Go's module graph pruning (go 1.13), so importing even
-// its pkg/apis subpackage drags in its full, unpruned dependency graph —
-// the minio server itself, docker/cli, gopsutil, and more — none of which
-// this provider needs. Field names, JSON tags, and the group/version/kind
-// below are taken verbatim from the real CRD so the objects this provider
+// module predates Go's module graph pruning, so importing even its
+// pkg/apis subpackage drags in its full dependency graph — the minio
+// server itself, docker/cli, gopsutil, and more — none of which this
+// provider needs. Field names, JSON tags, and the group/version/kind below
+// are taken verbatim from the real CRD so the objects this provider
 // creates are indistinguishable, on the wire, from ones built with the
 // upstream types; fields this provider doesn't set or read are simply
 // omitted, which is safe because they're all optional on the real CRD.
 
-// tenantGroupVersion is the real MinIO Operator Tenant CRD's group/version.
-// v2, not v1: verified directly against the operator installed in Phase 0
-// (`kubectl get crd tenants.minio.min.io` only serves v2 — v1 existed in
-// older operator releases but isn't what's deployed here).
+// tenantGroupVersion is the MinIO Operator Tenant CRD's group/version.
 var tenantGroupVersion = schema.GroupVersion{Group: "minio.min.io", Version: "v2"} //nolint:gochecknoglobals // schema.GroupVersion is a value type used as a constant; same pattern as resource.MustParse elsewhere in this repo
 
 // AddToScheme registers the Tenant/TenantList types with a scheme, mirroring
@@ -68,7 +65,7 @@ type TenantSpec struct {
 
 // Bucket is the subset of the real Bucket (Tenant.spec.buckets[]) this
 // provider sets: just a name, auto-created by the operator at reconcile
-// time. Used for the Phase 3 backup-bridge bucket.
+// time. Used for the backup-bridge bucket.
 type Bucket struct {
 	Name string `json:"name,omitempty"`
 }

--- a/providers/minio/tenant_types.go
+++ b/providers/minio/tenant_types.go
@@ -37,7 +37,7 @@ import (
 // v2, not v1: verified directly against the operator installed in Phase 0
 // (`kubectl get crd tenants.minio.min.io` only serves v2 — v1 existed in
 // older operator releases but isn't what's deployed here).
-var tenantGroupVersion = schema.GroupVersion{Group: "minio.min.io", Version: "v2"}
+var tenantGroupVersion = schema.GroupVersion{Group: "minio.min.io", Version: "v2"} //nolint:gochecknoglobals // schema.GroupVersion is a value type used as a constant; same pattern as resource.MustParse elsewhere in this repo
 
 // AddToScheme registers the Tenant/TenantList types with a scheme, mirroring
 // github.com/minio/operator/pkg/apis/minio.min.io/v1.AddToScheme.
@@ -91,17 +91,18 @@ type TenantStatus struct {
 type TenantList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitzero"`
-	Items           []Tenant `json:"items"`
+
+	Items []Tenant `json:"items"`
 }
 
 // DeepCopyObject implements runtime.Object.
-func (t *Tenant) DeepCopyObject() runtime.Object {
+func (t *Tenant) DeepCopyObject() runtime.Object { //nolint:ireturn // mandated by the runtime.Object interface
 	if t == nil {
 		return nil
 	}
 	out := new(Tenant)
 	out.TypeMeta = t.TypeMeta
-	t.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	t.DeepCopyInto(&out.ObjectMeta)
 	out.Status = t.Status
 	out.Spec.Image = t.Spec.Image
 	if t.Spec.RequestAutoCert != nil {
@@ -133,17 +134,19 @@ func (t *Tenant) DeepCopyObject() runtime.Object {
 }
 
 // DeepCopyObject implements runtime.Object.
-func (l *TenantList) DeepCopyObject() runtime.Object {
+func (l *TenantList) DeepCopyObject() runtime.Object { //nolint:ireturn // mandated by the runtime.Object interface
 	if l == nil {
 		return nil
 	}
 	out := new(TenantList)
 	out.TypeMeta = l.TypeMeta
-	l.ListMeta.DeepCopyInto(&out.ListMeta)
+	l.DeepCopyInto(&out.ListMeta)
 	if l.Items != nil {
 		out.Items = make([]Tenant, len(l.Items))
 		for i, t := range l.Items {
-			out.Items[i] = *t.DeepCopyObject().(*Tenant)
+			if copied, ok := t.DeepCopyObject().(*Tenant); ok {
+				out.Items[i] = *copied
+			}
 		}
 	}
 	return out

--- a/providers/minio/tenant_types.go
+++ b/providers/minio/tenant_types.go
@@ -1,0 +1,150 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package minio
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// This file hand-declares the subset of the MinIO Operator's Tenant CRD
+// (group minio.min.io, version v1) that this provider needs to read and
+// write. It intentionally does not import github.com/minio/operator: that
+// module predates Go's module graph pruning (go 1.13), so importing even
+// its pkg/apis subpackage drags in its full, unpruned dependency graph —
+// the minio server itself, docker/cli, gopsutil, and more — none of which
+// this provider needs. Field names, JSON tags, and the group/version/kind
+// below are taken verbatim from the real CRD so the objects this provider
+// creates are indistinguishable, on the wire, from ones built with the
+// upstream types; fields this provider doesn't set or read are simply
+// omitted, which is safe because they're all optional on the real CRD.
+
+// tenantGroupVersion is the real MinIO Operator Tenant CRD's group/version.
+// v2, not v1: verified directly against the operator installed in Phase 0
+// (`kubectl get crd tenants.minio.min.io` only serves v2 — v1 existed in
+// older operator releases but isn't what's deployed here).
+var tenantGroupVersion = schema.GroupVersion{Group: "minio.min.io", Version: "v2"}
+
+// AddToScheme registers the Tenant/TenantList types with a scheme, mirroring
+// github.com/minio/operator/pkg/apis/minio.min.io/v1.AddToScheme.
+func AddToScheme(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(tenantGroupVersion, &Tenant{}, &TenantList{})
+	metav1.AddToGroupVersion(scheme, tenantGroupVersion)
+	return nil
+}
+
+// Tenant is the subset of the MinIO Operator's Tenant resource this
+// provider uses.
+type Tenant struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
+
+	Spec   TenantSpec   `json:"spec"`
+	Status TenantStatus `json:"status,omitzero"`
+}
+
+// TenantSpec is the subset of the real TenantSpec this provider sets.
+type TenantSpec struct {
+	Pools           []Pool                       `json:"pools"`
+	Image           string                       `json:"image,omitempty"`
+	RequestAutoCert *bool                        `json:"requestAutoCert,omitempty"`
+	Configuration   *corev1.LocalObjectReference `json:"configuration,omitempty"`
+	Buckets         []Bucket                     `json:"buckets,omitempty"`
+}
+
+// Bucket is the subset of the real Bucket (Tenant.spec.buckets[]) this
+// provider sets: just a name, auto-created by the operator at reconcile
+// time. Used for the Phase 3 backup-bridge bucket.
+type Bucket struct {
+	Name string `json:"name,omitempty"`
+}
+
+// Pool is the subset of the real Pool this provider sets.
+type Pool struct {
+	Name                string                        `json:"name,omitempty"`
+	Servers             int32                         `json:"servers"`
+	VolumesPerServer    int32                         `json:"volumesPerServer"`
+	VolumeClaimTemplate *corev1.PersistentVolumeClaim `json:"volumeClaimTemplate"`
+}
+
+// TenantStatus is the subset of the real TenantStatus this provider reads.
+type TenantStatus struct {
+	CurrentState      string `json:"currentState"`
+	AvailableReplicas int32  `json:"availableReplicas"`
+}
+
+// TenantList is the list type paired with Tenant for scheme registration.
+type TenantList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitzero"`
+	Items           []Tenant `json:"items"`
+}
+
+// DeepCopyObject implements runtime.Object.
+func (t *Tenant) DeepCopyObject() runtime.Object {
+	if t == nil {
+		return nil
+	}
+	out := new(Tenant)
+	out.TypeMeta = t.TypeMeta
+	t.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	out.Status = t.Status
+	out.Spec.Image = t.Spec.Image
+	if t.Spec.RequestAutoCert != nil {
+		v := *t.Spec.RequestAutoCert
+		out.Spec.RequestAutoCert = &v
+	}
+	if t.Spec.Configuration != nil {
+		v := *t.Spec.Configuration
+		out.Spec.Configuration = &v
+	}
+	if t.Spec.Buckets != nil {
+		out.Spec.Buckets = make([]Bucket, len(t.Spec.Buckets))
+		copy(out.Spec.Buckets, t.Spec.Buckets)
+	}
+	if t.Spec.Pools != nil {
+		out.Spec.Pools = make([]Pool, len(t.Spec.Pools))
+		for i, p := range t.Spec.Pools {
+			out.Spec.Pools[i] = Pool{
+				Name:             p.Name,
+				Servers:          p.Servers,
+				VolumesPerServer: p.VolumesPerServer,
+			}
+			if p.VolumeClaimTemplate != nil {
+				out.Spec.Pools[i].VolumeClaimTemplate = p.VolumeClaimTemplate.DeepCopy()
+			}
+		}
+	}
+	return out
+}
+
+// DeepCopyObject implements runtime.Object.
+func (l *TenantList) DeepCopyObject() runtime.Object {
+	if l == nil {
+		return nil
+	}
+	out := new(TenantList)
+	out.TypeMeta = l.TypeMeta
+	l.ListMeta.DeepCopyInto(&out.ListMeta)
+	if l.Items != nil {
+		out.Items = make([]Tenant, len(l.Items))
+		for i, t := range l.Items {
+			out.Items[i] = *t.DeepCopyObject().(*Tenant)
+		}
+	}
+	return out
+}


### PR DESCRIPTION

> **This PR does not close or fully resolve #2255.** 
It is a proof-of-concept
> submitted to demonstrate prior working code toward the object storage
> provider effort described in that issue, not a request to merge as-is.
> Opened as a draft for visibility and early feedback.

## What this is

A working `provider-runtime` (`ProviderInterface`) implementation for MinIO, built and verified end-to-end against a real `kind` cluster and MinIO Operator install before this PR was opened. It uses the existing Provider`/`Instance` CRDs rather than a new database-shaped CRD, follow up on the scope question raised in the CNCF Slack (linked below).

## What it does

- `Sync()` renders a real MinIO Operator `Tenant` from an `Instance`'s `server` component and applies it.
- Creates the root-credentials `Secret` the `Tenant` needs and declares a dedicated backup bucket.
- `Status()` reads the `Tenant`'s health back onto the `Instance`, and once `Initialized`, auto-registers it as a `BackupStorage` so existing  OpenEverest-managed databases can back up to it with zero backup-side  code changes.
- `Cleanup()` is a no-op: everything is owned by the `Instance`, so  Kubernetes garbage collection handles teardown.

## Verified (real cluster)
- `kubectl apply -f manifest/sample-instance.yaml` produces a real `Tenantreaching`Initialized`/`green`, with `Instance.status.phase` reaching  `Ready`.
- A real S3 client round-trips data through both the primary and auto-created backup buckets.
- The auto-registered `BackupStorage` is a real, independently-writable  backup target.
- `go test ./providers/minio/...`: 7 tests, 10 sub-tests, all passing.

## Known limitations

Full list in `providers/minio/README.md`. In short: single pool/component, root-credential reuse in the backup bridge, no bucket/user management surface yet, no scaling/upgrade path exercised, and no real OpenEverest-managed database has backed up through this path yet (verified so far with a raw S3 client standing in for one). SeaweedFS, named
alongside MinIO in #2255, is unimplemented.

## Design note

Built on `Provider`/`Instance` instead of a new CRD after confirming in CNCF Slack that `provider-runtime` is intended to generalize to non-database resources:
https://cloud-native.slack.com/archives/C09RRGZL2UX/p1786604988377989

## Why open this now, as a draft

Filed as proof of prior work ahead of an LFX Mentorship Term 3 application against this issue, not a request to merge as-is.