### PR TITLE
ci: fix dead go mod tidy check in dev-be-ci.yaml

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -47,8 +47,7 @@ jobs:
           # `go mod tidy` could remove old checksums from that file, and that's okay on CI,
           # and actually expected for PRs made by @dependabot.
           # Checksums of actually used modules are checked by previous `go` subcommands.
-          pushd tools && go mod tidy -v && git checkout go.sum
-          popd        && go mod tidy -v && git checkout go.sum
+          go mod tidy -v && git checkout go.sum
           git diff --exit-code
 
       - name: Run debug commands on failure
@@ -98,8 +97,7 @@ jobs:
       - name: Check that there are no source code changes
         run: |
           make format
-          pushd tools && go mod tidy -v
-          popd        && go mod tidy -v
+          go mod tidy -v && git checkout go.sum
           git status
           git diff --exit-code
 


### PR DESCRIPTION
## Problem

`tools/` was deleted (#1521, replaced by the tool directive), but
`dev-be-ci.yaml` still tried to `cd` into it via `pushd tools`. Under the
shell Actions uses (`bash -e -o pipefail`), a failure in a non-final member
of an `&&` list doesn't trigger `set -e`: `pushd tools` fails, the list
short-circuits, `popd` then fails on an empty stack, and `git diff --exit-code`
passes on a clean tree — so the step reports success without `go mod tidy`
or `git checkout go.sum` ever running.

Net effect: an untidy `go.mod`/`go.sum` currently passes both the `test` and
`check` jobs.

## Fix
fixes #2957 
The repo is a single module now (root `go.mod` only), so this drops the
`pushd`/`popd` wrapper entirely instead of repointing it — one
`go mod tidy -v` per step.

The two copies weren't symmetric: the `test` job's step restores `go.sum`
afterwards (expected, since `go mod tidy` dropping stale checksums is normal
on dependabot PRs), but the `check` job's copy had no `git checkout go.sum`
at all. Un-breaking `tidy` there without the restore would start failing
dependabot PRs on a go.sum diff, so this adds the same restore to the
`check` job's copy.

## Verification

`go mod tidy` is currently a no-op on this branch and `go.sum` comes back
unchanged, so restoring the check does not turn CI red.
