### PR TITLE
fix(validation): report the matching namespace on duplicate backup storage create

### DIFF
--- a/internal/server/handlers/validation/backup_storage.go
+++ b/internal/server/handlers/validation/backup_storage.go
@@ -115,13 +115,14 @@ func validateCreateBackupStorageRequest(
 	params *api.CreateBackupStorageParams,
 	existingStorages *everestv1alpha1.BackupStorageList,
 ) error {
-	if slices.ContainsFunc(existingStorages.Items, func(storage everestv1alpha1.BackupStorage) bool {
+	duplicateIdx := slices.IndexFunc(existingStorages.Items, func(storage everestv1alpha1.BackupStorage) bool {
 		// Check if the storage already exists with the same region, endpoint URL, and bucket name
 		return storage.Spec.Region == params.Region &&
 			storage.Spec.EndpointURL == pointer.GetString(params.Url) &&
 			storage.Spec.Bucket == params.BucketName
-	}) {
-		return errDuplicatedBackupStorage(existingStorages.Items[0].GetNamespace())
+	})
+	if duplicateIdx >= 0 {
+		return errDuplicatedBackupStorage(existingStorages.Items[duplicateIdx].GetNamespace())
 	}
 
 	if err := operatorUtils.ValidateEverestResourceName(params.Name, "name"); err != nil {

--- a/internal/server/handlers/validation/backup_storage_test.go
+++ b/internal/server/handlers/validation/backup_storage_test.go
@@ -38,6 +38,53 @@ const (
 	bsNamespace = "test-ns"
 )
 
+func TestValidateCreateBackupStorageRequestReportsMatchingNamespace(t *testing.T) {
+	t.Parallel()
+
+	url := "https://s3.example.com"
+	existingStorages := &everestv1alpha1.BackupStorageList{
+		Items: []everestv1alpha1.BackupStorage{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "storage-a",
+					Namespace: "ns-a",
+				},
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Bucket:      "other-bucket",
+					Region:      "us-west-2",
+					EndpointURL: "https://s3.other.com",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "storage-b",
+					Namespace: "ns-b",
+				},
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Bucket:      "my-bucket",
+					Region:      "us-east-1",
+					EndpointURL: url,
+				},
+			},
+		},
+	}
+
+	params := &everestapi.CreateBackupStorageParams{
+		Name:       "new-storage",
+		BucketName: "my-bucket",
+		Region:     "us-east-1",
+		Url:        &url,
+	}
+
+	err := validateCreateBackupStorageRequest(context.Background(), zap.NewNop().Sugar(), params, existingStorages)
+	require.Error(t, err)
+	assert.EqualError(
+		t,
+		err,
+		"backup storage with the same url, bucket and region already exists in namespace='ns-b'",
+	)
+}
+
 func TestValidateDuplicateStorageByUpdate(t *testing.T) {
 	t.Parallel()
 	cases := []struct {


### PR DESCRIPTION
Hi, I looked at this while going through backup storage validation.

The duplicate check was already finding the right storage, but the error message always used `Items[0]` for the namespace. So if you had storages in multiple namespaces, the message could point at the wrong one even though the validation itself was correct.

I switched it to `slices.IndexFunc` and used the matched item's namespace in the error. Also added a small test for the create path — the update path already had coverage, but this one didn't.

Fixes #2952