### PR TITLE
chore: refresh the Everest Helm chart dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.1.0
 	github.com/oapi-codegen/runtime v1.6.0
-	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260814140616-eceba292c94a
+	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818180808-80822324f802
 	github.com/operator-framework/api v0.45.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20260429065444-70caa52c384a
 	github.com/rodaine/table v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -847,8 +847,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260814140616-eceba292c94a h1:IXGOPvdPH1wdBLDkThfGqrar1TYERstfburM3FmOfH8=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260814140616-eceba292c94a/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818180808-80822324f802 h1:tmN/6iE9A12EXShGjJUdpoAzLEtfb0yHlTVVLDhJdFI=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818180808-80822324f802/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
 github.com/operator-framework/api v0.45.0 h1:hkROwtsLH3oszp4IW+WsXEFSDgveSahHI7DKStOtrUI=
 github.com/operator-framework/api v0.45.0/go.mod h1:IQ4uuISTiIhV09oAurJSGD4KabayhY5nV6k1XmA235M=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=


### PR DESCRIPTION
Follow-up to the branch swap. **Merge promptly — `dev-be-ci` is red on every PR against `main` until this lands.**

openeverest/helm-charts#91 moved the tip of the branch this line tracks, and `dev-be-ci` runs `make update-dev-chart && git diff --exit-code` on every PR. The pin has to move with it.

```
- helm-charts/charts/everest v0.0.0-20260814140616-eceba292c94a
+ helm-charts/charts/everest v0.0.0-20260818180808-80822324f802
```

Generated with `make update-dev-chart`; `go.mod` + `go.sum` only.

This coupling is pre-existing and unrelated to the rename: *any* merge to helm-charts turns openeverest CI red until a bump lands. Worth a separate look — a nightly bump job, or checking the pin is an ancestor of the branch tip rather than equal to it.