### PR TITLE
refactor(runtime): share the version bundle selection order

### DIFF
--- a/provider-runtime/controller/metadata.go
+++ b/provider-runtime/controller/metadata.go
@@ -167,6 +167,28 @@ func GetDefaultVersionBundleName(spec *v1alpha1.ProviderSpec) string {
 	return ""
 }
 
+// EffectiveVersionBundleName returns the bundle in force for an Instance:
+//
+//  1. spec.version, when the user chose one.
+//  2. status.version, frozen on the first reconcile so that upgrading a
+//     Provider does not silently move existing Instances to a new bundle.
+//  3. the Provider's default bundle.
+//
+// Returns empty string when the spec declares no bundles at all. This is the
+// same order the runtime applies before calling Sync, so a provider that needs
+// the bundle itself — to read component versions the runtime does not resolve
+// on its behalf — agrees with the runtime by construction.
+func EffectiveVersionBundleName(spec *v1alpha1.ProviderSpec, in *v1alpha1.Instance) string {
+	switch {
+	case in.Spec.Version != "":
+		return in.Spec.Version
+	case in.Status.Version != "":
+		return in.Status.Version
+	default:
+		return GetDefaultVersionBundleName(spec)
+	}
+}
+
 // =============================================================================
 // VALIDATION HELPERS
 // =============================================================================

--- a/provider-runtime/controller/metadata_test.go
+++ b/provider-runtime/controller/metadata_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+)
+
+func TestEffectiveVersionBundleName(t *testing.T) {
+	t.Parallel()
+
+	withBundles := &v1alpha1.ProviderSpec{
+		Versions: []v1alpha1.VersionBundle{
+			{Name: "1.0.0"},
+			{Name: "2.0.0", Default: true},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		spec          *v1alpha1.ProviderSpec
+		specVersion   string
+		statusVersion string
+		want          string
+	}{
+		{
+			name:          "spec.version outranks both status.version and the default",
+			spec:          withBundles,
+			specVersion:   "1.0.0",
+			statusVersion: "2.0.0",
+			want:          "1.0.0",
+		},
+		{
+			name:          "status.version outranks the default, so a new default does not move an existing Instance",
+			spec:          withBundles,
+			statusVersion: "1.0.0",
+			want:          "1.0.0",
+		},
+		{
+			name: "the default bundle applies on the first reconcile",
+			spec: withBundles,
+			want: "2.0.0",
+		},
+		{
+			name: "no bundle in force when the spec declares no default",
+			spec: &v1alpha1.ProviderSpec{
+				Versions: []v1alpha1.VersionBundle{{Name: "1.0.0"}},
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			in := &v1alpha1.Instance{
+				Spec:   v1alpha1.InstanceSpec{Version: tc.specVersion},
+				Status: v1alpha1.InstanceStatus{Version: tc.statusVersion},
+			}
+			assert.Equal(t, tc.want, EffectiveVersionBundleName(tc.spec, in))
+		})
+	}
+}

--- a/provider-runtime/reconciler/provider.go
+++ b/provider-runtime/reconciler/provider.go
@@ -773,15 +773,9 @@ func setCondition(in *v1alpha1.Instance, condType string, status metav1.Conditio
 // a deep copy of in, and returns both the effective bundle name and the
 // resolved Instance. The original Instance stored in etcd is never mutated.
 //
-// Resolution order:
-//  1. spec.version — explicitly set by the user (always honoured).
-//  2. status.version — the bundle name frozen on the first reconciliation;
-//     prevents a Provider upgrade from silently upgrading existing Instances.
-//  3. Provider's default bundle — resolved once on the very first reconcile
-//     of a new Instance; the name is then written to status.version so
-//     subsequent reconciles use step 2 instead.
-//  4. No bundle — returns ("" , in, nil); Sync() falls back to per-type
-//     defaults from the componentTypes catalog.
+// The bundle is chosen by controller.EffectiveVersionBundleName. With no
+// bundle in force it returns ("", in, nil) and Sync() falls back to the
+// per-type defaults in the componentTypes catalog.
 //
 // For each component the bundle version is applied only when the component's
 // Version field is not already explicitly set by the user.
@@ -792,20 +786,7 @@ func (r *ProviderReconciler) resolveVersionBundle(ctx context.Context, in *v1alp
 	}
 	spec := &providerObj.Spec
 
-	switch {
-	case in.Spec.Version != "":
-		// User explicitly chose a bundle.
-		effectiveBundleName = in.Spec.Version
-	case in.Status.Version != "":
-		// Default was frozen on a previous reconcile; honour it regardless of
-		// what the Provider's current default is.
-		effectiveBundleName = in.Status.Version
-	default:
-		// First reconcile of a new Instance with no explicit version: resolve
-		// the Provider's current default and freeze it in status.
-		effectiveBundleName = controller.GetDefaultVersionBundleName(spec)
-	}
-
+	effectiveBundleName = controller.EffectiveVersionBundleName(spec, in)
 	if effectiveBundleName == "" {
 		return "", in, nil
 	}


### PR DESCRIPTION
The order that decides which version bundle is in force for an Instance — `spec.version`, then `status.version`, then the Provider's default — is currently reimplemented in four places outside the runtime: `selectedVersionBundleName` in provider-percona-postgresql, and three separate inlined copies in provider-percona-xtradb-cluster (`imageForBundledProxy`, `monitoringImageForComponent`, and `backup_mirror.go`).

Every copy has to track the runtime by hand. That matters more than ordinary duplication does, because the runtime resolves the bundle *before* calling `Sync`: a provider that picks a different one renders images for a version the Instance is not actually running, and nothing catches the divergence.

This exports the selection as `controller.EffectiveVersionBundleName(spec, in)` and has the reconciler call it, so those copies have something to converge on. The signature is the one all four call sites already need — PG's helper and PXC's three copies each reduce to `controller.EffectiveVersionBundleName(spec, c.Instance())`.

Only the *selection* is exported. Applying a bundle to an Instance stays in the reconciler, since no provider does that.

### Tests

The order had no test of its own: there is no reference to `resolveVersionBundle` or `GetDefaultVersionBundleName` in any test file under `provider-runtime/`. This adds a table test for the precedence, including the case that carries the most weight — `status.version` outranking a default that has since changed, which is what stops a Provider upgrade from silently moving existing Instances onto a new bundle.

### Relationship to #3053

This was extracted from #3053 so the provider-side cleanups are not gated on it. The two are independent: #3053's net diff does not touch `provider-runtime/controller/` at all. I test-rebased a squashed #3053 onto this branch — one conflicted file, both hunks inside the function this PR touches, resolved by taking #3053's side, after which `instanceprep`'s private copy is deleted in favour of the exported one and the module builds with all runtime tests green.

### Follow-ups

Deleting the copies in provider-percona-postgresql and provider-percona-xtradb-cluster, once this is merged and there is a SHA to pin.
