### PR TITLE
docs: name both tracks instead of saying "where development happens"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,8 +139,9 @@ Please say when a contribution is substantially AI-generated. Reports and pull r
 
 Unless an issue says otherwise, open your pull request against `main`.
 
-`main` carried v1 until 18 August 2026. The swap reflects where development
-happens and changes nothing about the
+`main` carried v1 until 18 August 2026, when the two lines swapped branches: v2
+moved from `release-2.0` to `main`, and v1 moved to `v1.x`. Both lines are
+still developed. This changes nothing about the
 [v1 lifecycle](https://openeverest.io/blog/v2-developer-preview-release/#timeline):
 v1 remains the released version, is still maintained, and only enters
 maintenance mode three months after v2 reaches GA.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OpenEverest - Run Data Workloads on Kubernetes
 > [!IMPORTANT]
 > **This branch carries OpenEverest v2, which is a [Developer Preview](https://openeverest.io/blog/v2-developer-preview-release/) — not feature-complete and not for production.**
 >
-> OpenEverest **v1 is the current released version** and is unchanged by this. It lives on [`v1.x`](https://github.com/openeverest/openeverest/tree/v1.x) and continues to receive releases. `main` moved to v2 on 18 August 2026 because that is where day-to-day development happens; it is not a statement about what to run. The [v1 lifecycle](https://openeverest.io/blog/v2-developer-preview-release/#timeline) is unchanged.
+> OpenEverest **v1 is the current released version** and is unchanged by this. It lives on [`v1.x`](https://github.com/openeverest/openeverest/tree/v1.x) and continues to receive releases. On 18 August 2026 the two lines swapped branches: v2 moved from `release-2.0` to `main`, and v1 moved to `v1.x`. **Both lines are still developed** — only the branch names changed, and this is not a statement about what to run. The [v1 lifecycle](https://openeverest.io/blog/v2-developer-preview-release/#timeline) is unchanged.
 >
 > Cloned or forked before that date? Your `main` still holds v1 code — see [Which branch to target](CONTRIBUTING.md#which-branch-to-target) before you branch.
 


### PR DESCRIPTION
Follow-up to #2983 — this wording fix was pushed a moment after that PR merged, so it missed the train. `v1.x` counterpart: #2986.

Both v1 and v2 are actively developed lines, so "the swap reflects where development happens" reads as though v1 development stopped. It did not — only the branch names changed.

Replaced with an explicit statement of what moved where: v2 from `release-2.0` to `main`, v1 from `main` to `v1.x`, both still developed.
