### PR TITLE
test: harden rate limiter concurrency regression

### DIFF
--- a/internal/server/session_failures_storage_test.go
+++ b/internal/server/session_failures_storage_test.go
@@ -17,7 +17,9 @@ package server
 import (
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/time/rate"
 )
 
@@ -31,7 +33,8 @@ func TestRateLimiterMemoryStore_ConcurrentAllowAndIncreaseTimeout(t *testing.T) 
 	})
 
 	const identifier = "1.2.3.4"
-	const iterations = 200
+	const iterations = 20
+	_, _ = store.Allow(identifier)
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -51,4 +54,9 @@ func TestRateLimiterMemoryStore_ConcurrentAllowAndIncreaseTimeout(t *testing.T) 
 	}()
 
 	wg.Wait()
+
+	store.mutex.Lock()
+	actualTimeout := store.visitors[identifier].timeout
+	store.mutex.Unlock()
+	assert.Equal(t, initialTimeout*time.Duration(1<<iterations), actualTimeout)
 }


### PR DESCRIPTION
## Issue

Fixes #2958.

## Background

The existing race regression test could pass without exercising `IncreaseTimeout`: if all writer iterations ran before the first `Allow`, every write was a no-op, and the test had no assertions.

## Changes

- Create the visitor before starting the concurrent goroutines.
- Reduce doublings to 20 to avoid `time.Duration` overflow.
- Assert that the visitor timeout equals `initialTimeout << iterations` after the concurrent run.

This is test-only and has no runtime compatibility impact.

## Validation

- `git diff --check` — passed.
- `go test ./internal/server -run TestRateLimiterMemoryStore_ConcurrentAllowAndIncreaseTimeout -count=10` — not completed: the environment spent over two minutes downloading the repository's large Go dependency graph before I stopped it.
- `go test -race ...` — not run because the local Go toolchain reports `CGO_ENABLED=0` and no C compiler is available.

This contribution was implemented with AI assistance and manually reviewed against the issue and repository conventions.