### PR TITLE
chore: refresh the Everest Helm chart dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.1.0
 	github.com/oapi-codegen/runtime v1.6.0
-	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818181041-0ea10dba1f6c
+	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818184755-daa3c06f8d4b
 	github.com/operator-framework/api v0.45.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20260802124914-e2aa472c7107
 	github.com/rodaine/table v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -824,8 +824,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818181041-0ea10dba1f6c h1:Co5EB+9dnrAZNmcQJwByeyPOtN0zGO/pamwiBtBrEPk=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818181041-0ea10dba1f6c/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818184755-daa3c06f8d4b h1:qH3FVfRnqA+v8JC9mqpDUbTjexNSK8lxOVX8LAMbJpY=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818184755-daa3c06f8d4b/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
 github.com/operator-framework/api v0.45.0 h1:hkROwtsLH3oszp4IW+WsXEFSDgveSahHI7DKStOtrUI=
 github.com/operator-framework/api v0.45.0/go.mod h1:IQ4uuISTiIhV09oAurJSGD4KabayhY5nV6k1XmA235M=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=


### PR DESCRIPTION
**Merge promptly — `dev-be-ci` is red on every PR against `v1.x` until this lands.** Mirror of #2988.

```
- helm-charts/charts/everest v0.0.0-20260818181041-0ea10dba1f6c
+ helm-charts/charts/everest v0.0.0-20260818184755-daa3c06f8d4b
```

Generated with `make update-dev-chart`; `go.mod` + `go.sum` only.

Picks up openeverest/helm-charts#94, which touched only `README.md` and `CONTRIBUTING.md` — the pin is a commit SHA, so even a docs-only commit on the tracked branch invalidates it. See #2988 for why this check is worth changing.
