### PR TITLE
ci: follow helm-charts to its post-swap branch names (v2 line)

### DIFF
--- a/.github/workflows/feature-build-v1.yaml
+++ b/.github/workflows/feature-build-v1.yaml
@@ -21,7 +21,7 @@ on:
         description: "Version Service branch with the feature to checkout"
       helm_branch:
         required: false
-        default: main
+        default: v1.x
         description: "Helm charts branch with the feature to checkout"
       artifacts_retention_days:
         required: false
@@ -52,7 +52,7 @@ on:
       helm_branch:
         required: false
         type: string
-        default: main
+        default: v1.x
         description: "Helm charts branch with the feature to checkout"
       artifacts_retention_days:
         required: false
@@ -164,7 +164,7 @@ jobs:
 
           # Fall back to default branch if the specified branch does not exist
           git ls-remote --heads --exit-code --quiet https://github.com/Percona-Lab/percona-version-service.git $VS_BRANCH > /dev/null || echo "VS_BRANCH=production" | tee -a $GITHUB_ENV
-          git ls-remote --heads --exit-code --quiet https://github.com/openeverest/helm-charts.git $HELM_BRANCH > /dev/null || echo "HELM_BRANCH=main" | tee -a $GITHUB_ENV
+          git ls-remote --heads --exit-code --quiet https://github.com/openeverest/helm-charts.git $HELM_BRANCH > /dev/null || echo "HELM_BRANCH=v1.x" | tee -a $GITHUB_ENV
           git ls-remote --heads --exit-code --quiet https://github.com/openeverest/openeverest.git $EVEREST_BRANCH > /dev/null || echo "EVEREST_BRANCH=v1.x" | tee -a $GITHUB_ENV
           git ls-remote --heads --exit-code --quiet https://github.com/openeverest/openeverest-operator.git $EVEREST_OPERATOR_BRANCH > /dev/null || echo "EVEREST_OPERATOR_BRANCH=main" | tee -a $GITHUB_ENV
           git ls-remote --heads --exit-code --quiet https://github.com/openeverest/openeverest-catalog.git $EVEREST_CATALOG_BRANCH > /dev/null || echo "EVEREST_CATALOG_BRANCH=main" | tee -a $GITHUB_ENV

--- a/.github/workflows/feature-build.yaml
+++ b/.github/workflows/feature-build.yaml
@@ -9,7 +9,7 @@ on:
         description: "Everest branch with the feature to checkout"
       helm_branch:
         required: false
-        default: v2
+        default: main
         description: "Helm charts branch with the feature to checkout"
       artifacts_retention_days:
         required: false
@@ -25,7 +25,7 @@ on:
       helm_branch:
         required: false
         type: string
-        default: v2
+        default: main
         description: "Helm charts branch with the feature to checkout"
       artifacts_retention_days:
         required: false
@@ -121,7 +121,7 @@ jobs:
           echo "VERSION_TAG=${{ needs.prepare.outputs.version_tag }}" | tee -a $GITHUB_ENV
 
           # Fall back to default branch if the specified branch does not exist
-          git ls-remote --heads --exit-code --quiet https://github.com/openeverest/helm-charts.git $HELM_BRANCH > /dev/null || echo "HELM_BRANCH=v2" | tee -a $GITHUB_ENV
+          git ls-remote --heads --exit-code --quiet https://github.com/openeverest/helm-charts.git $HELM_BRANCH > /dev/null || echo "HELM_BRANCH=main" | tee -a $GITHUB_ENV
           git ls-remote --heads --exit-code --quiet https://github.com/openeverest/openeverest.git $EVEREST_BRANCH > /dev/null || echo "EVEREST_BRANCH=main" | tee -a $GITHUB_ENV
 
       - name: Create temporary directory for storing artifacts

--- a/Makefile
+++ b/Makefile
@@ -452,9 +452,9 @@ dev-destroy: k3d-cluster-down-dev ## Destroy the k3d cluster.
 
 ##@ GitHub PR
 
-CHART_BRANCH ?= v2
+CHART_BRANCH ?= main
 .PHONY: update-dev-chart
-update-dev-chart: ## Update dependency to Everest Helm chart to the latest version from the specified branch (default v2).
+update-dev-chart: ## Update dependency to Everest Helm chart to the latest version from the specified branch (default main).
 	@COMMIT=$$(git ls-remote --exit-code https://github.com/openeverest/helm-charts refs/heads/$(CHART_BRANCH) | cut -f1) || \
 		{ echo "helm-charts branch '$(CHART_BRANCH)' not found. Set CHART_BRANCH to an existing branch."; exit 1; }; \
 	go get -u github.com/openeverest/helm-charts/charts/everest@$$COMMIT


### PR DESCRIPTION
**Step 5d of the branch swap. Do not merge until helm-charts has renamed `v2` -> `main`.**

Stacked on #2976 — review the top commit only until that merges.

helm-charts renames `main` -> `v1.x` and `v2` -> `main`, so every pin here moves one step:

| Pin | Before | After |
|---|---|---|
| `Makefile` `CHART_BRANCH` | `v2` | `main` |
| `feature-build.yaml` `helm_branch` | `v2` | `main` |
| `feature-build-v1.yaml` `helm_branch` | `main` | `v1.x` |

### Why the timing is strict

`dev-be-ci.yaml` runs `make update-dev-chart && git diff --exit-code` on **every** PR. Merge this early and `CHART_BRANCH=main` resolves to the v1 chart, so every PR on this branch goes red and a merge would downgrade the chart dependency in `go.mod`.

This is the one unavoidable red window in the migration: between helm-charts renaming `v2` -> `main` and this landing, `CHART_BRANCH=v2` no longer resolves. Keep it short. Maintainers hold `bypass_mode: pull_request` on the `Protect Main` ruleset, so this can be merged even if the gatekeeper is red.