### PR TITLE
Fix CLI TTY tests from hanging until timeout

### DIFF
--- a/pkg/cli/backup/delete_test.go
+++ b/pkg/cli/backup/delete_test.go
@@ -348,6 +348,7 @@ func TestDelete_VerboseAloneDoesNotForceNonInteractive(t *testing.T) {
 		Cluster:    "main",
 		JSON:       false,
 		IsTerminal: func() bool { return true },
+		Yes:        true,
 	}
 
 	bd := NewDeleter(Config{Pretty: false}, zap.NewNop().Sugar())

--- a/pkg/cli/backupstorage/delete_test.go
+++ b/pkg/cli/backupstorage/delete_test.go
@@ -295,6 +295,7 @@ func TestDelete_VerboseAloneDoesNotForceNonInteractive(t *testing.T) {
 		Cluster:    "main",
 		JSON:       false,
 		IsTerminal: func() bool { return true },
+		Yes:        true,
 	}
 
 	d := NewDeleter(Config{Pretty: false}, zap.NewNop().Sugar())

--- a/pkg/cli/restore/delete_test.go
+++ b/pkg/cli/restore/delete_test.go
@@ -303,6 +303,7 @@ func TestDelete_VerboseAloneDoesNotForceNonInteractive(t *testing.T) {
 		Namespace:  "everest",
 		Cluster:    "main",
 		JSON:       false,
+		Yes:        true,
 		IsTerminal: func() bool { return true },
 	}
 


### PR DESCRIPTION
If you are using terminal to run tests (i.e. `main test`), following tests block and hang until timeout (20min).

* `TestDelete_VerboseAloneDoesNotForceNonInteractive`
* `TestDelete_VerboseAloneDoesNotForceNonInteractive`
* `TestDelete_VerboseAloneDoesNotForceNonInteractive`

The tests set `IsTerminal: func() bool { return true }` with and no `--yes`, so `Run()` actually launches the interactive prompt and blocks forever on a real terminal. On CI, it passes only because stdin is EOF.

Below I used sigint to kill tests after a while, you can see cli tests were running for long time waiting for input:

```
FAIL	github.com/openeverest/openeverest/v2/pkg/cli/backupstorage	110.651s
```

