### PR TITLE
ci: check the chart pin is on the branch, not equal to its tip

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -34,3 +34,7 @@
 - name: status/blocked
   color: b60205
   description: Waiting on something we owe — a design review, a decision, an upstream fix
+
+- name: chart/pending
+  color: fbca04
+  description: Pins an unmerged helm-charts commit; that PR must land before this one

--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -99,10 +99,9 @@ jobs:
           git status
           git diff --exit-code
 
-      - name: Check that dev Helm chart is up-to-date
-        run: |
-          make update-dev-chart
-          git diff --exit-code
+      - name: Check that the pinned dev Helm chart is on the tracked branch
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'chart/pending') }}
+        run: make check-dev-chart
 
       - name: Check the Makefile references dev version
         run: |

--- a/Makefile
+++ b/Makefile
@@ -460,6 +460,24 @@ update-dev-chart: ## Update dependency to Everest Helm chart to the latest versi
 	go get -u github.com/openeverest/helm-charts/charts/everest@$$COMMIT
 	go mod tidy
 
+.PHONY: check-dev-chart
+check-dev-chart: ## Verify the pinned Everest Helm chart commit is on CHART_BRANCH.
+	@PINNED=$$(go list -m -f '{{.Version}}' github.com/openeverest/helm-charts/charts/everest) && \
+	SHA=$${PINNED##*-} && \
+	TMP=$$(mktemp -d) && trap 'rm -rf "$$TMP"' EXIT && \
+	git clone --quiet --filter=blob:none --no-checkout --single-branch \
+		--branch $(CHART_BRANCH) https://github.com/openeverest/helm-charts "$$TMP" && \
+	if ! git -C "$$TMP" cat-file -e "$$SHA^{commit}" 2>/dev/null; then \
+		echo "Pinned chart commit $$SHA is not on helm-charts/$(CHART_BRANCH)."; \
+		echo "Run 'make update-dev-chart' to move the pin to the branch tip."; \
+		exit 1; \
+	fi; \
+	if ! git -C "$$TMP" merge-base --is-ancestor "$$SHA" HEAD; then \
+		echo "Pinned chart commit $$SHA is not an ancestor of helm-charts/$(CHART_BRANCH)."; \
+		exit 1; \
+	fi; \
+	echo "Pinned chart commit $$SHA is on helm-charts/$(CHART_BRANCH) ($$(git -C "$$TMP" rev-list --count "$$SHA"..HEAD) commit(s) behind tip)."
+
 EVEREST_OPERATOR_BRANCH ?= main
 .PHONY: update-dev-everest-operator
 update-dev-everest-operator: ## Update dependency to Everest operator to the latest version from the specified branch (default main).


### PR DESCRIPTION
`v1.x` counterpart: #2999.

### The problem

`dev-be-ci` runs `make update-dev-chart && git diff --exit-code`. The pin is a **commit SHA**, so this fails whenever helm-charts moves *at all* — not when the chart changes. Twice this week that was a docs-only commit, and each time every open PR on the line went red until someone hand-landed a `go.mod` bump: #2981/#2982, #2988/#2989, #2996/#2997. Three rounds in two days.

It also forbids the one thing it should allow. To test against an unmerged chart PR you pin that PR's commit — and `update-dev-chart` immediately rewrites it back to the branch tip, so the check fails. There is no way to say "this pin is deliberate", which makes "merge the chart first, then bump, then merge" the only supported path.

Those are two different properties being conflated:

| | Deserves a red X? |
|---|---|
| Pin isn't on the tracked branch — force-pushed away, wrong line, abandoned | **yes**, nothing else catches it |
| Pin is a few commits behind the tip | no |

### The change

`make check-dev-chart` asserts the pinned commit is **reachable on `CHART_BRANCH`**, and reports the lag instead of failing on it.

```
Pinned chart commit 311840d26860 is on helm-charts/main (0 commit(s) behind tip).
Pinned chart commit 6e16546a324f is on helm-charts/main (1 commit(s) behind tip).
Pinned chart commit 3a42084dd10a is not on helm-charts/main.
Run 'make update-dev-chart' to move the pin to the branch tip.
```

All three verified locally, on both branches. It uses a treeless clone (`--filter=blob:none --no-checkout --single-branch`) because `git ls-remote` can't answer ancestry — full commit history, no file content, no token, so it runs the same locally as in CI.

The `cat-file -e` guard runs first deliberately: with `--single-branch`, a commit that isn't on the branch doesn't exist in the clone at all, and `merge-base` would die with "not a valid object name" instead of saying why.

`update-dev-chart` is untouched — still how you move the pin deliberately.

### The `chart/pending` label

Skips the check, making an in-flight cross-repo pin a supported state. It also records on the PR that it must not merge before its chart counterpart, which today lives only in someone's head. Declared in `labels.yml`; `label-sync` is `delete-other-labels: false`, so it is additive.

**Caveat:** `dev-be-ci` is `on: pull_request` with no `types:`, so it defaults to `opened, synchronize, reopened` — adding a label does **not** re-trigger it. After labelling, re-run the `check` job. Adding `labeled`/`unlabeled` to `types` would fix that but re-runs the whole workflow on every label change, which seemed a poor trade for an infrequent case. Happy to add it if you disagree.

### What this does not do

Doesn't automate the bump. That's a separate decision, and less pressing once the check stops nagging — worth deciding on its own merits rather than bundled here.
