### PR TITLE
UI generator now can have a foldable section

### DIFF
--- a/ui/apps/everest/src/components/ui-generator/constants.ts
+++ b/ui/apps/everest/src/components/ui-generator/constants.ts
@@ -16,6 +16,7 @@ import { SelectInput, SwitchInput, TextInput } from '@percona/ui-lib';
 import { FieldType, GroupType } from './ui-generator.types';
 import AccordionWrapper from './ui-group-wrappers/accordion-wrapper';
 import StackWrapper from './ui-group-wrappers/stack-wrapper';
+import SwitchGroupWrapper from './ui-group-wrappers/switch-group-wrapper';
 import { z } from 'zod';
 
 export const UI_TYPE_DEFAULT_VALUE: Partial<Record<FieldType, unknown>> = {
@@ -28,6 +29,7 @@ export const UI_TYPE_DEFAULT_VALUE: Partial<Record<FieldType, unknown>> = {
 export const componentGroupMap: Record<string, React.ElementType> = {
   [GroupType.Accordion]: AccordionWrapper,
   [GroupType.Line]: StackWrapper,
+  [GroupType.Switch]: SwitchGroupWrapper,
 };
 export const muiComponentMap: Record<FieldType, React.ElementType> = {
   [FieldType.Number]: TextInput,

--- a/ui/apps/everest/src/components/ui-generator/ui-generator.types.ts
+++ b/ui/apps/everest/src/components/ui-generator/ui-generator.types.ts
@@ -64,6 +64,7 @@ export enum FieldType {
 export enum GroupType {
   Accordion = 'accordion',
   Line = 'line',
+  Switch = 'switch',
 }
 
 interface CommonFieldParams {

--- a/ui/apps/everest/src/components/ui-generator/ui-group-wrappers/switch-group-wrapper/index.ts
+++ b/ui/apps/everest/src/components/ui-generator/ui-group-wrappers/switch-group-wrapper/index.ts
@@ -1,0 +1,1 @@
+export { default } from './switch-group-wrapper';

--- a/ui/apps/everest/src/components/ui-generator/ui-group-wrappers/switch-group-wrapper/switch-group-wrapper.test.tsx
+++ b/ui/apps/everest/src/components/ui-generator/ui-group-wrappers/switch-group-wrapper/switch-group-wrapper.test.tsx
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TestWrapper } from 'utils/test';
+import SwitchGroupWrapper from './switch-group-wrapper';
+
+const renderWrapper = (defaultExpanded?: boolean) =>
+  render(
+    <SwitchGroupWrapper
+      label="Customize resource requests"
+      labelCaption="Lower requests below the limits."
+      defaultExpanded={defaultExpanded}
+    >
+      <div>child content</div>
+    </SwitchGroupWrapper>,
+    { wrapper: TestWrapper }
+  );
+
+const getSwitch = () => screen.getByRole('switch');
+
+describe('SwitchGroupWrapper', () => {
+  it('renders collapsed with the switch off by default', () => {
+    renderWrapper();
+    expect(getSwitch()).not.toBeChecked();
+    expect(screen.getByText('child content')).not.toBeVisible();
+  });
+
+  it('reveals children when the switch is turned on', () => {
+    renderWrapper();
+    fireEvent.click(getSwitch());
+    expect(getSwitch()).toBeChecked();
+    expect(screen.getByText('child content')).toBeVisible();
+  });
+
+  it('renders expanded when defaultExpanded is true', () => {
+    renderWrapper(true);
+    expect(getSwitch()).toBeChecked();
+    expect(screen.getByText('child content')).toBeVisible();
+  });
+});

--- a/ui/apps/everest/src/components/ui-generator/ui-group-wrappers/switch-group-wrapper/switch-group-wrapper.tsx
+++ b/ui/apps/everest/src/components/ui-generator/ui-group-wrappers/switch-group-wrapper/switch-group-wrapper.tsx
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useState } from 'react';
+import { Box, Collapse, FormControlLabel, Switch } from '@mui/material';
+import { FormCard } from 'components/form-card';
+import { SwitchGroupWrapperProps } from './switch-group-wrapper.types';
+
+// Composes the shared FormCard (title left, control right) and reveals its
+// children on toggle. Children stay mounted while collapsed so their form
+// values and validation persist.
+const SwitchGroupWrapper = ({
+  label,
+  labelCaption,
+  switchLabel = '',
+  defaultExpanded = false,
+  children,
+}: SwitchGroupWrapperProps) => {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  return (
+    <FormCard
+      title={label ?? ''}
+      description={labelCaption}
+      controlComponent={
+        <FormControlLabel
+          labelPlacement="start"
+          label={switchLabel}
+          control={
+            <Switch
+              checked={expanded}
+              onChange={(event) => setExpanded(event.target.checked)}
+            />
+          }
+        />
+      }
+      cardContent={
+        <Collapse in={expanded}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+            {children}
+          </Box>
+        </Collapse>
+      }
+    />
+  );
+};
+
+export default SwitchGroupWrapper;

--- a/ui/apps/everest/src/components/ui-generator/ui-group-wrappers/switch-group-wrapper/switch-group-wrapper.types.ts
+++ b/ui/apps/everest/src/components/ui-generator/ui-group-wrappers/switch-group-wrapper/switch-group-wrapper.types.ts
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ReactNode } from 'react';
+
+export type SwitchGroupWrapperProps = {
+  label?: string;
+  labelCaption?: string;
+  switchLabel?: string;
+  defaultExpanded?: boolean;
+  children: ReactNode;
+};

--- a/ui/apps/everest/src/components/ui-generator/ui-group/ui-group.tsx
+++ b/ui/apps/everest/src/components/ui-generator/ui-group/ui-group.tsx
@@ -16,8 +16,7 @@ export type UIGroupProps = {
 const UIGroup = ({
   groupType,
   children,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  groupParams: _groupParams,
+  groupParams,
   item,
 }: UIGroupProps) => {
   const Component = groupType ? componentGroupMap[groupType] : undefined;
@@ -28,6 +27,7 @@ const UIGroup = ({
         React.createElement(Component, {
           children,
           label: item?.label,
+          ...groupParams,
         })
       ) : (
         <Stack spacing={2}>{children}</Stack>


### PR DESCRIPTION
Sometimes you would group some components in the separate section. This section might be folded by default (like some advanced section). This PR introduces such a card.

Signed-off-by: Sergey Pronin <sp@solanica.io>