### PR TITLE
fix(ui): hide provider version in database tile

### DIFF
--- a/ui/apps/everest/src/components/empty-state-databases/provider-tiles/provider-tile/provider-tile.tsx
+++ b/ui/apps/everest/src/components/empty-state-databases/provider-tiles/provider-tile/provider-tile.tsx
@@ -29,7 +29,6 @@ import {
   bodyAnchorSx,
   cardActionAreaSx,
   cardContentSx,
-  cardFooterSx,
   cardFooterEndSx,
   cardHeaderSx,
   cardSx,
@@ -51,7 +50,9 @@ export const ProviderTile = ({
   const [active, setActive] = useState(false);
 
   // Render meta-derived fields only when the hub provides them — never fabricate.
-  const { description, maturity, version } = meta ?? {};
+  // The provider version is intentionally not shown here: it's not meaningful
+  // to users and only adds confusion (see issue #3051).
+  const { description, maturity } = meta ?? {};
   const categories = meta?.categories?.slice(0, 2) ?? [];
 
   const renderTail = (expanded: boolean) => (
@@ -76,8 +77,7 @@ export const ProviderTile = ({
           </Box>
         )}
       </CardContent>
-      <Box sx={version ? cardFooterSx : cardFooterEndSx}>
-        {version && <Typography variant="caption">{version}</Typography>}
+      <Box sx={cardFooterEndSx}>
         <ArrowForwardIcon fontSize="small" aria-hidden="true" />
       </Box>
     </>

--- a/ui/apps/everest/src/components/empty-state-databases/provider-tiles/provider-tiles.constants.ts
+++ b/ui/apps/everest/src/components/empty-state-databases/provider-tiles/provider-tiles.constants.ts
@@ -161,27 +161,18 @@ export const categoriesRowSx: SxProps<Theme> = {
   mt: 0.5,
 };
 
-const footerBaseSx = {
+export const cardFooterEndSx: SxProps<Theme> = {
   display: 'flex',
   alignItems: 'center',
   gap: 1,
   py: 1.25,
   px: 2,
+  // Only the forward arrow lives here now; keep it right-aligned.
+  justifyContent: 'flex-end',
   borderTop: '1px solid',
   borderColor: (theme: Theme) => theme.palette.dividers?.divider,
   color: 'text.secondary',
   // Round bottom corners (card is overflow-visible).
   borderRadius: (theme: Theme) =>
     `0 0 ${theme.shape.borderRadius}px ${theme.shape.borderRadius}px`,
-} satisfies SxProps<Theme>;
-
-export const cardFooterSx: SxProps<Theme> = {
-  ...footerBaseSx,
-  justifyContent: 'space-between',
-};
-
-// Footer variant when there's no version: keep the forward arrow right-aligned.
-export const cardFooterEndSx: SxProps<Theme> = {
-  ...footerBaseSx,
-  justifyContent: 'flex-end',
 };


### PR DESCRIPTION
## Problem

On the "add database" empty state, the provider tile shows the provider's
version string in its footer. As noted in the issue, this isn't meaningful
to users on that screen and only adds confusion.

## Fix

`ui/apps/everest/src/components/empty-state-databases/provider-tiles/provider-tile/provider-tile.tsx`:
stop destructuring/rendering `meta.version` in the tile footer, and always
right-align the forward-arrow icon in the footer instead of conditionally
switching layouts based on whether a version was present.

`ui/apps/everest/src/components/empty-state-databases/provider-tiles/provider-tiles.constants.ts`:
the two footer style variants (`cardFooterSx` for the version case,
`cardFooterEndSx` for the no-version case) collapse into a single
`cardFooterEndSx`, since there's now only one footer layout. Removed the
now-unused `cardFooterSx` export and its shared base rather than leaving
dead code.

No other logic changes; the `version` field itself remains on the shared
`ResolvedExtensionMeta` type since it may still be used elsewhere.

## Tests

- No existing test file covers this component
  (`provider-tile.tsx`/`provider-tiles.constants.ts` have no
  `.test.tsx`/`.spec.tsx`), so no test was added or updated.
- `npx eslint` on both changed files — clean.
- `npx prettier --check` on both changed files — clean.
- `npx tsc --noEmit` — no new errors introduced by this change (the app has
  11 pre-existing, unrelated `@openeverest/plugin-sdk` module-resolution
  errors from an unbuilt workspace package; confirmed identical count with
  and without this diff via `git stash`).

## Related issue

Fixes #3051

## AI-assisted contribution disclosure

This fix (investigation, code change) was produced with AI assistance
(Claude Code) and reviewed by me before submitting. I can explain and
defend the change: it removes the version display and folds the two footer
style variants into one, since only the no-version layout is needed now.