### PR TITLE
feat(plugins): performance-testing plugin PoC (sysbench/PostgreSQL) — proof-of-work.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,7 @@
 !model
 !public
 !pkg
+# Needed for plugins/performance-testing/Dockerfile, which builds from the
+# repo root (single go.mod) like the other Dockerfiles here — without this,
+# `COPY . .` silently drops the entire plugins/ tree from the build context.
+!plugins

--- a/plugins/performance-testing/Dockerfile
+++ b/plugins/performance-testing/Dockerfile
@@ -1,0 +1,15 @@
+# Build context is the repo root (this plugin's backend is part of the
+# single-module monorepo, github.com/openeverest/openeverest/v2), so this
+# is built with:
+#   docker build -f plugins/performance-testing/Dockerfile -t performance-testing-backend .
+FROM golang:1.26 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /out/backend ./plugins/performance-testing/backend
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /out/backend /backend
+USER nonroot:nonroot
+ENTRYPOINT ["/backend"]

--- a/plugins/performance-testing/Dockerfile.sysbench
+++ b/plugins/performance-testing/Dockerfile.sysbench
@@ -1,0 +1,14 @@
+# The benchmark Job's own image — separate from ./Dockerfile, which builds
+# this plugin's backend. Deliberately not severalnines/sysbench:latest,
+# whose bundled libpq predates PostgreSQL's SCRAM-SHA-256 default (PG10+):
+# a real prepare run against the target pg-poc failed with "SCRAM
+# authentication requires libpq version 10 or above" the first time this
+# was actually run against a live cluster, the same way the MinIO
+# provider's placeholder image tag only broke once actually deployed.
+# debian:trixie-slim's packaged sysbench (1.0.20, linked against a current
+# libpq) was hand-verified against the same cluster: prepare/cleanup both
+# succeeded with real SCRAM auth.
+FROM debian:trixie-slim
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends sysbench ca-certificates && \
+    rm -rf /var/lib/apt/lists/*

--- a/plugins/performance-testing/README.md
+++ b/plugins/performance-testing/README.md
@@ -1,0 +1,71 @@
+# performance-testing plugin (PoC)
+
+A generic OpenEverest plugin (`docs/process/generic-plugins-design.md`)
+that runs [sysbench](https://github.com/akopytov/sysbench) benchmarks
+against Everest-managed PostgreSQL databases as ephemeral Kubernetes Jobs,
+and retains results for comparison over time. Built for CNCF LFX
+Mentorship Term 3 issue
+[openeverest/openeverest#2464](https://github.com/openeverest/openeverest/issues/2464).
+
+## Scope of this PoC
+
+PostgreSQL + sysbench only, against a real `DatabaseCluster` (the
+`everest.percona.com` resource type every real OpenEverest database
+actually is today — see "Design notes" below). MySQL/pgbench and
+MongoDB/YCSB are the natural next engines once this mechanism is proven,
+not built here.
+
+## Layout
+
+```
+performance-testing/
+├── Dockerfile
+├── backend/              # Go backend (plain net/http, no framework)
+│   ├── main.go
+│   ├── handlers.go       # POST/GET /api/runs
+│   ├── job.go             # builds the benchmark batchv1.Job
+│   ├── parser.go           # parses sysbench's text report
+│   ├── store.go             # in-memory run history
+│   └── kube.go               # client-go clientset bootstrap
+├── charts/performance-testing/  # Helm chart: Plugin CR, Deployment,
+│                                  # Service, ServiceAccount, Role, RoleBinding
+└── manifest/sample-plugin.yaml   # minimal Plugin CR for kubectl apply testing
+```
+
+## API
+
+- `POST /api/runs` — `{"instance": "pg-poc", "namespace": "everest", "workload": "smoke"}`.
+  Returns `{"id": "run-..."}` immediately; the Job runs asynchronously.
+  Workloads: `smoke`, `read-heavy`, `write-heavy`, `mixed-oltp`.
+- `GET /api/runs/{id}` — status + parsed throughput/latency once the Job finishes.
+- `GET /api/runs` — history, most recent first.
+
+## Design notes
+
+**Credentials.** `GET /clusters/{cluster}/namespaces/{namespace}/instances/{instance}/connection`
+(`internal/server/handlers/k8s/instance.go`) only brokers credentials for
+the newer spec-001 `Instance` type. Every real database on a default
+OpenEverest v2 install — including the `pg-poc` this PoC was verified
+against — is still the older `DatabaseCluster` type
+(`databaseclusters.everest.percona.com`), which has no equivalent broker
+anywhere in `release-2.0`. This plugin reads the target's credentials
+Secret (`everest-secrets-<instance>`) directly, scoped by its own RBAC to
+a `get` on `secrets` in its install namespace — the same pattern
+`internal/controller/backup/backup_controller.go` already uses for
+`Instance`-based backups, just applied to the resource type that doesn't
+have a broker yet. See `backend/job.go`'s `credentialsSecretName` doc
+comment for the full reasoning. Building the missing
+`DatabaseCluster`-equivalent broker is real, well-scoped follow-up work.
+
+**Job isolation.** The benchmark Job declares a soft `podAntiAffinity`
+against the target instance's `app.kubernetes.io/instance` label, so it
+prefers scheduling away from the database's own pods (the "observer
+effect" question raised publicly on #2464). Not verified against actual
+multi-node placement — `everest-poc`, the cluster this was tested on, is
+single-node, so only the Job's *declared* affinity was confirmed, not
+enforced placement.
+
+**Result storage.** In-memory only, ephemeral by default — matches the
+maintainers' explicit rejection of ConfigMap/PVC-by-default storage in the
+#2464 issue thread. A durable, opt-in backend is a straightforward
+`RunStore` implementation away, not built here.

--- a/plugins/performance-testing/backend/handlers.go
+++ b/plugins/performance-testing/backend/handlers.go
@@ -1,0 +1,264 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	defaultDBName   = "postgres"
+	jobPollInterval = 2 * time.Second
+	jobPollTimeout  = (jobActiveDeadline + 60) * time.Second
+)
+
+// server holds the dependencies the HTTP handlers need. Deliberately not a
+// framework-specific type (no Echo, no chi) — the generic-plugin-template
+// reference plugin uses plain net/http, and matching that convention keeps
+// this backend swappable/comparable against other real plugins in the org.
+type server struct {
+	kube  kubernetes.Interface
+	store RunStore
+}
+
+func (s *server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+type createRunRequest struct {
+	Instance  string   `json:"instance"`
+	Namespace string   `json:"namespace"`
+	Workload  Workload `json:"workload"`
+	DBName    string   `json:"dbName,omitempty"`
+}
+
+// validateCreateRunRequest checks the request shape and fills in the
+// dbName default. Split out of handleCreateRun purely to keep that
+// handler short — no independent reuse yet.
+func validateCreateRunRequest(req createRunRequest) (string, error) {
+	if req.Instance == "" || req.Namespace == "" {
+		return "", fmt.Errorf("instance and namespace are required")
+	}
+	if _, ok := workloadProfiles[req.Workload]; !ok {
+		return "", fmt.Errorf("unknown workload %q", req.Workload)
+	}
+	if req.DBName != "" {
+		return req.DBName, nil
+	}
+	return defaultDBName, nil
+}
+
+// checkCredentialsSecretExists confirms the target's credentials Secret is
+// present before creating a Job that would otherwise fail inside the
+// cluster with a much less legible error.
+func (s *server) checkCredentialsSecretExists(ctx context.Context, namespace, instance string) error {
+	secretName := credentialsSecretName(instance)
+	_, err := s.kube.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err == nil {
+		return nil
+	}
+	if apierrors.IsNotFound(err) {
+		return fmt.Errorf("credentials secret %q not found in namespace %q — is %q a running DatabaseCluster? %w",
+			secretName, namespace, instance, errNotFound)
+	}
+	return err
+}
+
+var errNotFound = errors.New("not found")
+
+func (s *server) handleCreateRun(w http.ResponseWriter, r *http.Request) {
+	var req createRunRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apiError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	dbName, err := validateCreateRunRequest(req)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	ctx := r.Context()
+	if err := s.checkCredentialsSecretExists(ctx, req.Namespace, req.Instance); err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, errNotFound) {
+			status = http.StatusNotFound
+		}
+		apiError(w, status, err.Error())
+		return
+	}
+
+	runID := fmt.Sprintf("run-%d", time.Now().UnixNano())
+	job, err := buildJob(runID, req.Instance, req.Namespace, dbName, req.Workload)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	created, err := s.kube.BatchV1().Jobs(req.Namespace).Create(ctx, job, metav1.CreateOptions{})
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, "creating benchmark job: "+err.Error())
+		return
+	}
+
+	run := Run{ //nolint:exhaustruct // FinishedAt/Result/Error are filled in later, once the job completes.
+		ID:        runID,
+		Instance:  req.Instance,
+		Namespace: req.Namespace,
+		Workload:  req.Workload,
+		Status:    RunStatusRunning,
+		JobName:   created.Name,
+		StartedAt: time.Now(),
+	}
+	if err := s.store.Save(run); err != nil {
+		apiError(w, http.StatusInternalServerError, "saving run: "+err.Error())
+		return
+	}
+
+	// The Job runs prepare+run+cleanup sequentially and can take tens of
+	// seconds; the HTTP request returns immediately with the run ID and a
+	// background goroutine tracks completion, matching "hits run and sees
+	// results" as a poll-for-status UX rather than a blocking request.
+	// context.Background() is deliberate here, not an oversight: the
+	// tracking goroutine must outlive this request's own context, which is
+	// cancelled the moment the HTTP response is written.
+	go s.trackRun(context.Background(), run) //nolint:contextcheck,gosec // deliberately detached from the request context, see comment above
+
+	writeJSON(w, http.StatusAccepted, map[string]string{"id": runID})
+}
+
+func (s *server) trackRun(ctx context.Context, run Run) {
+	ctx, cancel := context.WithTimeout(ctx, jobPollTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(jobPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			run.Status = RunStatusFailed
+			run.Error = "timed out waiting for benchmark job to finish"
+			s.finishRun(run)
+			return
+		case <-ticker.C:
+			job, err := s.kube.BatchV1().Jobs(run.Namespace).Get(ctx, run.JobName, metav1.GetOptions{})
+			if err != nil {
+				log.Printf("run %s: get job %s: %v", run.ID, run.JobName, err)
+				continue
+			}
+			if job.Status.Succeeded > 0 {
+				s.completeRun(ctx, run, job)
+				return
+			}
+			if job.Status.Failed > 0 {
+				run.Status = RunStatusFailed
+				run.Error = "benchmark job failed — see kubectl logs for the job's pod"
+				s.finishRun(run)
+				return
+			}
+		}
+	}
+}
+
+func (s *server) completeRun(ctx context.Context, run Run, job *batchv1.Job) {
+	output, err := s.readJobLogs(ctx, job)
+	if err != nil {
+		run.Status = RunStatusFailed
+		run.Error = "job succeeded but reading its logs failed: " + err.Error()
+		s.finishRun(run)
+		return
+	}
+	run.Status = RunStatusSucceeded
+	run.Result = parseSysbenchOutput(output)
+	s.finishRun(run)
+}
+
+func (s *server) finishRun(run Run) {
+	now := time.Now()
+	run.FinishedAt = &now
+	if err := s.store.Save(run); err != nil {
+		log.Printf("run %s: save final state: %v", run.ID, err)
+	}
+}
+
+// readJobLogs finds the (single, RestartPolicy: Never) pod the Job created
+// and reads its combined stdout/stderr, which is where sysbench's
+// human-readable report lands — sysbench has no --output=json mode to
+// unmarshal instead (see parser.go).
+func (s *server) readJobLogs(ctx context.Context, job *batchv1.Job) (string, error) {
+	pods, err := s.kube.CoreV1().Pods(job.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "job-name=" + job.Name,
+	})
+	if err != nil {
+		return "", fmt.Errorf("list pods for job %s: %w", job.Name, err)
+	}
+	if len(pods.Items) == 0 {
+		return "", errors.New("no pods found for completed job")
+	}
+	pod := pods.Items[0]
+
+	stream, err := s.kube.CoreV1().Pods(job.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{}).Stream(ctx) //nolint:exhaustruct // only Container matters and the Job has a single container
+	if err != nil {
+		return "", fmt.Errorf("stream logs for pod %s: %w", pod.Name, err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		return "", fmt.Errorf("read logs for pod %s: %w", pod.Name, err)
+	}
+	return string(data), nil
+}
+
+func (s *server) handleGetRun(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	run, ok := s.store.Get(id)
+	if !ok {
+		apiError(w, http.StatusNotFound, "run not found: "+id)
+		return
+	}
+	writeJSON(w, http.StatusOK, run)
+}
+
+func (s *server) handleListRuns(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, s.store.List())
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("writeJSON error: %v", err)
+	}
+}
+
+func apiError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/plugins/performance-testing/backend/handlers_test.go
+++ b/plugins/performance-testing/backend/handlers_test.go
@@ -1,0 +1,170 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func newTestServer(secrets ...*corev1.Secret) *server {
+	kube := fake.NewSimpleClientset()
+	for _, secret := range secrets {
+		_, _ = kube.CoreV1().Secrets(secret.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
+	}
+	return &server{kube: kube, store: newMemoryStore()}
+}
+
+func testSecret(namespace, instance string) *corev1.Secret {
+	return &corev1.Secret{ //nolint:exhaustruct // TypeMeta/other fields unused by the fake clientset in these tests
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      credentialsSecretName(instance),
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"pgbouncer-host": []byte("pg-poc-pgbouncer.everest.svc"),
+			"pgbouncer-port": []byte("5432"),
+			"user":           []byte("postgres"),
+			"password":       []byte("does-not-matter-for-this-test"),
+		},
+	}
+}
+
+func TestHandleCreateRun_MissingSecret_Returns404(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	body := strings.NewReader(`{"instance":"pg-poc","namespace":"everest","workload":"smoke"}`)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/runs", body)
+	rec := httptest.NewRecorder()
+
+	s.handleCreateRun(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleCreateRun_UnknownWorkload_Returns400(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer(testSecret("everest", "pg-poc"))
+	body := strings.NewReader(`{"instance":"pg-poc","namespace":"everest","workload":"not-a-workload"}`)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/runs", body)
+	rec := httptest.NewRecorder()
+
+	s.handleCreateRun(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleCreateRun_MissingFields_Returns400(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	body := strings.NewReader(`{"workload":"smoke"}`)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/runs", body)
+	rec := httptest.NewRecorder()
+
+	s.handleCreateRun(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleCreateRun_ValidRequest_CreatesJobAndStoresRun(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer(testSecret("everest", "pg-poc"))
+	body := strings.NewReader(`{"instance":"pg-poc","namespace":"everest","workload":"smoke"}`)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/runs", body)
+	rec := httptest.NewRecorder()
+
+	s.handleCreateRun(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	runID := resp["id"]
+	require.NotEmpty(t, runID)
+
+	// The run is stored immediately (Running), independent of the
+	// background job-tracking goroutine's eventual completion.
+	run, ok := s.store.Get(runID)
+	require.True(t, ok)
+	assert.Equal(t, RunStatusRunning, run.Status)
+	assert.Equal(t, "pg-poc", run.Instance)
+
+	job, err := s.kube.BatchV1().Jobs("everest").Get(req.Context(), "perf-test-"+runID, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, sysbenchImage, job.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestHandleGetRun_NotFound_Returns404(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/runs/does-not-exist", nil)
+	req.SetPathValue("id", "does-not-exist")
+	rec := httptest.NewRecorder()
+
+	s.handleGetRun(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleGetRun_Found_ReturnsRun(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	require.NoError(t, s.store.Save(Run{ID: "run-1", Instance: "pg-poc", Status: RunStatusSucceeded}))
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/runs/run-1", nil)
+	req.SetPathValue("id", "run-1")
+	rec := httptest.NewRecorder()
+
+	s.handleGetRun(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got Run
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "pg-poc", got.Instance)
+}
+
+func TestHandleListRuns_ReturnsAllStoredRuns(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	require.NoError(t, s.store.Save(Run{ID: "run-1", Instance: "pg-poc"}))
+	require.NoError(t, s.store.Save(Run{ID: "run-2", Instance: "pg-poc"}))
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/runs", nil)
+	rec := httptest.NewRecorder()
+
+	s.handleListRuns(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []Run
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Len(t, got, 2)
+}

--- a/plugins/performance-testing/backend/job.go
+++ b/plugins/performance-testing/backend/job.go
@@ -1,0 +1,201 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// sysbenchImage is built from ../Dockerfile.sysbench (debian:trixie-slim's
+// packaged sysbench 1.0.20). The obvious first choice,
+// severalnines/sysbench:latest, was tried and rejected: its bundled libpq
+// predates PostgreSQL's SCRAM-SHA-256 default and fails against pg-poc
+// with "SCRAM authentication requires libpq version 10 or above". This
+// image was hand-verified against the same live cluster (a real
+// prepare/cleanup round-trip succeeded) before being trusted, the same way
+// the MinIO provider's image tag was hand-verified rather than assumed.
+const sysbenchImage = "localhost/performance-testing-sysbench:0.1.0"
+
+// credentialsSecretName is the naming convention observed on the real
+// everest-poc cluster's DatabaseCluster credentials Secret
+// ("everest-secrets-<cluster-name>"). This convention does not appear
+// anywhere in the current release-2.0 source tree — there is no generic,
+// API-brokered way to obtain DatabaseCluster credentials (the connection
+// broker at GET .../instances/{instance}/connection only covers the newer
+// spec-001 Instance type, which has zero real database engines running on
+// it in the current release). Reading this Secret directly, scoped by the
+// plugin's own RBAC to only this one key pattern, mirrors how
+// internal/controller/backup/backup_controller.go already reads a
+// connection Secret directly for its own Job's env — this is not a novel
+// credential-handling pattern, it fills the same gap the same way for a
+// resource type the existing broker doesn't cover.
+func credentialsSecretName(instance string) string {
+	return "everest-secrets-" + instance
+}
+
+// sysbench test names, extracted to constants since oltp_read_only backs
+// two different workload profiles (smoke and read-heavy differ only in
+// concurrency/duration, not which test runs).
+const (
+	sysbenchOLTPReadOnly  = "oltp_read_only"
+	sysbenchOLTPWriteOnly = "oltp_write_only" //nolint:gosec // sysbench test name, not a credential
+	sysbenchOLTPReadWrite = "oltp_read_write"
+)
+
+// workloadProfile maps a named Workload onto sysbench parameters. Hiding
+// raw sysbench flags behind these names is the "Benchmark Workload
+// Profiles" idea multiple applicants proposed publicly on #2464 — Postgres
+// is the only engine this PoC exercises, so only the pgsql-relevant knobs
+// are modelled.
+type workloadProfile struct {
+	sysbenchTest string
+	threads      int
+	durationSecs int
+}
+
+//nolint:gochecknoglobals // workloadProfiles is a fixed lookup table, not mutable shared state; same pattern as provider.go's other package-level maps in this repo.
+var workloadProfiles = map[Workload]workloadProfile{
+	WorkloadSmoke:      {sysbenchTest: sysbenchOLTPReadOnly, threads: 2, durationSecs: 10},
+	WorkloadReadHeavy:  {sysbenchTest: sysbenchOLTPReadOnly, threads: 8, durationSecs: 30},
+	WorkloadWriteHeavy: {sysbenchTest: sysbenchOLTPWriteOnly, threads: 8, durationSecs: 30},
+	WorkloadMixedOLTP:  {sysbenchTest: sysbenchOLTPReadWrite, threads: 8, durationSecs: 30},
+}
+
+const (
+	sysbenchTables    = 4
+	sysbenchTableSize = 10000
+	jobActiveDeadline = 600 // seconds; caps a hung benchmark, mirrors the BackoffLimit:0 "fail fast" precedent in backup_controller.go
+)
+
+// secretEnvVar builds an env var sourced from a key in the target
+// DatabaseCluster's own credentials Secret. Values are injected by the
+// kubelet at container start — this process never reads or holds the raw
+// credential.
+func secretEnvVar(name, secretName, key string) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: name,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+				Key:                  key,
+			},
+		},
+	}
+}
+
+// benchmarkScript renders the prepare/run/cleanup shell script. All
+// interpolated values (test name, thread count, duration) come from the
+// fixed workloadProfiles table, never from caller input, so this isn't
+// building a shell command out of untrusted strings.
+func benchmarkScript(profile workloadProfile) string {
+	args := fmt.Sprintf(
+		`--db-driver=pgsql --pgsql-host="$SB_PGHOST" --pgsql-port="$SB_PGPORT" --pgsql-user="$SB_PGUSER" --pgsql-password="$SB_PGPASSWORD" --pgsql-db="$SB_PGDB" --tables=%d --table-size=%d`,
+		sysbenchTables, sysbenchTableSize,
+	)
+	return fmt.Sprintf(
+		"set -e\n"+
+			"sysbench %s %s prepare\n"+
+			"sysbench %s %s --threads=%d --time=%d run\n"+
+			"sysbench %s %s cleanup\n",
+		profile.sysbenchTest, args,
+		profile.sysbenchTest, args, profile.threads, profile.durationSecs,
+		profile.sysbenchTest, args,
+	)
+}
+
+// benchmarkEnv wires the container's SB_PG* env vars: credentials sourced
+// from the target's own Secret via secretKeyRef, plus the plain-value
+// database name.
+func benchmarkEnv(secretName, dbName string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		secretEnvVar("SB_PGHOST", secretName, "pgbouncer-host"),
+		secretEnvVar("SB_PGPORT", secretName, "pgbouncer-port"),
+		secretEnvVar("SB_PGUSER", secretName, "user"),
+		secretEnvVar("SB_PGPASSWORD", secretName, "password"),
+		{Name: "SB_PGDB", Value: dbName},
+	}
+}
+
+// antiAffinity prefers scheduling the benchmark Job away from the target
+// database's own pods, answering the node-isolation open question raised
+// on #2464 by Aryanbhargava18: the load generator shouldn't compete with
+// the database it's measuring for the same node's CPU/memory ("observer
+// effect"). Soft preference, not a hard requirement — a single-node dev
+// cluster (like everest-poc) must still be able to run the Job at all.
+func antiAffinity(instance string) *corev1.Affinity {
+	return &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					Weight: 100,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app.kubernetes.io/instance": instance,
+							},
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildJob renders the benchmark Job.
+func buildJob(runID, instance, namespace, dbName string, workload Workload) (*batchv1.Job, error) {
+	profile, ok := workloadProfiles[workload]
+	if !ok {
+		return nil, fmt.Errorf("unknown workload %q", workload)
+	}
+
+	backoffLimit := int32(0)
+	activeDeadline := int64(jobActiveDeadline)
+	labels := map[string]string{
+		"app.kubernetes.io/managed-by":                   "performance-testing-plugin",
+		"performance-testing.plugins.openeverest.io/run": runID,
+	}
+
+	return &batchv1.Job{ //nolint:exhaustruct // TypeMeta and other unset fields use their zero values deliberately.
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "perf-test-" + runID,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:          &backoffLimit,
+			ActiveDeadlineSeconds: &activeDeadline,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Affinity:      antiAffinity(instance),
+					Containers: []corev1.Container{
+						{
+							Name:    "sysbench",
+							Image:   sysbenchImage,
+							Command: []string{"sh", "-c", benchmarkScript(profile)},
+							Env:     benchmarkEnv(credentialsSecretName(instance), dbName),
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/plugins/performance-testing/backend/job_test.go
+++ b/plugins/performance-testing/backend/job_test.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestBuildJob_UnknownWorkload_Errors(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildJob("run-1", "pg-poc", "everest", "postgres", Workload("not-a-real-workload"))
+	require.Error(t, err)
+}
+
+func TestBuildJob_WiresCredentialsFromInstanceSecret_NotLiteralValues(t *testing.T) {
+	t.Parallel()
+
+	job, err := buildJob("run-1", "pg-poc", "everest", "postgres", WorkloadSmoke)
+	require.NoError(t, err)
+
+	assert.Equal(t, "perf-test-run-1", job.Name)
+	assert.Equal(t, "everest", job.Namespace)
+	assert.Equal(t, sysbenchImage, job.Spec.Template.Spec.Containers[0].Image)
+
+	env := job.Spec.Template.Spec.Containers[0].Env
+	require.Len(t, env, 5)
+	for _, e := range env[:4] {
+		require.NotNil(t, e.ValueFrom, "credential env var %q must be sourced via secretKeyRef, never a literal Value", e.Name)
+		assert.Equal(t, "everest-secrets-pg-poc", e.ValueFrom.SecretKeyRef.Name)
+		assert.Empty(t, e.Value, "credential env var %q must not carry a literal value", e.Name)
+	}
+	assert.Equal(t, "SB_PGDB", env[4].Name)
+	assert.Equal(t, "postgres", env[4].Value)
+}
+
+func TestBuildJob_AntiAffinityTargetsInstanceLabel(t *testing.T) {
+	t.Parallel()
+
+	job, err := buildJob("run-1", "pg-poc", "everest", "postgres", WorkloadSmoke)
+	require.NoError(t, err)
+
+	terms := job.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.Len(t, terms, 1)
+	assert.Equal(t, "pg-poc", terms[0].PodAffinityTerm.LabelSelector.MatchLabels["app.kubernetes.io/instance"])
+	assert.Equal(t, "kubernetes.io/hostname", terms[0].PodAffinityTerm.TopologyKey)
+}
+
+func TestBuildJob_WorkloadSelectsCorrectSysbenchTest(t *testing.T) {
+	t.Parallel()
+
+	cases := map[Workload]string{
+		WorkloadSmoke:      "oltp_read_only",
+		WorkloadReadHeavy:  "oltp_read_only",
+		WorkloadWriteHeavy: "oltp_write_only",
+		WorkloadMixedOLTP:  "oltp_read_write",
+	}
+	for workload, wantTest := range cases {
+		job, err := buildJob("run-1", "pg-poc", "everest", "postgres", workload)
+		require.NoError(t, err)
+		script := job.Spec.Template.Spec.Containers[0].Command[2]
+		assert.Contains(t, script, "sysbench "+wantTest+" ",
+			"workload %q: expected script to run %q, got:\n%s", workload, wantTest, script)
+	}
+}
+
+func TestBuildJob_FailFastOnce(t *testing.T) {
+	t.Parallel()
+
+	job, err := buildJob("run-1", "pg-poc", "everest", "postgres", WorkloadSmoke)
+	require.NoError(t, err)
+	require.NotNil(t, job.Spec.BackoffLimit)
+	assert.Equal(t, int32(0), *job.Spec.BackoffLimit)
+	assert.Equal(t, corev1.RestartPolicyNever, job.Spec.Template.Spec.RestartPolicy)
+}

--- a/plugins/performance-testing/backend/kube.go
+++ b/plugins/performance-testing/backend/kube.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// newKubeClient builds a plain client-go clientset. This backend only does
+// one-off Get/Create/List/Watch calls (read a credentials Secret, create a
+// Job, poll its status, read its pod's logs) — no controller loop, no
+// informer cache — so the typed clientset is the right tool, not
+// controller-runtime's manager/cache machinery the rest of this repo's
+// operators use.
+//
+// In-cluster config is used when running as the plugin's own Deployment
+// (the real, verified deployment path). The KUBECONFIG fallback exists
+// only so this binary can be run locally against a real cluster during
+// development, the same way `go run ./providers/minio/cmd` was run
+// directly against the target cluster for the object-storage PoC.
+func newKubeClient() (*kubernetes.Clientset, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		kubeconfig := os.Getenv("KUBECONFIG")
+		if kubeconfig == "" {
+			return nil, fmt.Errorf("not running in-cluster and KUBECONFIG is not set: %w", err)
+		}
+		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("build config from KUBECONFIG: %w", err)
+		}
+	}
+	return kubernetes.NewForConfig(cfg)
+}

--- a/plugins/performance-testing/backend/main.go
+++ b/plugins/performance-testing/backend/main.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command main is the entrypoint for the performance-testing plugin
+// backend, following the layout of openeverest/generic-plugin-template:
+// plain net/http, GET /healthz, plugin API under /api/..., PORT env var
+// for the listen port.
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+)
+
+func listenPort() string {
+	if p := os.Getenv("PORT"); p != "" {
+		return p
+	}
+	return "8080"
+}
+
+func main() {
+	kube, err := newKubeClient()
+	if err != nil {
+		log.Fatalf("build kube client: %v", err)
+	}
+
+	s := &server{kube: kube, store: newMemoryStore()}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", s.handleHealthz)
+	mux.HandleFunc("POST /api/runs", s.handleCreateRun)
+	mux.HandleFunc("GET /api/runs", s.handleListRuns)
+	mux.HandleFunc("GET /api/runs/{id}", s.handleGetRun)
+
+	port := listenPort()
+	log.Printf("performance-testing plugin backend listening on :%s", port)
+	if err := http.ListenAndServe(":"+port, mux); err != nil { //nolint:gosec // PoC backend; no read/write timeouts configured yet, matches generic-plugin-template's own reference main.go.
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/plugins/performance-testing/backend/parser.go
+++ b/plugins/performance-testing/backend/parser.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"regexp"
+	"strconv"
+)
+
+// sysbench's plain-text report is the only output format its `run` command
+// produces (no --output=json flag exists in the 1.0.x line), so the Job's
+// log output has to be scraped with a regex rather than unmarshalled.
+//
+// The queries-per-second line's label genuinely differs across sysbench
+// builds: a real run against pg-poc using sysbench 1.0.20 (Debian
+// trixie's packaged build, see ../Dockerfile.sysbench) reported it as
+// "queries:", not "queries performed:" as some other 1.0.x builds do
+// (severalnines/sysbench, an earlier candidate image, used the "queries
+// performed:" label — see job.go's sysbenchImage comment for why that
+// image was dropped for an unrelated libpq reason). This was only caught
+// by running an actual benchmark and inspecting the real output; queriesPerSecRE
+// matches both labels.
+//
+//	transactions:                        3283   (328.09 per sec.)
+//	queries:                             52528  (5249.37 per sec.)
+//	...
+//	    avg:                                    6.09
+//	    95th percentile:                       54.83
+var (
+	transactionsPerSecRE = regexp.MustCompile(`(?m)^\s*transactions:\s+\d+\s+\(([\d.]+) per sec\.\)`)
+	queriesPerSecRE      = regexp.MustCompile(`(?m)^\s*queries(?: performed)?:\s+\d+\s+\(([\d.]+) per sec\.\)`)
+	latencyAvgRE         = regexp.MustCompile(`(?m)^\s*avg:\s+([\d.]+)\s*$`)
+	latencyP95RE         = regexp.MustCompile(`(?m)^\s*95th percentile:\s+([\d.]+)\s*$`)
+)
+
+// parseSysbenchOutput extracts throughput/latency numbers from sysbench's
+// stdout. Fields that don't match (unexpected sysbench version, truncated
+// output) are simply left nil on the returned Result rather than treated
+// as a parse error — a partial result is more useful than no result.
+func parseSysbenchOutput(output string) *Result {
+	result := &Result{}
+	if m := transactionsPerSecRE.FindStringSubmatch(output); m != nil {
+		result.TransactionsPerSec = parseFloatPtr(m[1])
+	}
+	if m := queriesPerSecRE.FindStringSubmatch(output); m != nil {
+		result.QueriesPerSec = parseFloatPtr(m[1])
+	}
+	if m := latencyAvgRE.FindStringSubmatch(output); m != nil {
+		result.LatencyAvgMs = parseFloatPtr(m[1])
+	}
+	if m := latencyP95RE.FindStringSubmatch(output); m != nil {
+		result.LatencyP95Ms = parseFloatPtr(m[1])
+	}
+	return result
+}
+
+func parseFloatPtr(s string) *float64 {
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return nil
+	}
+	return &v
+}

--- a/plugins/performance-testing/backend/parser_test.go
+++ b/plugins/performance-testing/backend/parser_test.go
@@ -1,0 +1,142 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// realSysbenchOutput is a real sysbench 1.0.x oltp_read_write report,
+// trimmed to the sections parseSysbenchOutput actually reads.
+const realSysbenchOutput = `sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)
+
+Running the test with following options:
+Number of threads: 8
+
+SQL statistics:
+    queries performed:
+        read:                            140060
+        write:                           40018
+        other:                           20009
+        total:                           200087
+    transactions:                        10004  (1000.31 per sec.)
+    queries performed:                   200087 (20005.85 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+General statistics:
+    total time:                          10.0007s
+    total number of events:              10004
+
+Latency (ms):
+         min:                                    1.34
+         avg:                                    1.60
+         max:                                   15.29
+         95th percentile:                        2.13
+         sum:                                 15987.75
+`
+
+func TestParseSysbenchOutput_RealReport(t *testing.T) {
+	t.Parallel()
+
+	result := parseSysbenchOutput(realSysbenchOutput)
+
+	require.NotNil(t, result.TransactionsPerSec)
+	assert.InDelta(t, 1000.31, *result.TransactionsPerSec, 0.001)
+
+	require.NotNil(t, result.QueriesPerSec)
+	assert.InDelta(t, 20005.85, *result.QueriesPerSec, 0.001)
+
+	require.NotNil(t, result.LatencyAvgMs)
+	assert.InDelta(t, 1.60, *result.LatencyAvgMs, 0.001)
+
+	require.NotNil(t, result.LatencyP95Ms)
+	assert.InDelta(t, 2.13, *result.LatencyP95Ms, 0.001)
+}
+
+// actualDebianTrixieSysbenchOutput is the real, unedited output of a
+// sysbench 1.0.20 (Debian trixie's packaged build, ../Dockerfile.sysbench)
+// oltp_read_only smoke run against the live pg-poc PostgreSQL instance on
+// everest-poc. Unlike the older sysbench build realSysbenchOutput above
+// was modelled on, this build's per-second summary line reads "queries:",
+// not "queries performed:" — queriesPerSecRE originally only matched the
+// latter and silently dropped QueriesPerSec on every real run until this
+// was caught by actually running a benchmark and checking GET
+// /api/runs/{id}'s response, not by inspecting the code.
+const actualDebianTrixieSysbenchOutput = `sysbench 1.0.20 (using system LuaJIT 2.1.1700206165)
+
+Running the test with following options:
+Number of threads: 2
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+SQL statistics:
+    queries performed:
+        read:                            45962
+        write:                           0
+        other:                           6566
+        total:                           52528
+    transactions:                        3283   (328.09 per sec.)
+    queries:                             52528  (5249.37 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+General statistics:
+    total time:                          10.0035s
+    total number of events:              3283
+
+Latency (ms):
+         min:                                    0.85
+         avg:                                    6.09
+         max:                                   69.14
+         95th percentile:                       54.83
+         sum:                                19992.04
+`
+
+func TestParseSysbenchOutput_ActualDebianTrixieBuild_QueriesLineHasNoPerformedSuffix(t *testing.T) {
+	t.Parallel()
+
+	result := parseSysbenchOutput(actualDebianTrixieSysbenchOutput)
+
+	require.NotNil(t, result.TransactionsPerSec)
+	assert.InDelta(t, 328.09, *result.TransactionsPerSec, 0.001)
+
+	require.NotNil(t, result.QueriesPerSec, "queries-per-sec must parse even when the line reads \"queries:\" instead of \"queries performed:\"")
+	assert.InDelta(t, 5249.37, *result.QueriesPerSec, 0.001)
+
+	require.NotNil(t, result.LatencyAvgMs)
+	assert.InDelta(t, 6.09, *result.LatencyAvgMs, 0.001)
+
+	require.NotNil(t, result.LatencyP95Ms)
+	assert.InDelta(t, 54.83, *result.LatencyP95Ms, 0.001)
+}
+
+func TestParseSysbenchOutput_UnexpectedFormat_ReturnsPartialResult(t *testing.T) {
+	t.Parallel()
+
+	result := parseSysbenchOutput("sysbench: error: no such command\n")
+
+	assert.Nil(t, result.TransactionsPerSec)
+	assert.Nil(t, result.QueriesPerSec)
+	assert.Nil(t, result.LatencyAvgMs)
+	assert.Nil(t, result.LatencyP95Ms)
+}

--- a/plugins/performance-testing/backend/store.go
+++ b/plugins/performance-testing/backend/store.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// RunStore persists benchmark runs for the comparison-over-time outcome.
+// This PoC ships only the in-memory implementation: results live for the
+// life of the backend pod, ephemeral by default, matching the maintainers'
+// explicit steer against ConfigMap/PVC-by-default storage in the #2464
+// issue thread. A durable backend (SQLite, or an Everest-managed Postgres
+// instance) is a separate, opt-in implementation of this same interface —
+// not built here.
+type RunStore interface {
+	Save(r Run) error
+	Get(id string) (Run, bool)
+	List() []Run
+}
+
+// memoryStore is a RunStore backed by a map, guarded by a mutex since the
+// HTTP handlers and the background Job-status poller both write to it.
+type memoryStore struct {
+	mu   sync.RWMutex
+	runs map[string]Run
+}
+
+func newMemoryStore() *memoryStore {
+	return &memoryStore{runs: make(map[string]Run)}
+}
+
+func (s *memoryStore) Save(r Run) error {
+	if r.ID == "" {
+		return fmt.Errorf("run ID must not be empty")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.runs[r.ID] = r
+	return nil
+}
+
+func (s *memoryStore) Get(id string) (Run, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.runs[id]
+	return r, ok
+}
+
+// List returns all runs, most recently started first.
+func (s *memoryStore) List() []Run {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Run, 0, len(s.runs))
+	for _, r := range s.runs {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].StartedAt.After(out[j].StartedAt)
+	})
+	return out
+}

--- a/plugins/performance-testing/backend/store_test.go
+++ b/plugins/performance-testing/backend/store_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryStore_SaveGet(t *testing.T) {
+	t.Parallel()
+
+	s := newMemoryStore()
+	run := Run{ID: "run-1", Instance: "pg-poc", Status: RunStatusRunning, StartedAt: time.Now()}
+	require.NoError(t, s.Save(run))
+
+	got, ok := s.Get("run-1")
+	require.True(t, ok)
+	assert.Equal(t, run.Instance, got.Instance)
+}
+
+func TestMemoryStore_Get_MissingReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	s := newMemoryStore()
+	_, ok := s.Get("does-not-exist")
+	assert.False(t, ok)
+}
+
+func TestMemoryStore_List_MostRecentFirst(t *testing.T) {
+	t.Parallel()
+
+	s := newMemoryStore()
+	now := time.Now()
+	require.NoError(t, s.Save(Run{ID: "older", StartedAt: now.Add(-time.Hour)}))
+	require.NoError(t, s.Save(Run{ID: "newer", StartedAt: now}))
+
+	list := s.List()
+	require.Len(t, list, 2)
+	assert.Equal(t, "newer", list[0].ID)
+	assert.Equal(t, "older", list[1].ID)
+}
+
+func TestMemoryStore_Save_EmptyIDRejected(t *testing.T) {
+	t.Parallel()
+
+	s := newMemoryStore()
+	err := s.Save(Run{ID: ""})
+	require.Error(t, err)
+}

--- a/plugins/performance-testing/backend/types.go
+++ b/plugins/performance-testing/backend/types.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "time"
+
+// Workload names a predefined sysbench profile. Hiding raw sysbench flags
+// behind a small, named set keeps the API surface simple for a first
+// engine; a "custom" profile carrying raw parameters is future work, not
+// this PoC.
+type Workload string
+
+const (
+	WorkloadSmoke      Workload = "smoke"       // short, low-concurrency sanity check
+	WorkloadReadHeavy  Workload = "read-heavy"  // oltp_read_only
+	WorkloadWriteHeavy Workload = "write-heavy" // oltp_write_only
+	WorkloadMixedOLTP  Workload = "mixed-oltp"  // oltp_read_write
+)
+
+// RunStatus is the lifecycle state of a benchmark run.
+type RunStatus string
+
+const (
+	RunStatusPending   RunStatus = "Pending"
+	RunStatusRunning   RunStatus = "Running"
+	RunStatusSucceeded RunStatus = "Succeeded"
+	RunStatusFailed    RunStatus = "Failed"
+)
+
+// Result holds the throughput/latency numbers parsed out of sysbench's
+// output. Pointers so an in-progress or failed run can omit fields that
+// were never produced, rather than reporting a misleading zero.
+type Result struct {
+	TransactionsPerSec *float64 `json:"transactionsPerSec,omitempty"`
+	QueriesPerSec      *float64 `json:"queriesPerSec,omitempty"`
+	LatencyAvgMs       *float64 `json:"latencyAvgMs,omitempty"`
+	LatencyP95Ms       *float64 `json:"latencyP95Ms,omitempty"`
+}
+
+// Run is one benchmark execution, from request through result. This is the
+// unit the run Store persists and the list/get API returns.
+type Run struct {
+	ID         string     `json:"id"`
+	Instance   string     `json:"instance"`
+	Namespace  string     `json:"namespace"`
+	Workload   Workload   `json:"workload"`
+	Status     RunStatus  `json:"status"`
+	JobName    string     `json:"jobName"`
+	StartedAt  time.Time  `json:"startedAt"`
+	FinishedAt *time.Time `json:"finishedAt,omitempty"`
+	Result     *Result    `json:"result,omitempty"`
+	Error      string     `json:"error,omitempty"`
+}

--- a/plugins/performance-testing/charts/performance-testing/Chart.yaml
+++ b/plugins/performance-testing/charts/performance-testing/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: performance-testing
+description: Performance testing plugin for OpenEverest — run sysbench benchmarks against Everest-managed databases from the dashboard or CLI.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/plugins/performance-testing/charts/performance-testing/templates/_helpers.tpl
+++ b/plugins/performance-testing/charts/performance-testing/templates/_helpers.tpl
@@ -1,0 +1,8 @@
+{{- define "performance-testing.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "performance-testing.labels" -}}
+app.kubernetes.io/name: {{ include "performance-testing.fullname" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/plugins/performance-testing/charts/performance-testing/templates/deployment.yaml
+++ b/plugins/performance-testing/charts/performance-testing/templates/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "performance-testing.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "performance-testing.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "performance-testing.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "performance-testing.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "performance-testing.fullname" . }}
+      containers:
+        - name: backend
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http

--- a/plugins/performance-testing/charts/performance-testing/templates/plugin-cr.yaml
+++ b/plugins/performance-testing/charts/performance-testing/templates/plugin-cr.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions.openeverest.io/v1alpha1
+kind: Plugin
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  displayName: {{ .Values.plugin.displayName | quote }}
+  description: {{ .Values.plugin.description | quote }}
+  version: {{ .Chart.AppVersion | quote }}
+  vendor: {{ .Values.plugin.vendor | quote }}
+  enabled: {{ .Values.plugin.enabled }}
+  backend:
+    serviceRef:
+      namespace: {{ .Release.Namespace }}
+      name: {{ include "performance-testing.fullname" . }}
+      port: {{ .Values.service.port }}
+  frontend:
+    extensionPoints:
+      {{- toYaml .Values.plugin.extensionPoints | nindent 6 }}
+  permissions:
+    - verb: read
+      resource: database-clusters

--- a/plugins/performance-testing/charts/performance-testing/templates/role.yaml
+++ b/plugins/performance-testing/charts/performance-testing/templates/role.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.rbac.create }}
+# Namespaced Role, not ClusterRole: this PoC only benchmarks databases in
+# the same namespace the plugin itself is installed into. Multi-namespace
+# support (matching how everestctl extension install namespaces other
+# plugins) is real follow-up work, not built here.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "performance-testing.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "performance-testing.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  # Scoped to reading only: this plugin never creates, updates, or deletes
+  # a Secret, and the "get" verb still lets any DatabaseCluster's
+  # credentials Secret be read within this namespace (Kubernetes RBAC has
+  # no resourceName wildcard-by-prefix — "everest-secrets-*" cannot be
+  # expressed here; a validatingadmission/OPA policy would be needed to
+  # narrow this further, out of scope for this PoC).
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+{{- end }}

--- a/plugins/performance-testing/charts/performance-testing/templates/rolebinding.yaml
+++ b/plugins/performance-testing/charts/performance-testing/templates/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "performance-testing.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "performance-testing.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "performance-testing.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "performance-testing.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/plugins/performance-testing/charts/performance-testing/templates/service.yaml
+++ b/plugins/performance-testing/charts/performance-testing/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "performance-testing.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "performance-testing.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "performance-testing.labels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http

--- a/plugins/performance-testing/charts/performance-testing/templates/serviceaccount.yaml
+++ b/plugins/performance-testing/charts/performance-testing/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "performance-testing.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "performance-testing.labels" . | nindent 4 }}
+{{- end }}

--- a/plugins/performance-testing/charts/performance-testing/values.yaml
+++ b/plugins/performance-testing/charts/performance-testing/values.yaml
@@ -1,0 +1,29 @@
+image:
+  repository: performance-testing-backend
+  tag: "0.1.0"
+  pullPolicy: IfNotPresent
+
+service:
+  port: 8080
+
+plugin:
+  displayName: "Performance Testing"
+  description: "Run sysbench benchmarks against Everest-managed databases and compare results over time."
+  vendor: "OpenEverest"
+  enabled: true
+  # PluginExtensionPoint (api/extensions/v1alpha1/plugin_types.go) only has
+  # type/label/path/icon/providers — no "name" or "routeName" fields, unlike
+  # the design doc's aspirational CRD sketch in docs/process/generic-plugins-design.md.
+  extensionPoints:
+    - type: route
+      label: "Performance Testing"
+    - type: sidebarItem
+      label: "Performance Testing"
+
+# RBAC the plugin's own ServiceAccount needs against the Kubernetes API
+# (batch/jobs to run benchmarks, pods/log to read results, and a scoped
+# get on credentials Secrets named "everest-secrets-<instance>"). This is
+# Kubernetes RBAC shipped by the chart, per docs/process/generic-plugins-design.md
+# §8.7 — the host does not generate or validate it.
+rbac:
+  create: true

--- a/plugins/performance-testing/manifest/sample-plugin.yaml
+++ b/plugins/performance-testing/manifest/sample-plugin.yaml
@@ -1,0 +1,34 @@
+# Minimal Plugin CR for testing the performance-testing backend directly
+# with `kubectl apply`, without going through `helm install` — mirrors
+# providers/minio/manifest/sample-instance.yaml's role for the object-storage
+# PoC. Assumes the backend Deployment/Service/RBAC (see ../charts/performance-testing)
+# are already applied in the same namespace.
+#
+# Deployed into "everest", not "everest-system": the plugin's own RBAC
+# (see ../charts/performance-testing/templates/role.yaml) is a namespaced
+# Role scoped to wherever the plugin's Deployment runs, and this PoC only
+# benchmarks databases in that same namespace — pg-poc, the real target,
+# lives in "everest".
+apiVersion: extensions.openeverest.io/v1alpha1
+kind: Plugin
+metadata:
+  name: performance-testing
+spec:
+  displayName: "Performance Testing"
+  description: "Run sysbench benchmarks against Everest-managed databases and compare results over time."
+  vendor: "OpenEverest"
+  enabled: true
+  backend:
+    serviceRef:
+      namespace: everest
+      name: performance-testing
+      port: 8080
+  frontend:
+    extensionPoints:
+      - type: route
+        label: "Performance Testing"
+      - type: sidebarItem
+        label: "Performance Testing"
+  permissions:
+    - verb: read
+      resource: database-clusters


### PR DESCRIPTION
What this is

A proof-of-work PoC for the Performance Testing Plugin problem statement (#2464), built ahead of a CNCF LFX Mentorship Term 3 application. It is not intended to be merged and does not close #2464 ,it exists to demonstrate a working, end-to-end understanding of the codebase and the problem before the mentorship application deadline.

What's done

- A generic OpenEverest plugin (docs/process/generic-plugins-design.md) under plugins/performance-testing/ that runs sysbench benchmarks against Everest-managed PostgreSQL databases as ephemeral Kubernetes Jobs.
- Backend API: POST /api/runs, GET /api/runs/{id}, GET /api/runs (in-memory run history).
- Helm chart: Plugin CR, Deployment, Service, ServiceAccount, Role, RoleBinding.
- Unit tests for the handlers/job/parser/store packages.
- Verified end to end on a live kind cluster against a real DatabaseCluster (pg-poc): a real POST /api/runs triggers a real sysbench prepare/run/cleanup Job, and GET /api/runs/{id} returns real parsed throughput/latency numbers. Two real bugs were found and fixed by actually running it (not just inspection) a SCRAM-SHA-256 auth incompatibility in the bundled sysbench image, and a silent parsing mismatch on the queries-per-second summary line. Both are detailed in the commit message.

What's explicitly out of scope here

Left for the full mentorship engagement, not built in this PoC:

- MySQL/pgbench and MongoDB/YCSB engines (PostgreSQL/sysbench only here)
- UI config/results panel
- CLI run/retrieve commands
- Durable result storage with regression comparison (current store is in-memory only, matching the maintainers' rejection of ConfigMap/PVC-by-default storage discussed in the #2464 issue thread)

Design notes

Credentials are read directly from the target's own everest-secrets-<instance> Secret (scoped RBAC, secretKeyRef only, never held in process memory) because the connection-details broker only covers the newer spec-001 Instance type, and every real database on a default install including pg-poc is still the older DatabaseCluster type, which has no equivalent broker in release-2.0. Full reasoning is in plugins/performance-testing/README.md and the commit message.