### PR TITLE
ci: check the chart pin is on the branch, not equal to its tip

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -34,3 +34,7 @@
 - name: status/blocked
   color: b60205
   description: Waiting on something we owe — a design review, a decision, an upstream fix
+
+- name: chart/pending
+  color: fbca04
+  description: Pins an unmerged helm-charts commit; that PR must land before this one

--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -89,10 +89,9 @@ jobs:
           # Stub the embedded UI build output so `//go:embed dist/*` typechecks (see `make build`/`make test`).
           mkdir -p ./public/dist && [ -f ./public/dist/index.html ] || touch ./public/dist/index.html
           go tool golangci-lint run --new-from-rev=$(git merge-base origin/${{ github.base_ref }} HEAD) --show-stats=false | env REVIEWDOG_GITHUB_API_TOKEN=${{ secrets.GITHUB_TOKEN }} go tool reviewdog -f=golangci-lint -reporter=github-pr-review -filter-mode=nofilter -fail-level=any
-      - name: Check that dev Helm chart is up-to-date
-        run: |
-          make update-dev-chart
-          git diff --exit-code
+      - name: Check that the pinned dev Helm chart is on the tracked branch
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'chart/pending') }}
+        run: make check-dev-chart
 
       - name: Check that there are no source code changes
         run: |

--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,24 @@ update-dev-chart: ## Update dependency to Everest Helm chart to the latest versi
 	go get -u github.com/openeverest/helm-charts/charts/everest@$$COMMIT
 	go mod tidy
 
+.PHONY: check-dev-chart
+check-dev-chart: ## Verify the pinned Everest Helm chart commit is on CHART_BRANCH.
+	@PINNED=$$(go list -m -f '{{.Version}}' github.com/openeverest/helm-charts/charts/everest) && \
+	SHA=$${PINNED##*-} && \
+	TMP=$$(mktemp -d) && trap 'rm -rf "$$TMP"' EXIT && \
+	git clone --quiet --filter=blob:none --no-checkout --single-branch \
+		--branch $(CHART_BRANCH) https://github.com/openeverest/helm-charts "$$TMP" && \
+	if ! git -C "$$TMP" cat-file -e "$$SHA^{commit}" 2>/dev/null; then \
+		echo "Pinned chart commit $$SHA is not on helm-charts/$(CHART_BRANCH)."; \
+		echo "Run 'make update-dev-chart' to move the pin to the branch tip."; \
+		exit 1; \
+	fi; \
+	if ! git -C "$$TMP" merge-base --is-ancestor "$$SHA" HEAD; then \
+		echo "Pinned chart commit $$SHA is not an ancestor of helm-charts/$(CHART_BRANCH)."; \
+		exit 1; \
+	fi; \
+	echo "Pinned chart commit $$SHA is on helm-charts/$(CHART_BRANCH) ($$(git -C "$$TMP" rev-list --count "$$SHA"..HEAD) commit(s) behind tip)."
+
 EVEREST_OPERATOR_BRANCH ?= main
 .PHONY: update-dev-everest-operator
 update-dev-everest-operator: ## Update dependency to Everest operator to the latest version from the specified branch (default main).


### PR DESCRIPTION
Mirror of #2998 on the v1 line — see there for the full rationale.

`dev-be-ci`'s `make update-dev-chart && git diff --exit-code` fails whenever helm-charts moves at all, because the pin is a commit SHA. `make check-dev-chart` instead asserts the pinned commit is reachable on `CHART_BRANCH`, reporting the lag rather than failing on it, and still rejects a pin that isn't on the branch.

Verified on this branch:

```
Pinned chart commit 3a42084dd10a is on helm-charts/v1.x (0 commit(s) behind tip).
Pinned chart commit 311840d26860 is not on helm-charts/v1.x.
```

The `chart/pending` label skips the check for deliberate in-flight pins. Kept identical to `main` so the two branches don't drift; `labels.yml` is only read from the default branch, so that part is inert here.
