### PR TITLE
docs: explain the branch layout without implying v1 is going away

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,9 +132,66 @@ Please say when a contribution is substantially AI-generated. Reports and pull r
 
 ### Which branch to target
 
-You are reading the `v1.x` branch, which carries OpenEverest v1. Current
-development happens on `main`, which carries v2. Target `v1.x` only for fixes
-to the 1.x line; everything else belongs on `main`.
+| Branch | Contents | Target it for |
+| --- | --- | --- |
+| `main` | OpenEverest v2 (Developer Preview) | New features and fixes |
+| `v1.x` | OpenEverest v1 (current release) | Fixes for the 1.x line |
+
+You are reading `v1.x`. Unless an issue says otherwise, open your pull request
+against `main`.
+
+This branch was called `main` until 18 August 2026. The swap reflects where
+development happens and changes nothing about the
+[v1 lifecycle](https://openeverest.io/blog/v2-developer-preview-release/#timeline):
+v1 remains the released version, is still maintained, and only enters
+maintenance mode three months after v2 reaches GA.
+
+#### If you cloned or forked before 18 August 2026
+
+Your `main` still holds v1 code, so a branch cut from it targets the wrong
+codebase. Check with:
+
+```sh
+git branch -vv | grep -E '\[origin/(main|release-2\.0)'
+```
+
+A local `main` reporting a large `ahead N, behind M` is v1 code tracking v2.
+Do not `git pull` it — that merges v2 into v1.
+
+**Working from a fork.** Your fork was not renamed. If you only work on v2 and
+have nothing unpushed on `main`, re-fork, or press **Sync fork** on your fork's
+`main` and choose *Discard commits*. To keep working on v1 as well, rename in
+your fork first — that is what makes the push below a plain create rather than
+a force-push:
+
+1. Fork on GitHub: Settings → Branches → rename `main` to `v1.x`.
+2. Then locally:
+
+```sh
+git remote add upstream https://github.com/openeverest/openeverest.git  # if missing
+git fetch --all --prune
+git branch -m main v1.x
+git branch -u origin/v1.x v1.x
+git checkout -b main upstream/main
+git push -u origin main
+git remote set-head origin -a
+```
+
+3. Fork on GitHub: Settings → General → set the default branch back to `main`.
+
+**Pushing directly to this repository.** Rename `main` first to free the name:
+
+```sh
+git fetch origin --prune
+git branch -m main v1.x
+git branch -u origin/v1.x v1.x
+git branch -m release-2.0 main   # skip if you never had it
+git branch -u origin/main main
+git remote set-head origin -a
+```
+
+[openeverest/helm-charts](https://github.com/openeverest/helm-charts) moved the
+same way, with `v2` in place of `release-2.0`.
 
 ### Backend
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ OpenEverest - Run Data Workloads on Kubernetes
 [![Documentation](https://img.shields.io/badge/Documentation-blue?logo=readthedocs&logoColor=white)](https://openeverest.io/documentation/current/)
 [![Join Slack](https://img.shields.io/badge/Join_Slack-blue)](https://cloud-native.slack.com/archives/C09RRGZL2UX)
 
+> [!IMPORTANT]
+> **This branch carries OpenEverest v1 — the current released version.** It is actively maintained and still receives releases.
+>
+> It was called `main` until 18 August 2026. `main` now carries the v2 [Developer Preview](https://openeverest.io/blog/v2-developer-preview-release/), which is where day-to-day development happens — but v2 is not feature-complete and not for production. The [v1 lifecycle](https://openeverest.io/blog/v2-developer-preview-release/#timeline) is unchanged: v1 enters maintenance mode three months after v2 reaches GA.
+>
+> Cloned or forked before that date? See [Which branch to target](CONTRIBUTING.md#which-branch-to-target).
+
 [OpenEverest](https://openeverest.io/) is an open source cloud-native database platform that helps developers deploy code faster, scale deployments rapidly, and reduce database administration overhead while regaining control over their data, database configuration, and DBaaS costs.
 
 Why you should try OpenEverest:


### PR DESCRIPTION
Mirror of #2983 on the v1 line.

This branch is the **current released version**, so the README banner leads with that rather than with the rename. It restates the [published lifecycle](https://openeverest.io/blog/v2-developer-preview-release/#timeline) — v1 is maintained, still shipping, and only enters maintenance mode three months after v2 reaches GA — so that landing here does not read as "this is the abandoned branch".

`CONTRIBUTING.md` gets the same fork-aware instructions as `main`; this branch previously had a three-line note with no migration steps at all. Kept identical to `main` apart from one sentence, so the two do not drift.
