### PR TITLE
docs: explain the branch layout without implying v1 is going away

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,23 +132,65 @@ Please say when a contribution is substantially AI-generated. Reports and pull r
 
 ### Which branch to target
 
-Two branches are actively developed:
-
 | Branch | Contents | Target it for |
 | --- | --- | --- |
-| `main` | OpenEverest v2 | New features and fixes |
-| `v1.x` | OpenEverest v1 | Fixes for the 1.x line |
+| `main` | OpenEverest v2 (Developer Preview) | New features and fixes |
+| `v1.x` | OpenEverest v1 (current release) | Fixes for the 1.x line |
 
-Unless an issue says otherwise, open your pull request against `main`. If you
-forked before v2 became the default, your fork's `main` still holds v1 code —
-reset it before branching:
+Unless an issue says otherwise, open your pull request against `main`.
+
+`main` carried v1 until 18 August 2026. The swap reflects where development
+happens and changes nothing about the
+[v1 lifecycle](https://openeverest.io/blog/v2-developer-preview-release/#timeline):
+v1 remains the released version, is still maintained, and only enters
+maintenance mode three months after v2 reaches GA.
+
+#### If you cloned or forked before 18 August 2026
+
+Your `main` still holds v1 code, so a branch cut from it targets the wrong
+codebase. Check with:
 
 ```sh
+git branch -vv | grep -E '\[origin/(main|release-2\.0)'
+```
+
+A local `main` reporting a large `ahead N, behind M` is v1 code tracking v2.
+Do not `git pull` it — that merges v2 into v1.
+
+**Working from a fork.** Your fork was not renamed. If you only work on v2 and
+have nothing unpushed on `main`, re-fork, or press **Sync fork** on your fork's
+`main` and choose *Discard commits*. To keep working on v1 as well, rename in
+your fork first — that is what makes the push below a plain create rather than
+a force-push:
+
+1. Fork on GitHub: Settings → Branches → rename `main` to `v1.x`.
+2. Then locally:
+
+```sh
+git remote add upstream https://github.com/openeverest/openeverest.git  # if missing
+git fetch --all --prune
 git branch -m main v1.x
-git fetch origin
 git branch -u origin/v1.x v1.x
+git checkout -b main upstream/main
+git push -u origin main
 git remote set-head origin -a
 ```
+
+3. Fork on GitHub: Settings → General → set the default branch back to `main`.
+
+**Pushing directly to this repository.** Rename `main` first to free the name:
+
+```sh
+git fetch origin --prune
+git branch -m main v1.x
+git branch -u origin/v1.x v1.x
+git branch -m release-2.0 main   # skip if you never had it
+git branch -u origin/main main
+git remote set-head origin -a
+```
+
+[openeverest/helm-charts](https://github.com/openeverest/helm-charts) moved the
+same way, with `v2` in place of `release-2.0`.
 
 ### Backend
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ OpenEverest - Run Data Workloads on Kubernetes
 [![Documentation](https://img.shields.io/badge/Documentation-blue?logo=readthedocs&logoColor=white)](https://openeverest.io/documentation/current/)
 [![Join Slack](https://img.shields.io/badge/Join_Slack-blue)](https://cloud-native.slack.com/archives/C09RRGZL2UX)
 
+> [!IMPORTANT]
+> **This branch carries OpenEverest v2, which is a [Developer Preview](https://openeverest.io/blog/v2-developer-preview-release/) — not feature-complete and not for production.**
+>
+> OpenEverest **v1 is the current released version** and is unchanged by this. It lives on [`v1.x`](https://github.com/openeverest/openeverest/tree/v1.x) and continues to receive releases. `main` moved to v2 on 18 August 2026 because that is where day-to-day development happens; it is not a statement about what to run. The [v1 lifecycle](https://openeverest.io/blog/v2-developer-preview-release/#timeline) is unchanged.
+>
+> Cloned or forked before that date? Your `main` still holds v1 code — see [Which branch to target](CONTRIBUTING.md#which-branch-to-target) before you branch.
+
 [OpenEverest](https://openeverest.io/) is an open source cloud-native database platform that helps developers deploy code faster, scale deployments rapidly, and reduce database administration overhead while regaining control over their data, database configuration, and DBaaS costs.
 
 Why you should try OpenEverest:


### PR DESCRIPTION
Follow-up to the branch swap, on both branches (`v1.x` counterpart: #2984).

### Why

Two problems with what we have now.

**1. The rename reads as "v1 is dead" if we do not say otherwise.** It is not. Our [published lifecycle](https://openeverest.io/blog/v2-developer-preview-release/#timeline) is unchanged:

| Stage | |
|---|---|
| v2 GA | expected in a few months |
| GA + 3 months | v1 enters maintenance mode |
| GA + 12 months | v1 EOL |

v2 on `main` is still a **Developer Preview** — not feature-complete, not for production. Somebody landing on the repo and seeing "main = v2" could reasonably conclude both the wrong things: that v1 is being dropped, and that v2 is ready to run. The README banner and CONTRIBUTING now state the lifecycle explicitly and link the blog post.

**2. The fork instructions were wrong.** The recipe I added in #2976 was the direct-clone one:

```sh
git branch -m main v1.x
git fetch origin
...
```

A fork is **not** renamed when upstream is, so for the majority of contributors that did nothing useful. Replaced with:

- how to tell whether you are affected (`git branch -vv` — a local `main` showing a big `ahead N, behind M` is v1 code tracking v2, and `git pull` on it merges v2 into v1)
- the fork path: re-fork, or **Sync fork** + *Discard commits* if you only want v2; otherwise rename `main` → `v1.x` **in your fork first**, which is what keeps the subsequent `git push origin main` a plain create instead of a force-push
- the direct-clone path, with the ordering fixed (`git branch -m release-2.0 main` fails with `fatal: a branch named 'main' already exists` unless you free the name first) and `--prune` added so stale `origin/release-2.0` goes away

Both recipes verified end to end on a scratch repo and on a real pre-rename clone.

### Not included

No `PULL_REQUEST_TEMPLATE.md` — this repo has none, and introducing one project-wide to carry a temporary migration notice is the wrong trade. Happy to add it separately if wanted.
