### PR TITLE
docs: name both tracks instead of saying "where development happens"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,8 +140,9 @@ Please say when a contribution is substantially AI-generated. Reports and pull r
 You are reading `v1.x`. Unless an issue says otherwise, open your pull request
 against `main`.
 
-This branch was called `main` until 18 August 2026. The swap reflects where
-development happens and changes nothing about the
+This branch was called `main` until 18 August 2026, when the two lines swapped
+branches: v2 moved from `release-2.0` to `main`, and v1 moved here. Both lines
+are still developed. This changes nothing about the
 [v1 lifecycle](https://openeverest.io/blog/v2-developer-preview-release/#timeline):
 v1 remains the released version, is still maintained, and only enters
 maintenance mode three months after v2 reaches GA.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OpenEverest - Run Data Workloads on Kubernetes
 > [!IMPORTANT]
 > **This branch carries OpenEverest v1 — the current released version.** It is actively maintained and still receives releases.
 >
-> It was called `main` until 18 August 2026. `main` now carries the v2 [Developer Preview](https://openeverest.io/blog/v2-developer-preview-release/), which is where day-to-day development happens — but v2 is not feature-complete and not for production. The [v1 lifecycle](https://openeverest.io/blog/v2-developer-preview-release/#timeline) is unchanged: v1 enters maintenance mode three months after v2 reaches GA.
+> It was called `main` until 18 August 2026, when the two lines swapped branches: v2 moved from `release-2.0` to `main`, and v1 moved here. **Both lines are still developed** — only the branch names changed. v2 is a [Developer Preview](https://openeverest.io/blog/v2-developer-preview-release/): not feature-complete, not for production. The [v1 lifecycle](https://openeverest.io/blog/v2-developer-preview-release/#timeline) is unchanged: v1 enters maintenance mode three months after v2 reaches GA.
 >
 > Cloned or forked before that date? See [Which branch to target](CONTRIBUTING.md#which-branch-to-target).
 


### PR DESCRIPTION
Follow-up to #2984 — this wording fix was pushed a moment after that PR merged, so it missed the train. Mirror of #2985.

Both v1 and v2 are actively developed lines, so "the swap reflects where development happens" reads as though v1 development stopped. Particularly worth getting right on this branch, which is the current released version.
