### PR TITLE
chore: refresh the Everest Helm chart dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.1.0
 	github.com/oapi-codegen/runtime v1.6.0
-	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260814143245-c6c176451253
+	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818181041-0ea10dba1f6c
 	github.com/operator-framework/api v0.45.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20260802124914-e2aa472c7107
 	github.com/rodaine/table v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -824,8 +824,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260814143245-c6c176451253 h1:MxeRB2VdgTDoKaH/r2w0/lV/2rCb1mNiCNHZV1d5pQQ=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260814143245-c6c176451253/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818181041-0ea10dba1f6c h1:Co5EB+9dnrAZNmcQJwByeyPOtN0zGO/pamwiBtBrEPk=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818181041-0ea10dba1f6c/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
 github.com/operator-framework/api v0.45.0 h1:hkROwtsLH3oszp4IW+WsXEFSDgveSahHI7DKStOtrUI=
 github.com/operator-framework/api v0.45.0/go.mod h1:IQ4uuISTiIhV09oAurJSGD4KabayhY5nV6k1XmA235M=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=


### PR DESCRIPTION
Follow-up to the branch swap. **Merge promptly — `dev-be-ci` is red on every PR against `v1.x` until this lands.**

openeverest/helm-charts#92 moved the tip of the branch this line tracks, and `dev-be-ci` runs `make update-dev-chart && git diff --exit-code` on every PR. The pin has to move with it.

```
- helm-charts/charts/everest v0.0.0-20260814143245-c6c176451253
+ helm-charts/charts/everest v0.0.0-20260818181041-0ea10dba1f6c
```

Generated with `make update-dev-chart`; `go.mod` + `go.sum` only.