### PR TITLE
chore: refresh the Everest Helm chart dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.1.0
 	github.com/oapi-codegen/runtime v1.6.0
-	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818180808-80822324f802
+	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818184751-6e16546a324f
 	github.com/operator-framework/api v0.45.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20260429065444-70caa52c384a
 	github.com/rodaine/table v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -847,8 +847,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818180808-80822324f802 h1:tmN/6iE9A12EXShGjJUdpoAzLEtfb0yHlTVVLDhJdFI=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818180808-80822324f802/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818184751-6e16546a324f h1:pg2iryt2CFsZjWfrtcZ763VxvsVuNg4Wzbn07kpPhN8=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818184751-6e16546a324f/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
 github.com/operator-framework/api v0.45.0 h1:hkROwtsLH3oszp4IW+WsXEFSDgveSahHI7DKStOtrUI=
 github.com/operator-framework/api v0.45.0/go.mod h1:IQ4uuISTiIhV09oAurJSGD4KabayhY5nV6k1XmA235M=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=


### PR DESCRIPTION
**Merge promptly — `dev-be-ci` is red on every PR against `main` until this lands.** `v1.x` counterpart: #2989.

```
- helm-charts/charts/everest v0.0.0-20260818180808-80822324f802
+ helm-charts/charts/everest v0.0.0-20260818184751-6e16546a324f
```

Generated with `make update-dev-chart`; `go.mod` + `go.sum` only.

### This is the second time today, and it is worth fixing

`dev-be-ci` runs `make update-dev-chart && git diff --exit-code` on every PR, and the pin is a **commit SHA**. So it is not "any chart change" that breaks us — it is **any commit at all** on the tracked branch. openeverest/helm-charts#93 touched nothing but `README.md` and `CONTRIBUTING.md`, and it still invalidated the pin on both openeverest lines.

With two active branches in each repo, that is four combinations, and every helm-charts merge now blocks every open openeverest PR until someone notices and lands a bump by hand.

Two ways out, either better than the status quo:

1. **Assert ancestry instead of equality** — check the pinned commit is an ancestor of `CHART_BRANCH`, so the pin only has to move when the chart actually needs to. Keeps the guarantee that we never pin a commit that is not on the branch.
2. **Automate the bump** — a scheduled job that runs `make update-dev-chart` and opens the PR itself, so it never lands on a human.

Happy to open either as a follow-up.
