### PR TITLE
ci: follow helm-charts to its post-swap branch names (v1 line)

### DIFF
--- a/.github/workflows/feature-build-v1.yaml
+++ b/.github/workflows/feature-build-v1.yaml
@@ -21,7 +21,7 @@ on:
         description: "Version Service branch with the feature to checkout"
       helm_branch:
         required: false
-        default: main
+        default: v1.x
         description: "Helm charts branch with the feature to checkout"
       artifacts_retention_days:
         required: false
@@ -52,7 +52,7 @@ on:
       helm_branch:
         required: false
         type: string
-        default: main
+        default: v1.x
         description: "Helm charts branch with the feature to checkout"
       artifacts_retention_days:
         required: false
@@ -164,7 +164,7 @@ jobs:
 
           # Fall back to default branch if the specified branch does not exist
           git ls-remote --heads --exit-code --quiet https://github.com/Percona-Lab/percona-version-service.git $VS_BRANCH > /dev/null || echo "VS_BRANCH=production" | tee -a $GITHUB_ENV
-          git ls-remote --heads --exit-code --quiet https://github.com/openeverest/helm-charts.git $HELM_BRANCH > /dev/null || echo "HELM_BRANCH=main" | tee -a $GITHUB_ENV
+          git ls-remote --heads --exit-code --quiet https://github.com/openeverest/helm-charts.git $HELM_BRANCH > /dev/null || echo "HELM_BRANCH=v1.x" | tee -a $GITHUB_ENV
           git ls-remote --heads --exit-code --quiet https://github.com/openeverest/openeverest.git $EVEREST_BRANCH > /dev/null || echo "EVEREST_BRANCH=v1.x" | tee -a $GITHUB_ENV
           git ls-remote --heads --exit-code --quiet https://github.com/openeverest/openeverest-operator.git $EVEREST_OPERATOR_BRANCH > /dev/null || echo "EVEREST_OPERATOR_BRANCH=main" | tee -a $GITHUB_ENV
           git ls-remote --heads --exit-code --quiet https://github.com/openeverest/openeverest-catalog.git $EVEREST_CATALOG_BRANCH > /dev/null || echo "EVEREST_CATALOG_BRANCH=main" | tee -a $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -338,9 +338,9 @@ dev-destroy: dev-down k3d-cluster-down-dev ## Stop Tilt and destroy the k3d clus
 
 ##@ GitHub PR
 
-CHART_BRANCH ?= main
+CHART_BRANCH ?= v1.x
 .PHONY: update-dev-chart
-update-dev-chart: ## Update dependency to Everest Helm chart to the latest version from the specified branch (default main).
+update-dev-chart: ## Update dependency to Everest Helm chart to the latest version from the specified branch (default v1.x).
 	@COMMIT=$$(git ls-remote --exit-code https://github.com/openeverest/helm-charts refs/heads/$(CHART_BRANCH) | cut -f1) || \
 		{ echo "helm-charts branch '$(CHART_BRANCH)' not found. Set CHART_BRANCH to an existing branch."; exit 1; }; \
 	go get -u github.com/openeverest/helm-charts/charts/everest@$$COMMIT


### PR DESCRIPTION
**Step 5b of the branch swap. Merge as soon as helm-charts has renamed `main` -> `v1.x`.**

Stacked on #2978 — review the top commit only until that merges. Targets today's `main`; GitHub retargets it to `v1.x` on rename.

| Pin | Before | After |
|---|---|---|
| `Makefile` `CHART_BRANCH` | `main` | `v1.x` |
| `feature-build-v1.yaml` `helm_branch` | `main` | `v1.x` |

Unlike the v2-side pin (#2977), this one has **no red window**: it can merge while helm-charts `v2` still exists, because nothing here depends on that branch. helm-charts `v1.x` points at the same commit `main` did, so `make update-dev-chart` produces no `go.mod` diff.