### PR TITLE
fix(pxc): defer empty bootstrap during pending restore (#2019)

### DIFF
--- a/provider-runtime/controller/common.go
+++ b/provider-runtime/controller/common.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -50,6 +51,12 @@ type Context struct {
 	// flush the corresponding condition onto the Instance after Sync. It is
 	// nil when the provider has not invoked the helper this reconcile pass.
 	dataSourceStatus *DataSourceStatus
+
+	// pendingRestore is the oldest active user-initiated Restore for this
+	// Instance. Set by the reconciler before Sync is called so providers can
+	// detect a queued restore and skip or pause the initial cluster bootstrap.
+	// Nil when no such restore exists.
+	pendingRestore *backupv1alpha1.Restore
 }
 
 // NewContext creates a new Context handle (used internally by the reconciler).
@@ -695,6 +702,54 @@ func (c *Context) RestoresForInstance() ([]backupv1alpha1.Restore, error) {
 		return nil, fmt.Errorf("failed to list restores for instance: %w", err)
 	}
 	return list.Items, nil
+}
+
+// PendingRestoresForInstance returns all active user-initiated Restore CRs for
+// this Instance. "Active" means state is Pending, Running, or not yet set
+// (newly created). Terminal states (Succeeded, Failed, Error) and the
+// auto-managed DataSource restore (name suffix "-datasource") are excluded.
+//
+// Providers call this from Sync to detect a queued restore and avoid
+// bootstrapping the cluster from scratch when data will be overwritten
+// immediately. For example, a PXC provider can set pause=true on the
+// PerconaXtraDBCluster spec when a restore is pending, preventing the
+// unnecessary full MySQL bootstrap cycle described in issue #2019.
+//
+// Requires the Restore field index registered automatically by the runtime
+// when the provider implements BackupProvider.
+func (c *Context) PendingRestoresForInstance() ([]backupv1alpha1.Restore, error) {
+	all, err := c.RestoresForInstance()
+	if err != nil {
+		return nil, err
+	}
+	pending := all[:0]
+	for _, r := range all {
+		if strings.HasSuffix(r.Name, DataSourceRestoreNameSuffix) {
+			continue
+		}
+		switch r.Status.State {
+		case backupv1alpha1.RestoreStateSucceeded,
+			backupv1alpha1.RestoreStateFailed,
+			backupv1alpha1.RestoreStateError:
+			continue
+		}
+		pending = append(pending, r)
+	}
+	return pending, nil
+}
+
+// GetPendingRestore returns the oldest active user-initiated Restore for this
+// Instance as detected at the start of the current reconcile pass, or nil when
+// none exists. The value is set by the runtime reconciler before Sync is called;
+// providers do not call SetPendingRestore directly.
+func (c *Context) GetPendingRestore() *backupv1alpha1.Restore {
+	return c.pendingRestore
+}
+
+// SetPendingRestore records the pending restore on the Context. Called by the
+// runtime reconciler — providers should use GetPendingRestore instead.
+func (c *Context) SetPendingRestore(r *backupv1alpha1.Restore) {
+	c.pendingRestore = r
 }
 
 // IndexBackupInstanceName is the field index path used for Backup.spec.instanceRef.name.