```
% make test
mkdir -p "/Users/chilagrow/source/openeverest/bin"
Setting up envtest binaries for Kubernetes version 1.36...
/Users/chilagrow/source/openeverest/bin/k8s/1.36.0-darwin-arm64mkdir -p ./public/dist && [ -f ./public/dist/index.html ] || touch ./public/dist/index.html
KUBEBUILDER_ASSETS="$("/Users/chilagrow/source/openeverest/bin/setup-envtest" use 1.36 --bin-dir "/Users/chilagrow/source/openeverest/bin" -p path)" \
	CGO_ENABLED=1 go test -race -timeout=20m ./...
?   	github.com/openeverest/openeverest/v2/api/backup/v1alpha1	[no test files]
?   	github.com/openeverest/openeverest/v2/api/backup/v1alpha1/jobspec	[no test files]
?   	github.com/openeverest/openeverest/v2/api/common/v1alpha1	[no test files]
?   	github.com/openeverest/openeverest/v2/api/core/v1alpha1	[no test files]
?   	github.com/openeverest/openeverest/v2/api/extensions/v1alpha1	[no test files]
?   	github.com/openeverest/openeverest/v2/api/monitoring/v1alpha1	[no test files]
?   	github.com/openeverest/openeverest/v2/api-tests/node_modules/flatted/golang/pkg/flatted	[no test files]
?   	github.com/openeverest/openeverest/v2/cli-tests/node_modules/flatted/golang/pkg/flatted	[no test files]
?   	github.com/openeverest/openeverest/v2/client	[no test files]
?   	github.com/openeverest/openeverest/v2/cmd	[no test files]
?   	github.com/openeverest/openeverest/v2/cmd/cli	[no test files]
?   	github.com/openeverest/openeverest/v2/cmd/config	[no test files]
?   	github.com/openeverest/openeverest/v2/cmd/controller	[no test files]
ok  	github.com/openeverest/openeverest/v2/commands	(cached)
?   	github.com/openeverest/openeverest/v2/commands/accounts	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/auth	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/backup	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/backupclass	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/backupstorage	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/common	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/extension	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/instance	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/namespaces	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/provider	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/restore	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/settings	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/settings/oidc	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/settings/rbac	[no test files]
?   	github.com/openeverest/openeverest/v2/data	[no test files]
?   	github.com/openeverest/openeverest/v2/hack	[no test files]
ok  	github.com/openeverest/openeverest/v2/hack/gen-crds-openapi	(cached)
?   	github.com/openeverest/openeverest/v2/hack/gen-rbac-resources	[no test files]
?   	github.com/openeverest/openeverest/v2/internal/controller/backup	[no test files]
?   	github.com/openeverest/openeverest/v2/internal/controller/extension	[no test files]
?   	github.com/openeverest/openeverest/v2/internal/controller/monitoring	[no test files]
ok  	github.com/openeverest/openeverest/v2/internal/server	(cached)
?   	github.com/openeverest/openeverest/v2/internal/server/api	[no test files]
?   	github.com/openeverest/openeverest/v2/internal/server/handlers	[no test files]
ok  	github.com/openeverest/openeverest/v2/internal/server/handlers/k8s	(cached)
ok  	github.com/openeverest/openeverest/v2/internal/server/handlers/rbac	(cached)
ok  	github.com/openeverest/openeverest/v2/internal/server/handlers/validation	(cached)
ok  	github.com/openeverest/openeverest/v2/internal/tokenregistry	(cached)
?   	github.com/openeverest/openeverest/v2/internal/webhook/monitoring/v1alpha1	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/accounts	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/accounts/cli	(cached)
?   	github.com/openeverest/openeverest/v2/pkg/cli	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/cli/auth	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/backup	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/backupclass	(cached)
{"name":"my-s3","namespace":"everest","deleted":false}
{"name":"my-s3","namespace":"everest","deleted":true}
✅ Backup storage "my-s3" created
NAME          NAMESPACE  TYPE  AGE
s3-primary    everest    s3    1h
s3-secondary  everest    s3    1h
✅ Backup storage "my-s3" created
{"name":"my-s3","namespace":"everest","deleted":true}
{"name":"my-s3","namespace":"everest","deleted":false}
NAME  NAMESPACE  TYPE  AGE
[{"metadata":{"name":"s3-primary","namespace":"everest","creationTimestamp":"2026-08-28T02:13:01Z"},"spec":{"s3":{"bucket":"my-bucket","credentialsSecretRef":{"name":""},"endpointURL":"","region":"us-east-1"},"type":"s3"}}]
NAME          NAMESPACE  TYPE  AGE
s3-primary    everest    s3    1h
s3-secondary  everest2   s3    1h
❓ Delete backup storage "my-s3" in namespace "everest"? (y/N):

y confirm | n abort | Esc/Ctrl+c quit

FAIL	github.com/openeverest/openeverest/v2/pkg/cli/backupstorage	110.651s
ok  	github.com/openeverest/openeverest/v2/pkg/cli/clienterr	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/clientmeta	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/config	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/confirm	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/deletion	(cached)
?   	github.com/openeverest/openeverest/v2/pkg/cli/extension	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/cli/helm	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/helm/utils	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/install	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/instance	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/namespaces	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/provider	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/restore	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/status	(cached)
?   	github.com/openeverest/openeverest/v2/pkg/cli/steps	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/cli/tui	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/cli/uninstall	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/cli/upgrade	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/utils	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/wait	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/cli/waitcmd	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/common	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/convertors	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/events	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/kubernetes	(cached)
?   	github.com/openeverest/openeverest/v2/pkg/kubernetes/informer	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/logger	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/oidc	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/output	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/plugintoken	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/pmm	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/rbac	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/rbac/configmap-adapter	(cached)
?   	github.com/openeverest/openeverest/v2/pkg/rbac/io-reader-adapter	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/rbac/mocks	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/rbac/utils	(cached)
ok  	github.com/openeverest/openeverest/v2/pkg/session	(cached)
?   	github.com/openeverest/openeverest/v2/pkg/utils/must	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/version	(cached)
?   	github.com/openeverest/openeverest/v2/pkg/version_service	[no test files]
ok  	github.com/openeverest/openeverest/v2/provider-runtime/conformance	(cached)
ok  	github.com/openeverest/openeverest/v2/provider-runtime/controller	(cached)
ok  	github.com/openeverest/openeverest/v2/provider-runtime/internal/instanceprep	(cached)
?   	github.com/openeverest/openeverest/v2/provider-runtime/openapi	[no test files]
ok  	github.com/openeverest/openeverest/v2/provider-runtime/reconciler	(cached)
ok  	github.com/openeverest/openeverest/v2/provider-runtime/server	(cached)
?   	github.com/openeverest/openeverest/v2/public	[no test files]
FAIL
make: *** [test] Error 1
```