### PR TITLE
fix(restore): allow configuring resource limits on restore job containers

### DIFF
--- a/api/backup/v1alpha1/backupclass_types.go
+++ b/api/backup/v1alpha1/backupclass_types.go
@@ -17,6 +17,7 @@ package v1alpha1
 import (
 	"slices"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -199,6 +200,10 @@ type BackupJobSpec struct {
 	// Command is the command to run the backup class.
 	// +optional
 	Command []string `json:"command,omitempty"`
+	// Resources sets default CPU and memory requests/limits for the job
+	// container. Individual Backup or Restore CRs may override this.
+	// +optional
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // BackupClassInstanceConstraints defines compatibility requirements and prerequisites

--- a/api/backup/v1alpha1/restore_types.go
+++ b/api/backup/v1alpha1/restore_types.go
@@ -15,6 +15,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -40,6 +41,11 @@ type RestoreSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	Parameters *runtime.RawExtension `json:"parameters,omitempty"`
+	// Resources sets CPU and memory requests/limits for the restore Job
+	// container. Overrides any default set in the BackupClass. Use this to
+	// prevent OOMKill on large restores (e.g. pgBackRest with big WAL).
+	// +optional
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // DataSourceType selects the restore intent: recover the state captured by a

--- a/internal/controller/backup/restore_controller.go
+++ b/internal/controller/backup/restore_controller.go
@@ -565,6 +565,17 @@ func (r *RestoreReconciler) getJobSpec(
 	bc *backupv1alpha1.BackupClass,
 	serviceAccountName string,
 ) batchv1.JobSpec {
+	// Start with the BackupClass-level default, then let the Restore CR override.
+	// This lets cluster admins set a sane default (e.g. 512Mi for pgBackRest)
+	// while individual restores can still raise it for unusually large datasets.
+	resources := corev1.ResourceRequirements{}
+	if bc.Spec.Job.Restore.JobSpec.Resources != nil {
+		resources = *bc.Spec.Job.Restore.JobSpec.Resources
+	}
+	if restore.Spec.Resources != nil {
+		resources = *restore.Spec.Resources
+	}
+
 	spec := batchv1.JobSpec{
 		BackoffLimit: pointer.ToInt32(0),
 		Template: corev1.PodTemplateSpec{
@@ -573,10 +584,11 @@ func (r *RestoreReconciler) getJobSpec(
 				ServiceAccountName:            serviceAccountName,
 				RestartPolicy:                 corev1.RestartPolicyNever,
 				Containers: []corev1.Container{{
-					Name:    "restorer",
-					Image:   bc.Spec.Job.Restore.JobSpec.Image,
-					Command: bc.Spec.Job.Restore.JobSpec.Command,
-					Args:    []string{fmt.Sprintf("%s/%s", payloadMountPath, backupJobJSONSecretKey)},
+					Name:      "restorer",
+					Image:     bc.Spec.Job.Restore.JobSpec.Image,
+					Command:   bc.Spec.Job.Restore.JobSpec.Command,
+					Args:      []string{fmt.Sprintf("%s/%s", payloadMountPath, backupJobJSONSecretKey)},
+					Resources: resources,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "payload",


### PR DESCRIPTION
## What

Adds a `resources` field to `RestoreSpec` and `BackupJobSpec`.

## Why

#1585 was filed against v1 where the restore is delegated to the
Percona operator and not fixable here. This fix addresses the same root                                     
 cause in the v2 Job-mode restore controller.
 Restore jobs were being created with no resource limits set, so whatever
the namespace LimitRange defaults to gets applied. On a lot of clusters
that's 128Mi, which isn't enough for pgBackRest — it needs to buffer WAL
and data during restore and gets OOMKilled (exit 137). There was no way to
raise it from the Restore CR side.

## How

Two places to configure it:

- `BackupClass.spec.job.restore.jobSpec.resources` — admin sets a
  reasonable default for the class (e.g. 512Mi for pgBackRest workloads)
- `Restore.spec.resources` — per-restore override when you know a specific
  restore is going to be large

If both are set the Restore field wins. If neither is set, behaviour is
identical to before — empty `ResourceRequirements` on the container.

## Testing

Ran the existing restore and validation test suites locally, all green.
Tested the four resource precedence cases (none, class only, restore
override, restore only) against `getJobSpec()` directly — screenshot in
comments.

Fixes #1585