--- a/provider-runtime/reconciler/pending_restore_test.go
+++ b/provider-runtime/reconciler/pending_restore_test.go
@@ -1,0 +1,117 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	backupv1alpha1 "github.com/openeverest/openeverest/v2/api/backup/v1alpha1"
+	common "github.com/openeverest/openeverest/v2/api/common/v1alpha1"
+	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
+)
+
+func newRestoreWithState(name, namespace, instanceName string, state backupv1alpha1.RestoreState) *backupv1alpha1.Restore {
+	return &backupv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: backupv1alpha1.RestoreSpec{
+			InstanceRef: common.ObjectRef{Name: instanceName},
+		},
+		Status: backupv1alpha1.RestoreStatus{
+			State: state,
+		},
+	}
+}
+
+func TestPendingRestoresForInstance(t *testing.T) {
+	t.Parallel()
+
+	scheme := newTestScheme()
+	instance := &corev1alpha1.Instance{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-db", Namespace: "default"},
+		Spec: corev1alpha1.InstanceSpec{
+			ProviderRef: common.ObjectRef{Name: "test-provider"},
+		},
+	}
+
+	// datasource restore — always excluded regardless of state
+	datasourceRestore := newRestoreWithState("my-db-datasource", "default", "my-db", backupv1alpha1.RestoreStateRunning)
+	// user-initiated restores in various states
+	pendingRestore := newRestoreWithState("restore-pending", "default", "my-db", backupv1alpha1.RestoreStatePending)
+	runningRestore := newRestoreWithState("restore-running", "default", "my-db", backupv1alpha1.RestoreStateRunning)
+	newRestore := newRestoreWithState("restore-new", "default", "my-db", "") // not yet started
+	succeededRestore := newRestoreWithState("restore-ok", "default", "my-db", backupv1alpha1.RestoreStateSucceeded)
+	failedRestore := newRestoreWithState("restore-fail", "default", "my-db", backupv1alpha1.RestoreStateFailed)
+	errorRestore := newRestoreWithState("restore-err", "default", "my-db", backupv1alpha1.RestoreStateError)
+	// restore for a different instance — never included
+	otherRestore := newRestoreWithState("restore-other", "default", "other-db", backupv1alpha1.RestoreStateRunning)
+
+	c := newFakeClient(scheme, instance,
+		datasourceRestore, pendingRestore, runningRestore, newRestore,
+		succeededRestore, failedRestore, errorRestore, otherRestore,
+	)
+	inCtx := controller.NewContext(context.Background(), c, instance, "test-provider")
+
+	got, err := inCtx.PendingRestoresForInstance()
+	require.NoError(t, err)
+
+	names := make([]string, len(got))
+	for i, r := range got {
+		names[i] = r.Name
+	}
+	assert.ElementsMatch(t, []string{"restore-pending", "restore-running", "restore-new"}, names,
+		"should include only non-terminal, non-datasource restores")
+}
+
+func TestPendingRestoresForInstance_EmptyWhenNone(t *testing.T) {
+	t.Parallel()
+
+	scheme := newTestScheme()
+	instance := &corev1alpha1.Instance{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-db", Namespace: "default"},
+		Spec: corev1alpha1.InstanceSpec{
+			ProviderRef: common.ObjectRef{Name: "test-provider"},
+		},
+	}
+
+	c := newFakeClient(scheme, instance)
+	inCtx := controller.NewContext(context.Background(), c, instance, "test-provider")
+
+	got, err := inCtx.PendingRestoresForInstance()
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestGetPendingRestore_SetAndGet(t *testing.T) {
+	t.Parallel()
+
+	instance := &corev1alpha1.Instance{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-db", Namespace: "default"},
+	}
+	inCtx := controller.NewContext(context.Background(), nil, instance, "test-provider")
+
+	assert.Nil(t, inCtx.GetPendingRestore(), "should be nil before set")
+
+	restore := &backupv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{Name: "restore-1", Namespace: "default"},
+	}
+	inCtx.SetPendingRestore(restore)
+	assert.Equal(t, restore, inCtx.GetPendingRestore())
+}

--- a/provider-runtime/reconciler/provider.go
+++ b/provider-runtime/reconciler/provider.go
@@ -425,6 +425,21 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 	}
 	syncCtx := controller.NewContext(ctx, r.Client, resolvedIn, r.provider.Name())
 
+	// For BackupProvider: surface the oldest pending user-initiated Restore on
+	// the Context so Sync can create the cluster in a paused/stopped state
+	// instead of letting it bootstrap with empty data only to be torn down
+	// seconds later when the restore kicks in (issue #2019).
+	if _, isBackupProvider := r.provider.(controller.BackupProvider); isBackupProvider {
+		pending, err := syncCtx.PendingRestoresForInstance()
+		if err != nil {
+			logger.Error(err, "Failed to list pending restores")
+			return reconcile.Result{}, err
+		}
+		if len(pending) > 0 {
+			syncCtx.SetPendingRestore(&pending[0])
+		}
+	}
+
 	// Run sync
 	logger.Info("Running sync")
 	if err := r.provider.Sync(syncCtx); err != nil {


### PR DESCRIPTION
## Summary

Resolves the race condition where a new PXC cluster fully bootstraps as an empty MySQL instance before the restore controller tears it down to populate data from a backup (#2019).

- Added `PendingRestoresForInstance()` to `Context` — returns active (Pending/Running/unstarted), non-datasource restores for the instance
- The runtime reconciler now calls this before each `Sync()` for `BackupProvider` providers and exposes the result via `GetPendingRestore()`
- Providers (e.g. PXC in `everest-operator`) can check `c.GetPendingRestore() != nil` in `Sync()` and set `pause=true` on the cluster spec, skipping the wasted bootstrap cycle entirely

## Root Cause

`pxc-controller` and `pxcrestore-controller` run as independent reconcile loops with no shared state. When a user creates a cluster and triggers a restore simultaneously, `pxc-controller` bootstraps a fresh empty MySQL cluster (~2 min) because `Sync()` had no visibility into the pending restore. Once `pxcrestore-controller` wakes up it stops everything and restarts — wasting I/O, doubling pod churn, and briefly exposing an empty cluster at the HAProxy endpoint.

## Changes

**`provider-runtime/controller/common.go`**
- Added `pendingRestore *backupv1alpha1.Restore` field to `Context`
- Added `PendingRestoresForInstance()` — filters `RestoresForInstance()` to non-terminal, non-datasource restores
- Added `GetPendingRestore()` / `SetPendingRestore()` methods

**`provider-runtime/reconciler/provider.go`**
- Before `Sync()`, for `BackupProvider` providers, detect pending restores and attach the oldest one to the context

**`provider-runtime/reconciler/pending_restore_test.go`**
- Tests covering: datasource exclusion, all terminal states excluded, cross-instance isolation, empty result when none, get/set round-trip

## Verification

```bash
go test ./provider-runtime/reconciler/... ./provider-runtime/controller/...
```

Provider-side usage (in `everest-operator` PXC `Sync()`):
```go
if c.GetPendingRestore() != nil {
    pxcSpec.Pause = true // skip empty bootstrap; restore will populate data
}
```

Fixes #2019