### PR TITLE
feat(provider-runtime): add a conformance check that declared fields are reconciled

### DIFF
--- a/provider-runtime/conformance/conformance.go
+++ b/provider-runtime/conformance/conformance.go
@@ -95,10 +95,24 @@ func UISchemaIsReconciled(t *testing.T, cfg Config) {
 		results = append(results, probeTopology(t, cfg, spec, topology, paths)...)
 	}
 
-	report(t, cfg, results)
+	report(t, cfg, results, uiSchemaSource())
 }
 
-func report(t *testing.T, cfg Config, results []result) {
+// source describes where a probed path came from, so a failure names the
+// declaration the author has to fix.
+type source struct {
+	subject string
+	ignored string
+}
+
+func uiSchemaSource() source {
+	return source{
+		subject: "UI schema references",
+		ignored: "offered by the UI, but setting it changes nothing the provider applies or requests",
+	}
+}
+
+func report(t *testing.T, cfg Config, results []result, src source) {
 	t.Helper()
 
 	var failures, notes []string
@@ -112,8 +126,8 @@ func report(t *testing.T, cfg Config, results []result) {
 			continue
 		case ignored:
 			failures = append(failures, fmt.Sprintf(
-				"  topology %s\n    %s\n      offered by the UI, but setting it changes nothing the provider applies or requests",
-				r.topology, r.path))
+				"  topology %s\n    %s\n      %s",
+				r.topology, r.path, src.ignored))
 		case unverified:
 			failures = append(failures, fmt.Sprintf(
 				"  topology %s\n    %s\n      could not be verified: %s%s",
@@ -125,8 +139,8 @@ func report(t *testing.T, cfg Config, results []result) {
 		t.Log(note)
 	}
 	if len(failures) > 0 {
-		t.Errorf("UI schema references %d field(s) this provider does not reconcile:\n%s",
-			len(failures), strings.Join(failures, "\n"))
+		t.Errorf("%s %d field(s) this provider does not reconcile:\n%s",
+			src.subject, len(failures), strings.Join(failures, "\n"))
 	}
 }
 

--- a/provider-runtime/conformance/supportedfields.go
+++ b/provider-runtime/conformance/supportedfields.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+)
+
+// maxDeclarationDepth bounds the walk into a declared field. Nothing in
+// ComponentSpec needs more, and a cycle would otherwise not terminate.
+const maxDeclarationDepth = 4
+
+// SupportedFieldsAreReconciled asserts that every field a component declares
+// in supportedFields is one the provider actually consumes.
+//
+// The declaration is a promise to the API: an undeclared field is rejected, so
+// a declared one that changes nothing is the silent no-op the declaration
+// exists to remove, now published as a contract.
+//
+// A property declared without nested properties promises the whole struct
+// beneath it, so it is probed at every scalar that struct reaches. Declaring
+// schedulingPolicy as a whole therefore has to hold for schedulerName too, not
+// only for the affinity the provider happens to read.
+func SupportedFieldsAreReconciled(t *testing.T, cfg Config) {
+	t.Helper()
+
+	spec, err := loadProviderSpec(cfg.ProviderSpecPath)
+	if err != nil {
+		t.Fatalf("conformance: %v", err)
+	}
+
+	var results []result
+	for _, topology := range sortedKeys(spec.Topologies) {
+		paths := declaredPaths(spec, topology)
+		if len(paths) == 0 {
+			continue
+		}
+		results = append(results, probeTopology(t, cfg, spec, topology, paths)...)
+	}
+
+	report(t, cfg, results, supportedFieldsSource())
+}
+
+func supportedFieldsSource() source {
+	return source{
+		subject: "supportedFields declares",
+		ignored: "declared in supportedFields, but setting it changes nothing the provider applies or requests",
+	}
+}
+
+// declaredPaths returns the scalar Instance fields the topology's components
+// declare they honour.
+func declaredPaths(spec *corev1alpha1.ProviderSpec, topology string) []string {
+	componentSpec := reflect.TypeFor[corev1alpha1.ComponentSpec]()
+
+	var paths []string
+	for _, name := range sortedKeys(spec.Topologies[topology].Components) {
+		component := spec.Topologies[topology].Components[name]
+		if component.SupportedFields == nil || component.SupportedFields.OpenAPIV3Schema == nil {
+			continue
+		}
+		expandDeclaration(
+			componentSpec,
+			component.SupportedFields.OpenAPIV3Schema,
+			"spec."+componentsSegment+"."+name,
+			&paths,
+		)
+	}
+	return dedupe(paths)
+}
+
+// expandDeclaration walks a declared schema against the type it selects from,
+// descending where the declaration does and expanding the Go type where it
+// stops.
+func expandDeclaration(t reflect.Type, schema *apiextensionsv1.JSONSchemaProps, prefix string, out *[]string) {
+	t = deref(t)
+	if t.Kind() != reflect.Struct {
+		return
+	}
+	for _, name := range sortedKeys(schema.Properties) {
+		property := schema.Properties[name]
+		field, ok := fieldByJSONTag(t, name)
+		if !ok {
+			// The generator rejects a property that names no field, so by the
+			// time a spec is published there is nothing to report here.
+			continue
+		}
+		path := prefix + "." + name
+		if len(property.Properties) > 0 {
+			expandDeclaration(field.Type, &property, path, out)
+			continue
+		}
+		scalarLeaves(field.Type, path, out, 0)
+	}
+}
+
+// scalarLeaves appends every scalar path reachable from t.
+//
+// It stops at maps, slices and parameters payloads: those have no fixed member
+// to address, so no probe can name one. A field that reaches no scalar is
+// simply not probed — the harness reports what it proved, not what it wished.
+func scalarLeaves(t reflect.Type, prefix string, out *[]string, depth int) {
+	t = deref(t)
+	if _, err := goLeaf(t); err == nil {
+		*out = append(*out, prefix)
+		return
+	}
+	if depth >= maxDeclarationDepth || t.Kind() != reflect.Struct || t.Name() == "RawExtension" {
+		return
+	}
+
+	for field := range t.Fields() {
+		tag, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if tag == "" {
+			if field.Anonymous {
+				// Inlined by core, so its fields are addressed as if declared here.
+				scalarLeaves(field.Type, prefix, out, depth)
+			}
+			continue
+		}
+		scalarLeaves(field.Type, prefix+"."+tag, out, depth+1)
+	}
+}

--- a/provider-runtime/conformance/supportedfields_test.go
+++ b/provider-runtime/conformance/supportedfields_test.go
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
+
+	commonv1alpha1 "github.com/openeverest/openeverest/v2/api/common/v1alpha1"
+	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+)
+
+// specDeclaring builds a spec whose "simple" topology gives engine the schema.
+func specDeclaring(t *testing.T, schema string) *corev1alpha1.ProviderSpec {
+	t.Helper()
+
+	props := &apiextensionsv1.JSONSchemaProps{}
+	require.NoError(t, yaml.Unmarshal([]byte(schema), props))
+
+	spec := testSpec()
+	spec.Topologies["simple"] = corev1alpha1.Topology{
+		Components: map[string]corev1alpha1.TopologyComponent{
+			"engine": {SupportedFields: &commonv1alpha1.ParametersSchema{OpenAPIV3Schema: props}},
+		},
+	}
+	return spec
+}
+
+func TestDeclaredPaths(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		schema string
+		want   []string
+	}{
+		"a scalar is probed directly": {
+			schema: "properties:\n  replicas: {}",
+			want:   []string{"spec.components.engine.replicas"},
+		},
+		"a struct expands to its scalars": {
+			schema: "properties:\n  storage: {}",
+			want: []string{
+				"spec.components.engine.storage.size",
+				"spec.components.engine.storage.storageClass",
+			},
+		},
+		// The case that makes an over-broad declaration observable: promising
+		// the whole policy has to hold for schedulerName, not only for the
+		// affinity a provider happens to read.
+		"a group declared whole expands past what a provider may read": {
+			schema: "properties:\n  schedulingPolicy: {}",
+			want:   []string{"spec.components.engine.schedulingPolicy.schedulerName"},
+		},
+		"a group narrowed to an unprobeable member yields nothing": {
+			schema: "properties:\n  schedulingPolicy:\n    properties:\n      affinity: {}",
+			want:   nil,
+		},
+		// Maps have no fixed member to address, so resources is left to the UI
+		// probe, which knows the key the form binds.
+		"a map yields nothing": {
+			schema: "properties:\n  resources: {}",
+			want:   nil,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := declaredPaths(specDeclaring(t, tc.schema), "simple")
+			if len(tc.want) == 0 {
+				assert.Empty(t, got)
+				return
+			}
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestDeclaredPathsIgnoresComponentsWithoutADeclaration(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, declaredPaths(testSpec(), "simple"))
+}


### PR DESCRIPTION
The other half of keeping per-component field applicability honest. **Stacked on #3057.**

The generator (openeverest/provider-sdk#38) checks a declaration is *well-formed* — the properties exist and are not re-typed. Nothing checked it was *true*. `supportedFields` is a promise to the API: an undeclared field gets rejected, so a **declared** field that changes nothing is the silent no-op this work removes, now published as a contract.

This adds `SupportedFieldsAreReconciled`, alongside the existing `UISchemaIsReconciled`, reusing the same probe machinery.

### Why it expands a declaration

A property declared without nested properties promises the whole struct beneath it, so it is probed at every scalar that struct reaches. Declaring `schedulingPolicy` as a whole therefore has to hold for `schedulerName`, not only for the `affinity` a provider happens to read.

That is what makes an over-broad declaration *observable* rather than merely wrong — and it is not hypothetical. PSMDB's first declaration (openeverest/provider-percona-server-mongodb#89) said `schedulingPolicy: {}` while the provider reads only `SchedulingPolicy.Affinity`. Reverting that fix makes this check fail:

```
spec.components.engine.schedulingPolicy.schedulerName
  declared in supportedFields, but setting it changes nothing the provider applies or requests
```

on all three components that declared it.

### What it does not probe

Maps and slices have no fixed member to address, so a field reaching no scalar is not probed rather than being guessed at. `resources` is the notable one — it stays covered by the UI check, which knows the key the form actually binds. The two checks are complementary, and the harness reports what it proved rather than what it wished.

### Testing

Unit tests cover the expansion, including the two cases that carry the design: a group declared whole expands past what a provider may read, and a group narrowed to an unprobeable member yields nothing. Verified against real PSMDB declarations, passing as narrowed and failing as originally written.