### PR TITLE
test(cli): use the generated enum constant for the Deleting state

### DIFF
--- a/pkg/cli/backup/delete_test.go
+++ b/pkg/cli/backup/delete_test.go
@@ -645,7 +645,7 @@ func TestInFlight(t *testing.T) {
 	assert.True(t, inFlight("", true), "read successfully but no status yet is the riskiest window, right after create")
 	assert.False(t, inFlight(client.BackupStatusStateSucceeded, true))
 	assert.False(t, inFlight(client.BackupStatusStateFailed, true), "Failed is genuinely terminal, unlike Error")
-	assert.False(t, inFlight("Deleting", true))
+	assert.False(t, inFlight(client.BackupStatusStateDeleting, true))
 	assert.False(t, inFlight("", false), "a failed/ambiguous fetch must never block — best-effort guard, not an invariant")
 }
 


### PR DESCRIPTION
Follow-up to #2933, which typed `BackupState`/`RestoreState` and converted the CLI and its tests to the generated constants. One literal was missed: `TestInFlight` still asserted against a bare `"Deleting"` while every other assertion around it names a `client.BackupStatusState` constant.

Behaviour is unchanged — the constant's value is `"Deleting"`. What changes is that renaming or removing the generated identifier now breaks the build instead of leaving the assertion quietly checking a stale string, which is the failure mode #2891 was filed for.

`go vet ./pkg/cli/backup` is clean and `TestInFlight`/`TestBackupStateForGuard` pass.
