### PR TITLE
feat(provider-runtime): carry supportedFields into the generated Provider CR

### DIFF
--- a/provider-runtime/manifest/manifest.go
+++ b/provider-runtime/manifest/manifest.go
@@ -95,6 +95,9 @@ type topologyConfig struct {
 
 type topologyComponentConfig struct {
 	Optional bool `json:"optional,omitempty"`
+	// SupportedFields is authored inline rather than as a Go type reference:
+	// it selects from ComponentSpec instead of describing a new type.
+	SupportedFields *apiextensionsv1.JSONSchemaProps `json:"supportedFields,omitempty"`
 }
 
 // Generate reads a provider-config.yaml, resolves Go type references to OpenAPI schemas,
@@ -198,6 +201,11 @@ func buildProviderSpec(pc *providerConfig, types map[string]any, rawSchemas map[
 		for compName, compCfg := range tc.Components {
 			topoComp := v1alpha1.TopologyComponent{
 				Optional: compCfg.Optional,
+			}
+			if compCfg.SupportedFields != nil {
+				topoComp.SupportedFields = &common.ParametersSchema{
+					OpenAPIV3Schema: compCfg.SupportedFields,
+				}
 			}
 			topo.Components[compName] = topoComp
 		}

--- a/provider-runtime/manifest/manifest_test.go
+++ b/provider-runtime/manifest/manifest_test.go
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+// buildSpecFromYAML runs the same path Generate does, minus reading the file.
+func buildSpecFromYAML(t *testing.T, config string) *providerConfig {
+	t.Helper()
+
+	var pc providerConfig
+	require.NoError(t, yaml.Unmarshal([]byte(config), &pc))
+	return &pc
+}
+
+func TestSupportedFieldsReachesTheProviderSpec(t *testing.T) {
+	t.Parallel()
+
+	pc := buildSpecFromYAML(t, `
+name: test-provider
+componentTypes: {}
+components:
+  engine:
+    type: mongod
+topologies:
+  sharded:
+    components:
+      engine:
+        supportedFields:
+          required: [storage]
+          properties:
+            storage: {}
+            replicas: {minimum: 1}
+            schedulingPolicy:
+              properties:
+                nodeSelector: {}
+                tolerations: {}
+      backupAgent:
+        optional: true
+`)
+
+	spec, err := buildProviderSpec(pc, nil, nil)
+	require.NoError(t, err)
+
+	engine := spec.Topologies["sharded"].Components["engine"]
+	require.NotNil(t, engine.SupportedFields)
+	schema := engine.SupportedFields.OpenAPIV3Schema
+	require.NotNil(t, schema)
+
+	assert.Equal(t, []string{"storage"}, schema.Required)
+	assert.Contains(t, schema.Properties, "storage")
+	assert.NotContains(t, schema.Properties, "resources", "an undeclared field must not appear")
+
+	// A bound survives the round trip through the wire format.
+	replicas := schema.Properties["replicas"]
+	require.NotNil(t, replicas.Minimum)
+	assert.InDelta(t, 1.0, *replicas.Minimum, 0)
+
+	// Nesting survives, so a component can honour part of a grouped field.
+	scheduling := schema.Properties["schedulingPolicy"]
+	assert.Contains(t, scheduling.Properties, "nodeSelector")
+	assert.Contains(t, scheduling.Properties, "tolerations")
+	assert.NotContains(t, scheduling.Properties, "affinity")
+}
+
+func TestComponentWithoutSupportedFieldsIsUnconstrained(t *testing.T) {
+	t.Parallel()
+
+	pc := buildSpecFromYAML(t, `
+name: test-provider
+componentTypes: {}
+components:
+  engine:
+    type: mongod
+topologies:
+  replicaSet:
+    components:
+      engine:
+        optional: true
+`)
+
+	spec, err := buildProviderSpec(pc, nil, nil)
+	require.NoError(t, err)
+
+	engine := spec.Topologies["replicaSet"].Components["engine"]
+	assert.True(t, engine.Optional)
+	assert.Nil(t, engine.SupportedFields)
+}


### PR DESCRIPTION
Second of a stack implementing per-component field applicability ([spec 013](https://github.com/openeverest/specs)). **Stacked on #3057** — this PR's diff is against it.

### This PR

Reads the per-component `supportedFields` block from the topology config and publishes it on `TopologyComponent`, so the declaration reaches the Provider CR that every client resolves against.

`supportedFields` is authored **inline**, unlike `parametersSchema`, which names a Go type the generator reflects on. It selects from `ComponentSpec` rather than describing a new type, and Go cannot express "a subset of an existing struct" without a parallel type that drifts from it. JSON Schema selects natively.

### Testing

The tests cover the wire format, which is where the risk actually is: `JSONSchemaProps` has custom marshalling, so the open question was whether an inline declaration survives YAML unmarshalling with its structure intact. It does —

- a bound (`replicas: {minimum: 1}`) round-trips,
- nesting round-trips, so a component can declare `schedulingPolicy` with only `nodeSelector` and `tolerations` and **not** promise `affinity`,
- an undeclared field does not appear,
- a component with no declaration yields `nil`, not an empty schema — absent means unconstrained, and the two must not be confused.

First tests in this package.

### Companion PR

openeverest/provider-sdk#37 lets `supportedFields` through `buildTopologySpec`, which is an allowlist and drops it today. Both are needed before any real `topology.yaml` reaches this code.

### Review notes

Draft until the PRs below it merge.
