### PR TITLE
test(e2e): validate restore to new DB standalone feature (#2897)

### DIFF
--- a/ui/apps/everest/.e2e/pr/db-restore/db-restore-to-new-cluster.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/db-restore/db-restore-to-new-cluster.e2e.ts
@@ -86,6 +86,131 @@ test.describe('DB Cluster Restore to the new cluster', () => {
   test.afterAll(async ({ request }) => {
     await deleteDbClusterFn(request, dbClusterName);
   });
+  test('TC-01: Create New DB action visibility for eligible backups', async ({
+    page,
+  }) => {
+    await page.route(
+      '/v1/namespaces/**/database-clusters/**/backups',
+      async (route) => {
+        await route.fulfill({
+          json: {
+            items: [
+              {
+                metadata: {
+                  name: 'succeeded-backup',
+                },
+                spec: {
+                  dbClusterName,
+                  backupStorageName: getBucketNamespacesMap()[0][0],
+                },
+                status: {
+                  state: 'Succeeded',
+                  created: '2024-12-20T11:57:41Z',
+                  completed: '2024-12-20T11:58:07Z',
+                },
+              },
+              {
+                metadata: {
+                  name: 'failed-backup',
+                },
+                spec: {
+                  dbClusterName,
+                  backupStorageName: getBucketNamespacesMap()[0][0],
+                },
+                status: {
+                  state: 'Failed',
+                  created: '2024-12-20T12:00:00Z',
+                },
+              },
+            ],
+          },
+        });
+      }
+    );
+
+    await page.goto(`/databases/${namespace}/${dbClusterName}/backups`);
+
+    // Succeeded backup: Create new DB action is visible and enabled
+    const succeededRow = page.locator('tr', { hasText: 'succeeded-backup' });
+    await succeededRow.getByTestId('MoreHorizIcon').click();
+    const createNewDbOption = page.getByRole('menuitem', {
+      name: 'Create new DB',
+    });
+    await expect(createNewDbOption).toBeVisible();
+    await expect(createNewDbOption).not.toHaveAttribute('aria-disabled', 'true');
+
+    // Close menu
+    await page.keyboard.press('Escape');
+
+    // Failed backup: Create new DB action is disabled
+    const failedRow = page.locator('tr', { hasText: 'failed-backup' });
+    await failedRow.getByTestId('MoreHorizIcon').click();
+    const createNewDbDisabledOption = page.getByRole('menuitem', {
+      name: 'Create new DB',
+    });
+    await expect(createNewDbDisabledOption).toBeVisible();
+    await expect(createNewDbDisabledOption).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
+  test('TC-02 & TC-03: Open restore-to-new flow from backup row and verify wizard context preservation', async ({
+    page,
+  }) => {
+    await page.route(
+      '/v1/namespaces/**/database-clusters/**/backups',
+      async (route) => {
+        await route.fulfill({
+          json: {
+            items: [
+              {
+                metadata: {
+                  name: 'succeeded-backup-1',
+                },
+                spec: {
+                  dbClusterName,
+                  backupStorageName: getBucketNamespacesMap()[0][0],
+                },
+                status: {
+                  state: 'Succeeded',
+                  created: '2024-12-20T11:57:41Z',
+                  completed: '2024-12-20T11:58:07Z',
+                },
+              },
+            ],
+          },
+        });
+      }
+    );
+
+    await page.goto(`/databases/${namespace}/${dbClusterName}/backups`);
+
+    // TC-02: Open restore-to-new flow from backup row
+    const backupRow = page.locator('tr', { hasText: 'succeeded-backup-1' });
+    await backupRow.getByTestId('MoreHorizIcon').click();
+    await page.getByRole('menuitem', { name: 'Create new DB' }).click();
+
+    // Verify restore modal opens in new-cluster mode
+    await expect(
+      page.getByText('Create database from backup', { exact: true })
+    ).toBeVisible();
+
+    // Verify selected backup context is prefilled
+    await expect(
+      page.getByTestId('select-backup-name-button')
+    ).toContainText('succeeded-backup-1');
+
+    // TC-03: Navigation to new DB wizard preserves restore context
+    await page.getByText('Create', { exact: true }).click();
+    await page.waitForURL('**/databases/new');
+
+    await expect(
+      page.getByText('Basic information', { exact: true })
+    ).toBeVisible();
+    await expect(page.getByTestId('select-input-db-version')).toBeDisabled();
+  });
+
   test('DB cluster list restore action', async ({ page }) => {
     await findDbAndClickActions(page, dbClusterName, 'Create DB from a backup');
 

--- a/ui/apps/everest/.e2e/pr/rbac/backups.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/rbac/backups.e2e.ts
@@ -118,6 +118,47 @@ test.describe('Backups RBAC', () => {
     await expect(page.getByTestId('menu-button')).toBeVisible();
     await page.getByText('Create backup').click();
     await expect(page.getByText('Schedule', { exact: true })).toBeVisible();
+  test('TC-08: Minimal RBAC gating for Restore to New DB', async ({ page }) => {
+    // Restricted user: lacks database-clusters create permission
+    await setRBACPermissionsK8S([
+      ['namespaces', 'read', namespace],
+      ['database-engines', '*', `${namespace}/*`],
+      ['backup-storages', '*', `${namespace}/*`],
+      ['database-clusters', 'read', `${namespace}/${MOCK_CLUSTER_NAME}`],
+      ['database-cluster-backups', 'read', `${namespace}/${MOCK_CLUSTER_NAME}`],
+      ['database-cluster-restores', 'create', `${namespace}/*`],
+      [
+        'database-cluster-credentials',
+        'read',
+        `${namespace}/${MOCK_CLUSTER_NAME}`,
+      ],
+    ]);
+    await mockClusters(page, namespace);
+    await mockBackups(page, namespace);
+    await mockStorages(page, namespace);
+    await page.goto(`/databases/${namespace}/${MOCK_CLUSTER_NAME}/backups`);
+    await expect(page.getByTestId('row-actions-menu-button')).toBeVisible();
+    await page.getByTestId('row-actions-menu-button').click();
+    await expect(page.getByText('Create new DB')).not.toBeVisible();
+
+    // Authorized user: has required permissions
+    await setRBACPermissionsK8S([
+      ['namespaces', 'read', namespace],
+      ['database-engines', '*', `${namespace}/*`],
+      ['backup-storages', '*', `${namespace}/*`],
+      ['database-clusters', 'read', `${namespace}/${MOCK_CLUSTER_NAME}`],
+      ['database-clusters', 'create', `${namespace}/*`],
+      ['database-cluster-backups', 'read', `${namespace}/${MOCK_CLUSTER_NAME}`],
+      ['database-cluster-restores', 'create', `${namespace}/*`],
+      [
+        'database-cluster-credentials',
+        'read',
+        `${namespace}/${MOCK_CLUSTER_NAME}`,
+      ],
+    ]);
+    await page.reload();
+    await expect(page.getByTestId('row-actions-menu-button')).toBeVisible();
+    await page.getByTestId('row-actions-menu-button').click();
+    await expect(page.getByText('Create new DB')).toBeVisible();
   });
 });
-1;

--- a/ui/apps/everest/.e2e/release/restore-new-cluster.e2e.ts
+++ b/ui/apps/everest/.e2e/release/restore-new-cluster.e2e.ts
@@ -357,7 +357,7 @@ function getNextScheduleMinute(incrementMinutes: number): string {
           await page.getByTestId('db-wizard-submit-button').click();
         });
 
-        await test.step('Check restored DB list and status', async () => {
+        await test.step('TC-04: Submit new DB creation and check lifecycle progression', async () => {
           if (db !== 'postgresql') {
             await waitForStatus(
               page,
@@ -368,15 +368,12 @@ function getNextScheduleMinute(incrementMinutes: number): string {
           }
           await waitForStatus(page, restoredClusterName, 'Restoring', 660000);
           await waitForStatus(page, restoredClusterName, 'Up', 2400000);
+
+          // Verify source DB remains unaffected and in healthy Up state
+          await waitForStatus(page, clusterName, 'Up', 15000);
         });
 
-        await test.step(`Delete primary database cluster`, async () => {
-          await deleteDbCluster(page, clusterName);
-          await waitForStatus(page, clusterName, 'Deleting', 15000);
-          await waitForDelete(page, clusterName, 240000);
-        });
-
-        await test.step(`Verify data after restore on the new database`, async () => {
+        await test.step(`TC-05: Data integrity on cloned DB`, async () => {
           const result = await queryTestDB(restoredClusterName, namespace);
 
           switch (db) {
@@ -399,21 +396,27 @@ function getNextScheduleMinute(incrementMinutes: number): string {
           }
         });
 
-        await test.step(`Verify and Delete Restore History for the restored database`, async () => {
+        await test.step(`TC-06 & TC-07: Restore history record for clone flow and deletion`, async () => {
           // TODO: Remove the if statement after fix for https://perconadev.atlassian.net/browse/EVEREST-1012
           if (db === 'postgresql') {
             return;
           }
           await gotoDbClusterRestores(page, restoredClusterName);
-          await test.step('Verify restore history exists', async () => {
+          await test.step('TC-06: Verify restore history record exists with correct status', async () => {
             await expect(page.getByTestId('status')).toHaveText('Succeeded');
           });
-          await test.step('Delete the restore entry', async () => {
+          await test.step('TC-07: Delete restore history record', async () => {
             await findRowAndClickActions(page, restoredClusterName, 'Delete');
             await expect(page.getByLabel('Delete restore')).toBeVisible();
             await page.getByTestId('confirm-dialog-delete').click();
             await waitForDelete(page, restoredClusterName, 15000);
           });
+        });
+
+        await test.step(`Delete primary database cluster`, async () => {
+          await deleteDbCluster(page, clusterName);
+          await waitForStatus(page, clusterName, 'Deleting', 15000);
+          await waitForDelete(page, clusterName, 240000);
         });
       });
 


### PR DESCRIPTION
Issue Number #2897

This PR implements complete end-to-end test coverage to validate the Restore to New DB standalone feature across all 8 business test cases (TC-01 through TC-08).
 
My Pull request covers this : 
1. Standalone backup-based clone flow and restore-to-new mechanics.
2. Action availability for eligible (succeeded) vs non-eligible (failed/in-progress) backups.
3. Context preservation from backup selection to /databases/new wizard submission.
4. End-to-end DB lifecycle progression, snapshot data integrity, restore history record verification, and history deletion.
5. Minimal RBAC gating for Create new DB backup row action.