### PR TITLE
chore: refresh the Everest Helm chart dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.1.0
 	github.com/oapi-codegen/runtime v1.6.0
-	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818184751-6e16546a324f
+	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260819095409-311840d26860
 	github.com/operator-framework/api v0.45.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20260429065444-70caa52c384a
 	github.com/rodaine/table v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -847,8 +847,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818184751-6e16546a324f h1:pg2iryt2CFsZjWfrtcZ763VxvsVuNg4Wzbn07kpPhN8=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260818184751-6e16546a324f/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260819095409-311840d26860 h1:AMDqdhV9Bs95Ruu6XW+OcHYpBDgHI9F7PoEwcEZPS3s=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260819095409-311840d26860/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
 github.com/operator-framework/api v0.45.0 h1:hkROwtsLH3oszp4IW+WsXEFSDgveSahHI7DKStOtrUI=
 github.com/operator-framework/api v0.45.0/go.mod h1:IQ4uuISTiIhV09oAurJSGD4KabayhY5nV6k1XmA235M=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=


### PR DESCRIPTION
**Merge promptly — `dev-be-ci` is red on every PR against `main` until this lands.** `v1.x` counterpart: #2997.

Picks up openeverest/helm-charts#95.

```
- helm-charts/charts/everest v0.0.0-20260818184751-6e16546a324f
+ helm-charts/charts/everest v0.0.0-20260819095409-311840d26860
```

Generated with `make update-dev-chart`; `go.mod` + `go.sum` only.

Third round of this in two days (after #2981 and #2988). The pin is a commit SHA, so every helm-charts merge invalidates it on both lines regardless of what changed. #2988 lays out the two ways to stop it — assert ancestry instead of equality, or automate the bump.
