### PR TITLE
feat(provider-runtime): add a conformance check that UI fields are reconciled

### DIFF
--- a/provider-runtime/conformance/conformance.go
+++ b/provider-runtime/conformance/conformance.go
@@ -1,0 +1,147 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package conformance exercises a provider against the contract the runtime
+// expects of it, without a cluster.
+//
+// It is meant to be called from a provider's own test suite:
+//
+//	func TestUISchemaIsReconciled(t *testing.T) {
+//	    conformance.UISchemaIsReconciled(t, conformance.Config{
+//	        Provider: NewMyProvider(),
+//	    })
+//	}
+package conformance
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Config configures a conformance run.
+type Config struct {
+	// Provider is the implementation under test.
+	Provider ProviderUnderTest
+
+	// ProviderSpecPath overrides the generated Provider CR to check against.
+	// When empty it is located by walking up to the module root and looking
+	// for charts/*/generated/provider-spec.yaml.
+	ProviderSpecPath string
+
+	// Unverifiable maps a UI schema path to the reason the harness cannot
+	// observe it. Use it when a provider reshapes a value so thoroughly that
+	// it is unrecognisable in the resulting engine CR — not to silence a
+	// field that is genuinely unhandled.
+	Unverifiable map[string]string
+}
+
+// outcome is what the harness observed for one UI schema path.
+type outcome int
+
+const (
+	// reconciled means the value reached an object the provider applied.
+	reconciled outcome = iota
+	// read means the value appeared in a request the provider made, which
+	// proves the field was consumed even though it never reaches the engine CR.
+	read
+	// ignored means nothing observable happened.
+	ignored
+	// unverified means the render failed, so nothing can be concluded.
+	unverified
+)
+
+type result struct {
+	topology string
+	path     string
+	outcome  outcome
+	detail   string
+	requests []string
+}
+
+// UISchemaIsReconciled asserts that every field the UI schema offers is
+// actually consumed by the provider. A form field bound to a path the provider
+// ignores accepts input and silently does nothing, which is worse than not
+// offering it at all.
+func UISchemaIsReconciled(t *testing.T, cfg Config) {
+	t.Helper()
+
+	spec, err := loadProviderSpec(cfg.ProviderSpecPath)
+	if err != nil {
+		t.Fatalf("conformance: %v", err)
+	}
+
+	var results []result
+	for _, topology := range sortedKeys(spec.Topologies) {
+		paths, err := uiPaths(spec, topology)
+		if err != nil {
+			t.Fatalf("conformance: reading UI schema for topology %q: %v", topology, err)
+		}
+		if len(paths) == 0 {
+			continue
+		}
+		results = append(results, probeTopology(t, cfg, spec, topology, paths)...)
+	}
+
+	report(t, cfg, results)
+}
+
+func report(t *testing.T, cfg Config, results []result) {
+	t.Helper()
+
+	var failures, notes []string
+	for _, r := range results {
+		if reason, ok := cfg.Unverifiable[r.path]; ok {
+			notes = append(notes, fmt.Sprintf("  %s %s\n    declared unverifiable: %s", r.topology, r.path, reason))
+			continue
+		}
+		switch r.outcome {
+		case reconciled, read:
+			continue
+		case ignored:
+			failures = append(failures, fmt.Sprintf(
+				"  topology %s\n    %s\n      offered by the UI, but setting it changes nothing the provider applies or requests",
+				r.topology, r.path))
+		case unverified:
+			failures = append(failures, fmt.Sprintf(
+				"  topology %s\n    %s\n      could not be verified: %s%s",
+				r.topology, r.path, r.detail, formatRequests(r.requests)))
+		}
+	}
+
+	for _, note := range notes {
+		t.Log(note)
+	}
+	if len(failures) > 0 {
+		t.Errorf("UI schema references %d field(s) this provider does not reconcile:\n%s",
+			len(failures), strings.Join(failures, "\n"))
+	}
+}
+
+func formatRequests(requests []string) string {
+	if len(requests) == 0 {
+		return ""
+	}
+	return "\n      requests observed: " + strings.Join(requests, ", ")
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/provider-runtime/conformance/conformance_test.go
+++ b/provider-runtime/conformance/conformance_test.go
@@ -1,0 +1,184 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	commonv1alpha1 "github.com/openeverest/openeverest/v2/api/common/v1alpha1"
+	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+)
+
+func testSpec() *corev1alpha1.ProviderSpec {
+	stringSchema := func(property string) *commonv1alpha1.ParametersSchema {
+		return &commonv1alpha1.ParametersSchema{
+			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					property: {Type: "string"},
+				},
+			},
+		}
+	}
+	return &corev1alpha1.ProviderSpec{
+		Components: map[string]corev1alpha1.Component{
+			"engine":     {Type: "db", ParametersSchema: stringSchema("configuration")},
+			"monitoring": {Type: "pmm"},
+		},
+		Topologies: map[string]corev1alpha1.Topology{
+			"simple": {
+				Components: map[string]corev1alpha1.TopologyComponent{
+					"engine":     {},
+					"monitoring": {Optional: true},
+				},
+			},
+		},
+	}
+}
+
+func TestCollectPaths(t *testing.T) {
+	t.Parallel()
+
+	var paths []string
+	collectPaths(map[string]any{
+		"sections": map[string]any{
+			"resources": map[string]any{
+				"uiType": "group",
+				"components": map[string]any{
+					"cpu": map[string]any{"path": "spec.components.engine.resources.limits.cpu"},
+				},
+			},
+			"nodes": map[string]any{
+				"path": "spec.components.engine.replicas",
+				"validation": map[string]any{
+					"celExpressions": []any{
+						// Read by the form, not written by it.
+						map[string]any{"celExpr": "spec.components.engine.replicas % 2 == 1"},
+					},
+				},
+			},
+		},
+		// Addresses the options payload, not an Instance field.
+		"labelPath": "name",
+	}, &paths)
+
+	assert.ElementsMatch(t, []string{
+		"spec.components.engine.resources.limits.cpu",
+		"spec.components.engine.replicas",
+	}, paths)
+}
+
+func TestResolveLeaf(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		path string
+		want leafKind
+	}{
+		"scalar on the instance":          {"spec.version", leafString},
+		"through the components map":      {"spec.components.engine.replicas", leafInteger},
+		"quantity":                        {"spec.components.engine.storage.size", leafQuantity},
+		"quantity behind a resource name": {"spec.components.engine.resources.limits.cpu", leafQuantity},
+		"declared parameters schema":      {"spec.components.engine.parameters.configuration", leafString},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveLeaf(testSpec(), "simple", tt.path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveLeafErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		path string
+		want string
+	}{
+		"field that does not exist": {
+			"spec.components.engine.config",
+			`no field "config" on ComponentSpec`,
+		},
+		"property absent from the declared schema": {
+			"spec.components.engine.parameters.nope",
+			`no property "nope" in the declared parameters schema`,
+		},
+		"component with no declared schema": {
+			"spec.components.monitoring.parameters.monitoringConfigName",
+			`no parametersSchema declared for "components.monitoring.parameters"`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := resolveLeaf(testSpec(), "simple", tt.path)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+// The baseline stays as small as the topology allows, so a provider is never
+// asked to render an optional component the probe is not even about.
+func TestBuildInstanceIncludesOptionalComponentsOnlyWhenAddressed(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		path string
+		want []string
+	}{
+		"unrelated path":     {"spec.version", []string{"engine"}},
+		"addresses required": {"spec.components.engine.replicas", []string{"engine"}},
+		"addresses optional": {"spec.components.monitoring.parameters.x", []string{"engine", "monitoring"}},
+		"no path at all":     {"", []string{"engine"}},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			instance, err := buildInstance(testSpec(), "test-provider", "simple", tt.path, nil)
+			require.NoError(t, err)
+
+			got := make([]string, 0, len(instance.Spec.Components))
+			for name := range instance.Spec.Components {
+				got = append(got, name)
+			}
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func TestBuildInstanceSetsTheProbeValue(t *testing.T) {
+	t.Parallel()
+
+	instance, err := buildInstance(testSpec(), "test-provider", "simple", "spec.components.engine.replicas", int64(7919))
+	require.NoError(t, err)
+
+	engine := instance.Spec.Components["engine"]
+	require.NotNil(t, engine.Replicas)
+	assert.Equal(t, int32(7919), *engine.Replicas)
+}

--- a/provider-runtime/conformance/conformance_test.go
+++ b/provider-runtime/conformance/conformance_test.go
@@ -19,10 +19,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	commonv1alpha1 "github.com/openeverest/openeverest/v2/api/common/v1alpha1"
 	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
 )
 
 func testSpec() *corev1alpha1.ProviderSpec {
@@ -181,4 +184,51 @@ func TestBuildInstanceSetsTheProbeValue(t *testing.T) {
 	engine := instance.Spec.Components["engine"]
 	require.NotNil(t, engine.Replicas)
 	assert.Equal(t, int32(7919), *engine.Replicas)
+}
+
+// boolProbeProvider always writes an unrelated true, which is what a value
+// token cannot tell apart from a provider that reads the probed field.
+type boolProbeProvider struct {
+	readsBackupEnabled bool
+}
+
+func (p *boolProbeProvider) Name() string                       { return "bool-probe" }
+func (p *boolProbeProvider) Types() func(*runtime.Scheme) error { return nil }
+func (p *boolProbeProvider) Validate(*controller.Context) error { return nil }
+func (p *boolProbeProvider) Cleanup(*controller.Context) error  { return nil }
+
+func (p *boolProbeProvider) Status(*controller.Context) (controller.Status, error) {
+	return controller.Status{}, nil
+}
+
+func (p *boolProbeProvider) Sync(c *controller.Context) error {
+	data := map[string]string{"unrelatedFlag": "true"}
+	if p.readsBackupEnabled && c.Instance().Spec.Backup != nil && c.Instance().Spec.Backup.Enabled {
+		data["backup"] = "on"
+	}
+	return c.Apply(&corev1.ConfigMap{ObjectMeta: c.ObjectMeta("probe"), Data: data})
+}
+
+func TestProbeBoolComparesRendersRatherThanSearchingForTrue(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		reads bool
+		want  outcome
+	}{
+		"reading the field changes what is applied": {true, reconciled},
+		"an unrelated true is not evidence":         {false, ignored},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := probeBool(
+				Config{Provider: &boolProbeProvider{readsBackupEnabled: tt.reads}},
+				testSpec(), "simple", "spec.backup.enabled",
+			)
+			assert.Equal(t, tt.want, got.outcome, got.detail)
+		})
+	}
 }

--- a/provider-runtime/conformance/render.go
+++ b/provider-runtime/conformance/render.go
@@ -59,11 +59,45 @@ func (o observation) contains(token string) (outcome, bool) {
 	return ignored, false
 }
 
-// differsFrom reports whether the provider applied anything differently. Some
+// changedFrom reports whether the provider behaved differently, and how. Some
 // fields never surface as a literal — a shard count changes how many objects
-// exist rather than appearing in one — so a change is evidence in itself.
-func (o observation) differsFrom(baseline observation) bool {
-	return strings.Join(o.applied, "\n") != strings.Join(baseline.applied, "\n")
+// exist rather than appearing in one, and a toggle may only change what the
+// provider reads — so a change is evidence in itself.
+func (o observation) changedFrom(baseline observation) (outcome, bool) {
+	if strings.Join(o.applied, "\n") != strings.Join(baseline.applied, "\n") {
+		return reconciled, true
+	}
+	if strings.Join(o.requests, "\n") != strings.Join(baseline.requests, "\n") {
+		return read, true
+	}
+	return ignored, false
+}
+
+// probeBool decides a boolean by rendering it both ways rather than searching
+// for its value: "true" is a substring of every boolean the provider sets for
+// its own reasons, so a token would match objects that have nothing to do with
+// this field. Two values exhaust a bool, so if neither render moves the
+// provider off its baseline, nothing consumes the field.
+func probeBool(cfg Config, spec *corev1alpha1.ProviderSpec, topology, path string) result {
+	unverifiable := func(detail string, requests []string) result {
+		return result{topology: topology, path: path, outcome: unverified, detail: detail, requests: requests}
+	}
+
+	baseline, err := render(cfg, spec, topology, "", nil)
+	if err != nil {
+		return unverifiable(fmt.Sprintf("baseline render failed: %v", err), baseline.requests)
+	}
+
+	for _, value := range []bool{true, false} {
+		probed, err := render(cfg, spec, topology, path, value)
+		if err != nil {
+			return unverifiable(err.Error(), probed.requests)
+		}
+		if got, changed := probed.changedFrom(baseline); changed {
+			return result{topology: topology, path: path, outcome: got, requests: probed.requests}
+		}
+	}
+	return result{topology: topology, path: path, outcome: ignored}
 }
 
 func probeTopology(
@@ -91,6 +125,9 @@ func probePath(cfg Config, spec *corev1alpha1.ProviderSpec, topology, path strin
 	if err != nil {
 		return failed(err.Error(), nil)
 	}
+	if kind == leafBool {
+		return probeBool(cfg, spec, topology, path)
+	}
 	value, token, err := sentinel(spec, path, kind)
 	if err != nil {
 		return failed(err.Error(), nil)
@@ -114,10 +151,7 @@ func probePath(cfg Config, spec *corev1alpha1.ProviderSpec, topology, path strin
 		return failed(err.Error(), probed.requests)
 	}
 
-	got := ignored
-	if probed.differsFrom(baseline) {
-		got = reconciled
-	}
+	got, _ := probed.changedFrom(baseline)
 	return result{topology: topology, path: path, outcome: got, requests: probed.requests}
 }
 

--- a/provider-runtime/conformance/render.go
+++ b/provider-runtime/conformance/render.go
@@ -1,0 +1,255 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
+	"github.com/openeverest/openeverest/v2/provider-runtime/internal/instanceprep"
+)
+
+const (
+	probeNamespace = "conformance"
+	probeName      = "probe"
+)
+
+// observation is everything the harness saw during one render.
+type observation struct {
+	applied  []string
+	requests []string
+}
+
+// contains reports whether the token surfaced, and where.
+func (o observation) contains(token string) (outcome, bool) {
+	for _, obj := range o.applied {
+		if strings.Contains(obj, token) {
+			return reconciled, true
+		}
+	}
+	for _, req := range o.requests {
+		if strings.Contains(req, token) {
+			return read, true
+		}
+	}
+	return ignored, false
+}
+
+// differsFrom reports whether the provider applied anything differently. Some
+// fields never surface as a literal — a shard count changes how many objects
+// exist rather than appearing in one — so a change is evidence in itself.
+func (o observation) differsFrom(baseline observation) bool {
+	return strings.Join(o.applied, "\n") != strings.Join(baseline.applied, "\n")
+}
+
+func probeTopology(
+	t *testing.T,
+	cfg Config,
+	spec *corev1alpha1.ProviderSpec,
+	topology string,
+	paths []string,
+) []result {
+	t.Helper()
+
+	results := make([]result, 0, len(paths))
+	for _, path := range paths {
+		results = append(results, probePath(cfg, spec, topology, path))
+	}
+	return results
+}
+
+func probePath(cfg Config, spec *corev1alpha1.ProviderSpec, topology, path string) result {
+	failed := func(detail string, requests []string) result {
+		return result{topology: topology, path: path, outcome: unverified, detail: detail, requests: requests}
+	}
+
+	kind, err := resolveLeaf(spec, topology, path)
+	if err != nil {
+		return failed(err.Error(), nil)
+	}
+	value, token, err := sentinel(spec, path, kind)
+	if err != nil {
+		return failed(err.Error(), nil)
+	}
+
+	baseline, err := render(cfg, spec, topology, "", nil)
+	if err != nil {
+		return failed(fmt.Sprintf("baseline render failed: %v", err), baseline.requests)
+	}
+	if _, found := baseline.contains(token); found {
+		return failed("the probe value already appears without being set", nil)
+	}
+
+	probed, err := render(cfg, spec, topology, path, value)
+	// A failed Sync does not discard what was already observed: if the value
+	// reached a request on the way, the field was read.
+	if got, found := probed.contains(token); found {
+		return result{topology: topology, path: path, outcome: got, requests: probed.requests}
+	}
+	if err != nil {
+		return failed(err.Error(), probed.requests)
+	}
+
+	got := ignored
+	if probed.differsFrom(baseline) {
+		got = reconciled
+	}
+	return result{topology: topology, path: path, outcome: got, requests: probed.requests}
+}
+
+// render runs Sync once against an Instance carrying value at path, and reports
+// every object the provider applied and every request it made.
+func render(
+	cfg Config,
+	spec *corev1alpha1.ProviderSpec,
+	topology, path string,
+	value any,
+) (observation, error) {
+	var obs observation
+
+	scheme, err := buildScheme(cfg.Provider)
+	if err != nil {
+		return obs, err
+	}
+
+	instance, err := buildInstance(spec, cfg.Provider.Name(), topology, path, value)
+	if err != nil {
+		return obs, err
+	}
+
+	// Hand the provider the Instance the reconciler would, not the one a user
+	// wrote: anything the runtime resolves before Sync happens here too.
+	instance, _, err = instanceprep.PrepareForSync(spec, instance)
+	if err != nil {
+		return obs, err
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(instance, providerObject(cfg.Provider.Name(), spec)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				obs.requests = append(obs.requests, describe(scheme, obj)+"/"+key.Name)
+				return c.Get(ctx, key, obj, opts...)
+			},
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				obs.applied = append(obs.applied, serialize(obj))
+				return c.Create(ctx, obj, opts...)
+			},
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				obs.applied = append(obs.applied, serialize(obj))
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	ctx := controller.NewContext(context.Background(), cl, instance, cfg.Provider.Name())
+	if err := cfg.Provider.Sync(ctx); err != nil {
+		return obs, fmt.Errorf("sync: %w", err)
+	}
+	return obs, nil
+}
+
+func buildScheme(provider ProviderUnderTest) (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1alpha1.AddToScheme, corev1.AddToScheme} {
+		if err := add(scheme); err != nil {
+			return nil, err
+		}
+	}
+	if types := provider.Types(); types != nil {
+		if err := types(scheme); err != nil {
+			return nil, fmt.Errorf("registering provider types: %w", err)
+		}
+	}
+	return scheme, nil
+}
+
+// buildInstance assembles the smallest Instance the topology allows: every
+// required component, plus whichever optional component the path addresses.
+func buildInstance(
+	spec *corev1alpha1.ProviderSpec,
+	providerName, topology, path string,
+	value any,
+) (*corev1alpha1.Instance, error) {
+	components := map[string]any{}
+	for name, topologyComponent := range spec.Topologies[topology].Components {
+		if topologyComponent.Optional && !addressesComponent(path, name) {
+			continue
+		}
+		components[name] = map[string]any{
+			"name": name,
+			"type": spec.Components[name].Type,
+		}
+	}
+
+	object := map[string]any{
+		"apiVersion": corev1alpha1.GroupVersion.String(),
+		"kind":       "Instance",
+		"metadata": map[string]any{
+			"name":      probeName,
+			"namespace": probeNamespace,
+		},
+		"spec": map[string]any{
+			"providerRef":     map[string]any{"name": providerName},
+			"topology":        map[string]any{"type": topology},
+			componentsSegment: components,
+		},
+	}
+
+	if value != nil {
+		if err := unstructured.SetNestedField(object, value, strings.Split(path, ".")...); err != nil {
+			return nil, fmt.Errorf("setting %s: %w", path, err)
+		}
+	}
+
+	instance := &corev1alpha1.Instance{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object, instance); err != nil {
+		return nil, fmt.Errorf("building an Instance with %s set: %w", path, err)
+	}
+	return instance, nil
+}
+
+func addressesComponent(path, component string) bool {
+	return strings.HasPrefix(path, "spec."+componentsSegment+"."+component+".")
+}
+
+func serialize(obj client.Object) string {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func describe(scheme *runtime.Scheme, obj client.Object) string {
+	kinds, _, err := scheme.ObjectKinds(obj)
+	if err != nil || len(kinds) == 0 {
+		return fmt.Sprintf("%T", obj)
+	}
+	return kinds[0].Kind
+}

--- a/provider-runtime/conformance/resolve.go
+++ b/provider-runtime/conformance/resolve.go
@@ -1,0 +1,217 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
+)
+
+// ProviderUnderTest is the contract a conformance run exercises.
+type ProviderUnderTest = controller.ProviderInterface
+
+// leafKind is the JSON shape of the value a UI control writes.
+type leafKind string
+
+const (
+	leafString   leafKind = "string"
+	leafInteger  leafKind = "integer"
+	leafNumber   leafKind = "number"
+	leafBool     leafKind = "boolean"
+	leafQuantity leafKind = "quantity"
+	leafUnknown  leafKind = ""
+)
+
+// quantityTypeName is a struct in Go but a string on the wire.
+const quantityTypeName = "Quantity"
+
+// componentsSegment is the map field every per-component path goes through.
+const componentsSegment = "components"
+
+// resolveLeaf reports the shape of the value a path addresses. Paths above a
+// parameters payload are resolved against the Instance types; below one they
+// are resolved against the schema the provider declared, since those types live
+// in the provider's own module.
+func resolveLeaf(spec *corev1alpha1.ProviderSpec, topology, path string) (leafKind, error) {
+	rest, ok := strings.CutPrefix(path, "spec.")
+	if !ok {
+		return leafUnknown, fmt.Errorf("path %q does not address the Instance spec", path)
+	}
+
+	current := reflect.TypeFor[corev1alpha1.InstanceSpec]()
+	var walked []string
+
+	for i, segment := range strings.Split(rest, ".") {
+		current = deref(current)
+
+		if current.Name() == "RawExtension" {
+			schema := parametersSchema(spec, topology, walked)
+			if schema == nil {
+				return leafUnknown, fmt.Errorf("no parametersSchema declared for %q", strings.Join(walked, "."))
+			}
+			return schemaLeaf(schema, strings.Split(rest, ".")[i:])
+		}
+		if current.Name() == quantityTypeName {
+			return leafUnknown, fmt.Errorf("%q is a quantity", strings.Join(walked, "."))
+		}
+
+		switch current.Kind() { //nolint:exhaustive // the default branch covers every other kind
+		case reflect.Map:
+			current = current.Elem()
+		case reflect.Struct:
+			field, ok := fieldByJSONTag(current, segment)
+			if !ok {
+				return leafUnknown, fmt.Errorf("no field %q on %s", segment, current.Name())
+			}
+			current = field.Type
+		default:
+			return leafUnknown, fmt.Errorf("%q is not addressable", strings.Join(walked, "."))
+		}
+		walked = append(walked, segment)
+	}
+
+	return goLeaf(deref(current))
+}
+
+func goLeaf(t reflect.Type) (leafKind, error) {
+	if t.Name() == quantityTypeName {
+		return leafQuantity, nil
+	}
+	switch t.Kind() { //nolint:exhaustive // the default branch covers every other kind
+	case reflect.String:
+		return leafString, nil
+	case reflect.Int, reflect.Int32, reflect.Int64:
+		return leafInteger, nil
+	case reflect.Float32, reflect.Float64:
+		return leafNumber, nil
+	case reflect.Bool:
+		return leafBool, nil
+	default:
+		return leafUnknown, fmt.Errorf("cannot generate a value for %s", t.Kind())
+	}
+}
+
+// schemaLeaf walks a declared parameters schema to the addressed property.
+func schemaLeaf(schema *apiextensionsv1.JSONSchemaProps, segments []string) (leafKind, error) {
+	current := schema
+	for _, segment := range segments {
+		next, ok := current.Properties[segment]
+		if !ok {
+			return leafUnknown, fmt.Errorf("no property %q in the declared parameters schema", segment)
+		}
+		current = &next
+	}
+	switch current.Type {
+	case "string", "integer", "number", "boolean":
+		return leafKind(current.Type), nil
+	default:
+		return leafUnknown, fmt.Errorf("cannot generate a value for schema type %q", current.Type)
+	}
+}
+
+// parametersSchema returns the schema governing the payload at this position.
+func parametersSchema(spec *corev1alpha1.ProviderSpec, topology string, walked []string) *apiextensionsv1.JSONSchemaProps {
+	switch {
+	case len(walked) == 3 && walked[0] == componentsSegment:
+		if c, ok := spec.Components[walked[1]]; ok && c.ParametersSchema != nil {
+			return c.ParametersSchema.OpenAPIV3Schema
+		}
+	case len(walked) == 2 && walked[0] == "topology":
+		if t, ok := spec.Topologies[topology]; ok && t.ParametersSchema != nil {
+			return t.ParametersSchema.OpenAPIV3Schema
+		}
+	case len(walked) == 1:
+		if spec.ParametersSchema != nil {
+			return spec.ParametersSchema.OpenAPIV3Schema
+		}
+	}
+	return nil
+}
+
+// versionPath selects a version bundle, whose legal values the Provider CR
+// enumerates. An invented token would be rejected, so the probe picks a real
+// alternative and looks for the component versions it pulls in.
+const versionPath = "spec.version"
+
+// sentinel returns a value recognisable wherever it surfaces, and the token to
+// search for. Integers get a distinctive prime so a bare number is unlikely to
+// collide with an unrelated default.
+func sentinel(spec *corev1alpha1.ProviderSpec, path string, kind leafKind) (any, string, error) {
+	if path == versionPath {
+		alternative := nonDefaultBundle(spec)
+		if alternative == "" {
+			return nil, "", errors.New("the provider declares fewer than two version bundles, so selecting one cannot be observed")
+		}
+		return alternative, alternative, nil
+	}
+
+	switch kind {
+	case leafString:
+		return "everest-conformance-7919", "everest-conformance-7919", nil
+	case leafQuantity:
+		// Must parse as a quantity, so the magnitude carries the signal.
+		return "7919", "7919", nil
+	case leafInteger:
+		return int64(7919), "7919", nil
+	case leafNumber:
+		return 79.19, "79.19", nil
+	case leafBool:
+		return true, "true", nil
+	case leafUnknown:
+	}
+	return nil, "", fmt.Errorf("cannot generate a probe value for %q", path)
+}
+
+// nonDefaultBundle returns a bundle the baseline render would not have used.
+func nonDefaultBundle(spec *corev1alpha1.ProviderSpec) string {
+	for _, bundle := range spec.Versions {
+		if !bundle.Default {
+			return bundle.Name
+		}
+	}
+	return ""
+}
+
+func deref(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t
+}
+
+func fieldByJSONTag(t reflect.Type, name string) (reflect.StructField, bool) {
+	for field := range t.Fields() {
+		tag, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if tag == name {
+			return field, true
+		}
+		if tag != "" || !field.Anonymous {
+			continue
+		}
+		if embedded := deref(field.Type); embedded.Kind() == reflect.Struct {
+			if promoted, ok := fieldByJSONTag(embedded, name); ok {
+				return promoted, true
+			}
+		}
+	}
+	return reflect.StructField{}, false
+}

--- a/provider-runtime/conformance/resolve.go
+++ b/provider-runtime/conformance/resolve.go
@@ -174,9 +174,9 @@ func sentinel(spec *corev1alpha1.ProviderSpec, path string, kind leafKind) (any,
 		return int64(7919), "7919", nil
 	case leafNumber:
 		return 79.19, "79.19", nil
-	case leafBool:
-		return true, "true", nil
-	case leafUnknown:
+	// Bools have no usable token: "true" matches any boolean in the output, so
+	// probeBool compares renders instead.
+	case leafBool, leafUnknown:
 	}
 	return nil, "", fmt.Errorf("cannot generate a probe value for %q", path)
 }

--- a/provider-runtime/conformance/spec.go
+++ b/provider-runtime/conformance/spec.go
@@ -1,0 +1,151 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+)
+
+// loadProviderSpec reads the generated Provider CR — the artifact that ships in
+// the Helm chart and that the UI actually consumes.
+func loadProviderSpec(path string) (*corev1alpha1.ProviderSpec, error) {
+	if path == "" {
+		located, err := findProviderSpec()
+		if err != nil {
+			return nil, err
+		}
+		path = located
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // a path inside the module under test
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var doc struct {
+		Spec corev1alpha1.ProviderSpec `json:"spec"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if len(doc.Spec.Topologies) == 0 {
+		return nil, fmt.Errorf("%s declares no topologies; run `make generate` first", path)
+	}
+	return &doc.Spec, nil
+}
+
+// findProviderSpec walks up to the module root and looks for the generated
+// chart artifact, so callers do not have to hardcode a path relative to
+// whichever package their test happens to live in.
+func findProviderSpec() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("could not find the module root; set Config.ProviderSpecPath")
+		}
+		dir = parent
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "charts", "*", "generated", "provider-spec.yaml"))
+	if err != nil {
+		return "", err
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return "", fmt.Errorf("no charts/*/generated/provider-spec.yaml under %s; run `make generate` first", dir)
+	default:
+		return "", fmt.Errorf("found %d generated provider specs under %s; set Config.ProviderSpecPath", len(matches), dir)
+	}
+}
+
+// uiPaths returns the Instance fields the topology's UI schema binds form
+// controls to. Only `path` values count: a field merely referenced by a CEL
+// expression is read by the form, not written by it.
+func uiPaths(spec *corev1alpha1.ProviderSpec, topology string) ([]string, error) {
+	if spec.UISchema == nil || len(spec.UISchema.Raw) == 0 {
+		return nil, nil
+	}
+
+	var schemas map[string]any
+	if err := yaml.Unmarshal(spec.UISchema.Raw, &schemas); err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	collectPaths(schemas[topology], &paths)
+	return dedupe(paths), nil
+}
+
+func collectPaths(node any, out *[]string) {
+	const pathKey = "path"
+
+	switch t := node.(type) {
+	case map[string]any:
+		for key, value := range t {
+			if key == pathKey {
+				if s, ok := value.(string); ok {
+					*out = append(*out, s)
+				}
+				continue
+			}
+			collectPaths(value, out)
+		}
+	case []any:
+		for _, value := range t {
+			collectPaths(value, out)
+		}
+	}
+}
+
+func dedupe(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// providerObject rebuilds the Provider CR from the generated spec so providers
+// that resolve images or schemas from it behave as they do in a cluster.
+func providerObject(name string, spec *corev1alpha1.ProviderSpec) *corev1alpha1.Provider {
+	return &corev1alpha1.Provider{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       *spec,
+	}
+}

--- a/provider-runtime/internal/instanceprep/instanceprep.go
+++ b/provider-runtime/internal/instanceprep/instanceprep.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package instanceprep holds the transformations the runtime applies to an
+// Instance before a provider sees it.
+//
+// It is internal on purpose. Providers are handed an already-prepared Instance,
+// so they have no reason to call this, and keeping it unexported leaves the
+// signature free to change as more preparation steps are added.
+package instanceprep
+
+import (
+	v1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
+)
+
+// PrepareForSync returns the Instance a provider is actually handed: a copy of
+// in with everything the runtime resolves on the provider's behalf already
+// applied. The stored object is never mutated.
+//
+// Every transformation the runtime performs between admission and Sync belongs
+// here, so that what a provider receives has a single definition.
+func PrepareForSync(
+	spec *v1alpha1.ProviderSpec,
+	in *v1alpha1.Instance,
+) (*v1alpha1.Instance, string, error) {
+	bundleName := controller.EffectiveVersionBundleName(spec, in)
+
+	prepared, err := applyVersionBundle(spec, in, bundleName)
+	if err != nil {
+		return nil, "", err
+	}
+	return prepared, bundleName, nil
+}
+
+// applyVersionBundle fills in each component's Version from the named bundle,
+// for components the user did not pin explicitly. With no bundle in force the
+// Instance is returned untouched, and Sync falls back to the per-type defaults
+// in the componentTypes catalog.
+func applyVersionBundle(
+	spec *v1alpha1.ProviderSpec,
+	in *v1alpha1.Instance,
+	bundleName string,
+) (*v1alpha1.Instance, error) {
+	if bundleName == "" {
+		return in, nil
+	}
+
+	bundle, err := controller.ResolveVersionBundle(spec, bundleName)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved := in.DeepCopy()
+	for componentName, bundleVersion := range bundle.Components {
+		component, exists := resolved.Spec.Components[componentName]
+		if !exists || component.Version != "" {
+			continue
+		}
+		component.Version = bundleVersion
+		resolved.Spec.Components[componentName] = component
+	}
+	return resolved, nil
+}

--- a/provider-runtime/internal/instanceprep/instanceprep_test.go
+++ b/provider-runtime/internal/instanceprep/instanceprep_test.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instanceprep_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	"github.com/openeverest/openeverest/v2/provider-runtime/internal/instanceprep"
+)
+
+func bundleSpec() *v1alpha1.ProviderSpec {
+	return &v1alpha1.ProviderSpec{
+		Versions: []v1alpha1.VersionBundle{
+			{
+				Name:       "8.0",
+				Default:    true,
+				Components: map[string]string{"engine": "8.0.12", "proxy": "8.0.12"},
+			},
+			{
+				Name:       "7.0",
+				Components: map[string]string{"engine": "7.0.18", "proxy": "7.0.18"},
+			},
+		},
+	}
+}
+
+func instanceWith(components map[string]v1alpha1.ComponentSpec) *v1alpha1.Instance {
+	return &v1alpha1.Instance{Spec: v1alpha1.InstanceSpec{Components: components}}
+}
+
+func TestPrepareForSyncFillsOnlyUnpinnedComponents(t *testing.T) {
+	t.Parallel()
+
+	in := instanceWith(map[string]v1alpha1.ComponentSpec{
+		"engine": {},
+		"proxy":  {Version: "6.0.19"},
+	})
+	in.Spec.Version = "7.0"
+
+	prepared, bundle, err := instanceprep.PrepareForSync(bundleSpec(), in)
+	require.NoError(t, err)
+
+	assert.Equal(t, "7.0", bundle)
+	assert.Equal(t, "7.0.18", prepared.Spec.Components["engine"].Version)
+	assert.Equal(t, "6.0.19", prepared.Spec.Components["proxy"].Version, "an explicit choice wins over the bundle")
+}
+
+func TestPrepareForSyncIgnoresComponentsNotInTheInstance(t *testing.T) {
+	t.Parallel()
+
+	prepared, _, err := instanceprep.PrepareForSync(bundleSpec(), instanceWith(map[string]v1alpha1.ComponentSpec{
+		"engine": {},
+	}))
+	require.NoError(t, err)
+
+	assert.Len(t, prepared.Spec.Components, 1)
+}
+
+func TestPrepareForSyncLeavesTheInstanceAloneWithoutABundle(t *testing.T) {
+	t.Parallel()
+
+	in := instanceWith(map[string]v1alpha1.ComponentSpec{"engine": {}})
+	prepared, bundle, err := instanceprep.PrepareForSync(&v1alpha1.ProviderSpec{}, in)
+	require.NoError(t, err)
+
+	assert.Empty(t, bundle)
+	assert.Same(t, in, prepared)
+}
+
+func TestPrepareForSyncRejectsAnUnknownBundle(t *testing.T) {
+	t.Parallel()
+
+	in := instanceWith(nil)
+	in.Spec.Version = "9.9"
+
+	_, _, err := instanceprep.PrepareForSync(bundleSpec(), in)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `version bundle "9.9" not found`)
+}
+
+// The caller's Instance must not be mutated: the runtime resolves a bundle for
+// the provider's benefit without writing it back to the stored object.
+func TestPrepareForSyncDoesNotMutateTheInput(t *testing.T) {
+	t.Parallel()
+
+	in := instanceWith(map[string]v1alpha1.ComponentSpec{"engine": {}})
+	_, _, err := instanceprep.PrepareForSync(bundleSpec(), in)
+	require.NoError(t, err)
+
+	assert.Empty(t, in.Spec.Components["engine"].Version)
+}

--- a/provider-runtime/reconciler/provider.go
+++ b/provider-runtime/reconciler/provider.go
@@ -41,6 +41,7 @@ import (
 	commonv1alpha1 "github.com/openeverest/openeverest/v2/api/common/v1alpha1"
 	"github.com/openeverest/openeverest/v2/api/core/v1alpha1"
 	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
+	"github.com/openeverest/openeverest/v2/provider-runtime/internal/instanceprep"
 	"github.com/openeverest/openeverest/v2/provider-runtime/server"
 )
 
@@ -414,13 +415,10 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		return reconcile.Result{}, err
 	}
 
-	// Resolve version bundle into a deep-copied instance so the stored spec is
-	// never mutated. The resolved copy is used for Sync() and Status() only.
-	// effectiveBundleName is the bundle that was applied (may differ from
-	// spec.version when the default was resolved on first reconcile).
-	effectiveBundleName, resolvedIn, err := r.resolveVersionBundle(ctx, in)
+	// The provider is handed a prepared copy, never the stored object.
+	resolvedIn, effectiveBundleName, err := r.prepareInstance(ctx, in)
 	if err != nil {
-		logger.Error(err, "Version bundle resolution failed")
+		logger.Error(err, "Preparing the instance for sync failed")
 		return reconcile.Result{}, err
 	}
 	syncCtx := controller.NewContext(ctx, r.Client, resolvedIn, r.provider.Name())
@@ -769,45 +767,21 @@ func setCondition(in *v1alpha1.Instance, condType string, status metav1.Conditio
 	})
 }
 
-// resolveVersionBundle determines the effective version bundle, applies it to
-// a deep copy of in, and returns both the effective bundle name and the
-// resolved Instance. The original Instance stored in etcd is never mutated.
+// prepareInstance fetches the Provider and returns the Instance the provider
+// should be handed, together with the version bundle that was applied. The
+// stored Instance is never mutated: the copy is used for Sync and Status only.
 //
-// The bundle is chosen by controller.EffectiveVersionBundleName. With no
-// bundle in force it returns ("", in, nil) and Sync() falls back to the
-// per-type defaults in the componentTypes catalog.
-//
-// For each component the bundle version is applied only when the component's
-// Version field is not already explicitly set by the user.
-func (r *ProviderReconciler) resolveVersionBundle(ctx context.Context, in *v1alpha1.Instance) (effectiveBundleName string, resolved *v1alpha1.Instance, err error) {
+// The applied bundle name is written to status.version by the caller, so that
+// later reconciles keep the bundle an Instance started on.
+func (r *ProviderReconciler) prepareInstance(
+	ctx context.Context,
+	in *v1alpha1.Instance,
+) (*v1alpha1.Instance, string, error) {
 	providerObj := &v1alpha1.Provider{}
-	if err = r.Get(ctx, client.ObjectKey{Name: in.Spec.ProviderRef.Name}, providerObj); err != nil {
-		return "", nil, fmt.Errorf("fetching provider for version resolution: %w", err)
+	if err := r.Get(ctx, client.ObjectKey{Name: in.Spec.ProviderRef.Name}, providerObj); err != nil {
+		return nil, "", fmt.Errorf("fetching provider for version resolution: %w", err)
 	}
-	spec := &providerObj.Spec
-
-	effectiveBundleName = controller.EffectiveVersionBundleName(spec, in)
-	if effectiveBundleName == "" {
-		return "", in, nil
-	}
-
-	bundle, err := controller.ResolveVersionBundle(spec, effectiveBundleName)
-	if err != nil {
-		return "", nil, err
-	}
-
-	resolved = in.DeepCopy()
-	for compName, bundleVersion := range bundle.Components {
-		compSpec, exists := resolved.Spec.Components[compName]
-		if !exists {
-			continue
-		}
-		if compSpec.Version == "" {
-			compSpec.Version = bundleVersion
-			resolved.Spec.Components[compName] = compSpec
-		}
-	}
-	return effectiveBundleName, resolved, nil
+	return instanceprep.PrepareForSync(&providerObj.Spec, in)
 }
 
 // validateVersionBundle checks that spec.version (if set) exists in the


### PR DESCRIPTION
## Problem

A topology UI schema binds form controls to Instance fields by path. [provider-sdk#36](https://github.com/openeverest/provider-sdk/pull/36) now proves those paths *exist*; nothing proves the provider does anything with them. A field can be offered in the UI, accept input, and be silently dropped — which is worse for a user than not offering it at all.

## What this adds

`provider-runtime/conformance`, called from a provider's own test suite:

```go
func TestUISchemaIsReconciled(t *testing.T) {
        conformance.UISchemaIsReconciled(t, conformance.Config{
                Provider: NewMyProvider(),
        })
}
```

For every path the **generated Provider CR** binds a control to — the artifact that ships in the chart and that the UI actually reads — it renders `Sync()` offline against a fake client with a recognisable value set, and counts the field as consumed if any of these hold:

| evidence | proves |
|---|---|
| the value reaches an object the provider applied | it reached the engine CR |
| the value appears in a request the provider made | the provider read the field |
| the render differs from a baseline with the field unset | the field changed behaviour even though its value never appears literally |

The second matters for reference-valued fields: `components.monitoring.parameters.monitoringConfigName` never reaches the engine CR, but the provider fetching a `MonitoringConfig` by that name is conclusive. Evidence collected before a failed `Sync` still counts — the request happened regardless of what came after.

The third matters for fields whose value is not a value in the output: a shard count changes *how many* objects exist rather than appearing in one.

## No per-provider fixtures

The Instance is built from the topology the Provider CR declares, and optional components are left out unless the probed path addresses one. Types come from `BaseProvider.SchemeFuncs`, and `parameters.*` paths are typed from the `openAPIV3Schema` already resolved into the Provider CR, so nothing needs the provider's Go types.

Verified against PSMDB: **zero fixtures**, and no `SetClient` wiring — `p.client` is only used by watch mapping, never by `Sync`.

## Faithfulness

The harness renders the Instance **the reconciler would hand to `Sync`**, not the one the user wrote. That matters: the runtime fills each `ComponentSpec.Version` from the version bundle before `Sync` runs, so `spec.version` is consumed by the runtime rather than by any provider. Rendering `Sync` directly reported `spec.version` as unreconciled on every provider — a false positive produced by the harness, not by the providers.

The first commit therefore moves that preparation out of the reconcile loop into `provider-runtime/internal/instanceprep`, which the reconciler and the harness both call. A preparation step added there reaches both by construction rather than by remembering. It is internal deliberately: providers are handed an already-prepared Instance and have no reason to call it.

For the same reason `spec.version` is probed with a real non-default bundle rather than an invented token: the Provider CR enumerates the legal values. A provider declaring a single bundle cannot have the field exercised, and is told so.

## Base

Stacked on #3054, which exports the version bundle selection order so that the four copies of it in provider-percona-postgresql and provider-percona-xtradb-cluster have something to converge on. `instanceprep` calls that instead of keeping a copy of its own. GitHub will retarget this branch to `main` once #3054 merges.

## Known limits

- Only `Sync` is exercised. Fields consumed elsewhere are invisible.
- Other enum-valued fields still get an arbitrary sentinel, so a provider that validates them may fail the render and report *unverified* rather than a verdict.
- `Config.Unverifiable` exists for values a provider reshapes beyond recognition. It takes a mandatory reason and should be reviewed like any other code — it is not a way to silence a genuinely unhandled field.
