### PR TITLE
fix(server): guard against nil CompletedAt in the PITR handler

### DIFF
--- a/internal/server/handlers/k8s/database_cluster.go
+++ b/internal/server/handlers/k8s/database_cluster.go
@@ -235,7 +235,7 @@ func (h *k8sHandler) GetDatabaseClusterPitr(ctx context.Context, namespace, name
 	}
 
 	latestBackup := latestSuccessfulBackup(backups.Items)
-	if latestBackup == nil || latestBackup.Status.CreatedAt == nil {
+	if latestBackup == nil || latestBackup.Status.CreatedAt == nil || latestBackup.Status.CompletedAt == nil {
 		return response, nil
 	}
 

--- a/internal/server/handlers/k8s/database_cluster_test.go
+++ b/internal/server/handlers/k8s/database_cluster_test.go
@@ -454,3 +454,50 @@ func TestCreateDatabaseClusterSecret(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDatabaseClusterPitrBackupWithoutCompletedAt(t *testing.T) {
+	t.Parallel()
+
+	const (
+		namespace   = "ns-pitr"
+		clusterName = "pxc-pitr"
+	)
+
+	db := &everestv1alpha1.DatabaseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: namespace},
+		Spec: everestv1alpha1.DatabaseClusterSpec{
+			Engine: everestv1alpha1.Engine{
+				Type:    everestv1alpha1.DatabaseEnginePXC,
+				Version: "8.0.36",
+			},
+			Backup: everestv1alpha1.Backup{
+				PITR: everestv1alpha1.PITRSpec{Enabled: true},
+			},
+		},
+	}
+	// A successful backup whose CompletedAt was never set. The field is
+	// optional in the CRD, so the API must not assume it is populated.
+	backup := &everestv1alpha1.DatabaseClusterBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backup-without-completed-at",
+			Namespace: namespace,
+			Labels:    map[string]string{common.DatabaseClusterNameLabel: clusterName},
+		},
+		Status: everestv1alpha1.DatabaseClusterBackupStatus{
+			State:     everestv1alpha1.BackupSucceeded,
+			CreatedAt: &metav1.Time{Time: time.Now().Add(-time.Hour)},
+		},
+	}
+
+	mockClient := fakeclient.NewClientBuilder().
+		WithScheme(kubernetes.CreateScheme()).
+		WithObjects(db, backup)
+	k := kubernetes.NewEmpty(zap.NewNop().Sugar()).WithKubernetesClient(mockClient.Build())
+	h := &k8sHandler{kubeConnector: k}
+
+	pitr, err := h.GetDatabaseClusterPitr(context.Background(), namespace, clusterName)
+	require.NoError(t, err)
+	require.NotNil(t, pitr)
+	require.Nil(t, pitr.LatestDate)
+	require.Nil(t, pitr.EarliestDate)
+}


### PR DESCRIPTION
## Summary

`GetDatabaseClusterPitr` guards `CreatedAt` and then dereferences `CompletedAt` on the next line. `CompletedAt` is optional in the CRD, so a successful backup without it panics the handler: `metav1.Time` embeds `time.Time`, so calling `.UTC()` through a nil pointer dereferences it.

The guard now covers `CompletedAt` too, which returns the empty response for that backup shape, exactly as the handler already does when `CreatedAt` is missing.

Fixes #2973

## Testing

The new test reproduces the panic against the unpatched handler:

```
--- FAIL: TestGetDatabaseClusterPitrBackupWithoutCompletedAt (0.05s)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0]
	k8s.(*k8sHandler).GetDatabaseClusterPitr
		internal/server/handlers/k8s/database_cluster.go:242
```

With the guard in place, run from a clean checkout of this branch:

- `CGO_ENABLED=1 go test -race -timeout=20m ./...` passes, including `internal/server/handlers/k8s`
- `make copyright-check` reports all headers present
- `go vet ./internal/server/handlers/k8s/...` and `golangci-lint run ./internal/server/handlers/k8s/...` are clean

## AI assistance

This contribution was made with AI assistance. I reviewed the change and ran every command quoted above.
