### PR TITLE
Plugin UI to match core

### DIFF
--- a/docs/process/generic-plugins-design.md
+++ b/docs/process/generic-plugins-design.md
@@ -359,12 +359,14 @@ config) as part of the normal instance lifecycle.
 **Decision: dynamic ESM module loading (Headlamp model), not iframes.**
 
 Rationale:
-- Tight UX integration — shared MUI theme, React context, router state.
+- Tight UX integration — host-themed components, React context, router state.
 - Iframes break deep-link navigation, inject a separate auth session, and cannot
   contribute sidebar entries or theme overrides in a seamless way.
-- Import maps let the host provide singleton instances of `react`, `react-dom`,
-  `@mui/material`, and `react-router` so plugin bundles stay small and the host
-  retains control over versions.
+- A browser import map lets the host provide the **React** singleton (`react`,
+  `react-dom`, `react/jsx-runtime`) so hooks and context work across the
+  host/plugin boundary. MUI/Emotion are *not* shared — each plugin bundles its
+  own pinned copy via `@openeverest/ui-lib` (Model B, §7.4), keeping plugins
+  independent across host UI upgrades.
 
 At shell startup:
 
@@ -403,17 +405,25 @@ useCluster(id: string): DatabaseCluster | undefined
 useNamespaces(): string[]
 useRBAC(): { can: (verb: string, resource: string) => boolean }
 
-// Re-exported singletons (resolved from host import map)
-export { React, ReactDOM, MUI, ReactRouter }
+// React is resolved from the host import map (do not bundle it).
+// Host-themed UI comes from a separate package, bundled into the plugin:
+//   import { PluginThemeProvider, Box, Button, Table } from '@openeverest/ui-lib'
 ```
+
+The `PluginApi` passed to `register()` also carries `cssNonce` (for the plugin's
+Emotion cache under CSP), `hostVersion`, and `uiContractVersion` (the shared
+React major). The host checks `Plugin.spec.compatibleHostVersions` at load time
+and refuses an incompatible plugin rather than rendering it detached/unthemed.
 
 ### 7.3 Bundle requirements
 
 Plugin authors produce a single ESM file with:
 
 - Default export: `register(api: PluginApi): void`
-- No bundled copies of `react`, `@mui/material`, or `react-router` — import them
-  from the SDK re-exports so the import map resolves to the host's singleton.
+- **React external** (`react`, `react-dom`, `react/jsx-runtime`) — resolved to
+  the host singleton via the import map. Never bundle a second React.
+- **MUI + Emotion bundled** (pulled in via `@openeverest/ui-lib`) so the plugin
+  owns its design-system version.
 - Target: `esnext` modules, no dynamic `require()`.
 
 ### 7.4 UI/UX consistency requirements
@@ -422,19 +432,35 @@ Plugins **must** use the host's existing design system and styling infrastructur
 The goal is that a user cannot visually distinguish plugin-contributed UI from
 core UI — plugins feel native, not bolted on.
 
+**Design-system delivery (Model B — see issue #2661).** Plugins do *not* import
+`@mui/material` directly and do *not* share the host's MUI instance. Instead:
+
+- The plugin depends on **`@openeverest/ui-lib`**, an npm package that bundles
+  its *own pinned* MUI + Emotion and re-exports a curated set of host-themed
+  components plus a `PluginThemeProvider`. Because each plugin carries its own
+  MUI, the host can upgrade its MUI without breaking already-built plugins.
+- The host owns the **design tokens** as CSS variables (its theme enables MUI
+  `cssVariables`, emitting `--mui-*` on `:root`). `PluginThemeProvider` builds a
+  theme whose palette references those variables, so brand and light/dark
+  changes reach the plugin live through the CSS cascade — no rebuild. The host
+  publishes the active mode on `document.documentElement[data-everest-color-scheme]`.
+- **React is the only shared runtime**, provided through the host import map.
+  The compatibility contract therefore tracks the React major.
+
 **Required:**
 
-- **MUI components only.** Use `@mui/material` (provided by the host via import
-  map) for all UI elements — buttons, tables, dialogs, forms, typography, icons.
-  Do not import alternative component libraries (Ant Design, Chakra, etc.).
-- **Host theme.** Use the host's MUI `ThemeProvider` context (automatically
-  inherited). Do not override `createTheme()` or inject competing theme
-  providers. Access theme tokens via `useTheme()` or the `sx` prop.
+- **Use `@openeverest/ui-lib` components.** Import UI primitives from
+  `@openeverest/ui-lib` (not `@mui/material` directly). Do not import alternative
+  component libraries (Ant Design, Chakra, etc.).
+- **Host theme via tokens.** Wrap plugin UI in `PluginThemeProvider` and access
+  theme values via `useTheme()` / the `sx` prop. Do not hardcode a competing
+  palette; the theme is bound to host CSS variables so it inherits the host
+  palette and dark mode automatically.
 - **`sx` prop and `styled()` for styling.** Use MUI's `sx` prop or the `styled`
-  utility (Emotion-based, shared with the host) for custom styles. Do not
-  introduce separate CSS-in-JS runtimes (styled-components, Tailwind runtime,
-  Stitches, etc.) — multiple runtimes cause specificity conflicts and increase
-  bundle size.
+  utility (Emotion-based) for custom styles, scoped through the plugin's
+  namespaced Emotion cache (from `PluginThemeProvider`). Do not introduce
+  separate CSS-in-JS runtimes (styled-components, Tailwind runtime, Stitches,
+  etc.) — multiple runtimes cause specificity conflicts and increase bundle size.
 - **No global CSS.** Do not inject `<style>` tags, import `.css` files that
   produce global selectors, or manipulate `document.styleSheets`. Global styles
   can break the host or other plugins. Scoped styles via `sx`/`styled` are the
@@ -446,7 +472,7 @@ core UI — plugins feel native, not bolted on.
 - **Layout patterns.** Use MUI layout primitives (`Box`, `Stack`, `Grid`,
   `Container`) for page structure. Follow the host's existing spacing rhythm
   (typically `theme.spacing(2)` / `theme.spacing(3)` between sections).
-- **Icons.** Use `@mui/icons-material` (provided by the host). For custom icons
+- **Icons.** Use icons re-exported by `@openeverest/ui-lib`. For custom icons
   not in the MUI set, use inline SVG wrapped in `SvgIcon`.
 
 **Prohibited:**

--- a/internal/server/everest.go
+++ b/internal/server/everest.go
@@ -59,6 +59,7 @@ import (
 	"github.com/openeverest/openeverest/v2/pkg/kubernetes"
 	"github.com/openeverest/openeverest/v2/pkg/oidc"
 	"github.com/openeverest/openeverest/v2/pkg/session"
+	"github.com/openeverest/openeverest/v2/pkg/version"
 	"github.com/openeverest/openeverest/v2/public"
 )
 
@@ -221,7 +222,12 @@ func (e *EverestServer) initHTTPServer(ctx context.Context) error {
 			// See the securityHeaders middleware for more information.
 			return c.Render(
 				http.StatusOK, "index.html",
-				map[string]any{"CSPNonce": secure.CSPNonce(c.Request().Context())},
+				map[string]any{
+					"CSPNonce": secure.CSPNonce(c.Request().Context()),
+					// Published so the UI can enforce a plugin's
+					// spec.compatibleHostVersions at load time.
+					"EverestVersion": version.Version,
+				},
 			)
 		}, e.securityHeaders(),
 	)

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -121,6 +121,10 @@ func (e *EverestServer) securityHeaders() echo.MiddlewareFunc {
 			// The YAML editor draws its inline lint underlines as data: SVG
 			// background-images (@codemirror/lint), so allow data: images.
 			cspbuilder.ImgSrc: {CSPSelf, "data:"},
+			// Same-origin scripts ('self') cover the app and plugin bundles;
+			// $NONCE allows the inline <script type="importmap"> that maps
+			// plugins' shared React/MUI specifiers to host modules.
+			cspbuilder.ScriptSrc: {CSPSelf, "$NONCE"},
 			cspbuilder.StyleSrc: {
 				CSPSelf,
 				// $NONCE will be replaced by the real nonce value

--- a/internal/server/plugins.go
+++ b/internal/server/plugins.go
@@ -118,14 +118,15 @@ func (pp *pluginProxy) listPluginsHandler(c echo.Context) error {
 	}
 
 	type pluginDescriptor struct {
-		Name            string                     `json:"name"`
-		DisplayName     string                     `json:"displayName"`
-		Description     string                     `json:"description,omitempty"`
-		Version         string                     `json:"version,omitempty"`
-		Vendor          string                     `json:"vendor,omitempty"`
-		Icon            string                     `json:"icon,omitempty"`
-		BundleURL       string                     `json:"bundleUrl"`
-		ExtensionPoints []extensionPointDescriptor `json:"extensionPoints,omitempty"`
+		Name                   string                     `json:"name"`
+		DisplayName            string                     `json:"displayName"`
+		Description            string                     `json:"description,omitempty"`
+		Version                string                     `json:"version,omitempty"`
+		Vendor                 string                     `json:"vendor,omitempty"`
+		Icon                   string                     `json:"icon,omitempty"`
+		BundleURL              string                     `json:"bundleUrl"`
+		CompatibleHostVersions string                     `json:"compatibleHostVersions,omitempty"`
+		ExtensionPoints        []extensionPointDescriptor `json:"extensionPoints,omitempty"`
 	}
 
 	plugins, err := pp.kubeConnector.ListPlugins(c.Request().Context())
@@ -165,14 +166,15 @@ func (pp *pluginProxy) listPluginsHandler(c echo.Context) error {
 			}
 		}
 		descriptors = append(descriptors, pluginDescriptor{
-			Name:            p.Name,
-			DisplayName:     p.Spec.DisplayName,
-			Description:     p.Spec.Description,
-			Version:         p.Spec.Version,
-			Vendor:          p.Spec.Vendor,
-			Icon:            resolvePluginAssetPath(p.Name, p.Spec.Icon),
-			BundleURL:       path.Join("/v1/plugins", p.Name, bundlePath),
-			ExtensionPoints: extPoints,
+			Name:                   p.Name,
+			DisplayName:            p.Spec.DisplayName,
+			Description:            p.Spec.Description,
+			Version:                p.Spec.Version,
+			Vendor:                 p.Spec.Vendor,
+			Icon:                   resolvePluginAssetPath(p.Name, p.Spec.Icon),
+			BundleURL:              path.Join("/v1/plugins", p.Name, bundlePath),
+			CompatibleHostVersions: p.Spec.CompatibleHostVersions,
+			ExtensionPoints:        extPoints,
 		})
 	}
 	return c.JSON(http.StatusOK, descriptors)

--- a/ui/apps/everest/index.html
+++ b/ui/apps/everest/index.html
@@ -6,6 +6,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="csp-nonce" content="{{.CSPNonce}}" />
     <title>OpenEverest</title>
+    <script type="importmap" nonce="{{.CSPNonce}}">
+      {
+        "imports": {
+          "react": "/static/plugin-runtime/react.js",
+          "react-dom": "/static/plugin-runtime/react-dom.js",
+          "react/jsx-runtime": "/static/plugin-runtime/react-jsx-runtime.js",
+          "@mui/material/colors": "/static/plugin-runtime/mui-colors.js"
+        }
+      }
+    </script>
     <style id="_goober" nonce="{{.CSPNonce}}">
       /* do not remove */
     </style>

--- a/ui/apps/everest/index.html
+++ b/ui/apps/everest/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/static/everest.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="csp-nonce" content="{{.CSPNonce}}" />
+    <meta name="everest-version" content="{{.EverestVersion}}" />
     <title>OpenEverest</title>
     <script type="importmap" nonce="{{.CSPNonce}}">
       {

--- a/ui/apps/everest/public/static/plugin-runtime/mui-colors.js
+++ b/ui/apps/everest/public/static/plugin-runtime/mui-colors.js
@@ -1,0 +1,29 @@
+// Import-map target for `@mui/material/colors` in plugin bundles.
+// MUI's createPalette self-imports this barrel with a bare specifier that plugin
+// bundlers can't resolve; the host shares these static color scales instead.
+const C = window.__EVEREST_PLUGIN_RUNTIME__.MuiColors;
+
+export default C;
+
+export const {
+  common,
+  red,
+  pink,
+  purple,
+  deepPurple,
+  indigo,
+  blue,
+  lightBlue,
+  cyan,
+  teal,
+  green,
+  lightGreen,
+  lime,
+  yellow,
+  amber,
+  orange,
+  deepOrange,
+  brown,
+  grey,
+  blueGrey,
+} = C;

--- a/ui/apps/everest/public/static/plugin-runtime/react-dom.js
+++ b/ui/apps/everest/public/static/plugin-runtime/react-dom.js
@@ -1,0 +1,16 @@
+// Import-map target for the bare `react-dom` specifier in plugin bundles.
+// Re-exports the host's single ReactDOM instance (used by MUI portals).
+const RD = window.__EVEREST_PLUGIN_RUNTIME__.ReactDOM;
+
+export default RD;
+
+export const {
+  createPortal,
+  flushSync,
+  unstable_batchedUpdates,
+  findDOMNode,
+  render,
+  hydrate,
+  unmountComponentAtNode,
+  version,
+} = RD;

--- a/ui/apps/everest/public/static/plugin-runtime/react-jsx-runtime.js
+++ b/ui/apps/everest/public/static/plugin-runtime/react-jsx-runtime.js
@@ -1,0 +1,6 @@
+// Import-map target for `react/jsx-runtime` (automatic JSX) in plugin bundles.
+const JSX = window.__EVEREST_PLUGIN_RUNTIME__.ReactJSXRuntime;
+
+export const jsx = JSX.jsx;
+export const jsxs = JSX.jsxs;
+export const Fragment = JSX.Fragment;

--- a/ui/apps/everest/public/static/plugin-runtime/react.js
+++ b/ui/apps/everest/public/static/plugin-runtime/react.js
@@ -1,0 +1,40 @@
+// Import-map target for the bare `react` specifier in plugin bundles.
+// Re-exports the host's single React instance (see src/plugin-runtime-host.ts).
+const R = window.__EVEREST_PLUGIN_RUNTIME__.React;
+
+export default R;
+
+export const {
+  Children,
+  Component,
+  Fragment,
+  Profiler,
+  PureComponent,
+  StrictMode,
+  Suspense,
+  cloneElement,
+  createContext,
+  createElement,
+  createRef,
+  forwardRef,
+  isValidElement,
+  lazy,
+  memo,
+  startTransition,
+  useCallback,
+  useContext,
+  useDebugValue,
+  useDeferredValue,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useInsertionEffect,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  useTransition,
+  version,
+} = R;

--- a/ui/apps/everest/src/contexts/plugins/plugin-version.test.ts
+++ b/ui/apps/everest/src/contexts/plugins/plugin-version.test.ts
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { parseVersion, satisfiesHostVersion } from './plugin-version';
+
+describe('parseVersion', () => {
+  it('accepts the v-prefixed versions Everest actually reports', () => {
+    // RELEASE_VERSION is v-prefixed and may carry a build suffix.
+    expect(parseVersion('v2.1.3')).toEqual([2, 1, 3]);
+    expect(parseVersion('v0.3.0-1-a93bef')).toEqual([0, 3, 0]);
+    expect(parseVersion('2.1.3')).toEqual([2, 1, 3]);
+  });
+
+  it('returns null for values that are not versions', () => {
+    expect(parseVersion('dev')).toBeNull();
+    // `vite dev` serves index.html without running the Go template.
+    expect(parseVersion('{{.EverestVersion}}')).toBeNull();
+    expect(parseVersion('')).toBeNull();
+  });
+});
+
+describe('satisfiesHostVersion', () => {
+  it('permits a plugin that declares no range', () => {
+    expect(satisfiesHostVersion('v2.1.0', undefined)).toBe(true);
+    expect(satisfiesHostVersion('v2.1.0', '')).toBe(true);
+  });
+
+  it('never gates when the host version is unusable', () => {
+    expect(satisfiesHostVersion('dev', '>=2.0.0')).toBe(true);
+    expect(satisfiesHostVersion('{{.EverestVersion}}', '>=2.0.0')).toBe(true);
+  });
+
+  it('never gates on a local build (v0.0.0-<sha>)', () => {
+    expect(satisfiesHostVersion('v0.0.0-a93bef', '>=2.0.0')).toBe(true);
+  });
+
+  it('accepts a host inside the declared range', () => {
+    expect(satisfiesHostVersion('v2.1.0', '>=2.0.0 <3.0.0')).toBe(true);
+    expect(satisfiesHostVersion('v2.1.0', '^2.0.0')).toBe(true);
+    expect(satisfiesHostVersion('v2.1.4', '~2.1.0')).toBe(true);
+  });
+
+  it('rejects a host outside the declared range', () => {
+    expect(satisfiesHostVersion('v3.0.0', '>=2.0.0 <3.0.0')).toBe(false);
+    expect(satisfiesHostVersion('v1.9.0', '>=2.0.0')).toBe(false);
+    expect(satisfiesHostVersion('v3.0.0', '^2.0.0')).toBe(false);
+    expect(satisfiesHostVersion('v2.2.0', '~2.1.0')).toBe(false);
+  });
+
+  it('supports || alternatives', () => {
+    expect(satisfiesHostVersion('v3.1.0', '^2.0.0 || ^3.0.0')).toBe(true);
+    expect(satisfiesHostVersion('v4.0.0', '^2.0.0 || ^3.0.0')).toBe(false);
+  });
+
+  it('tolerates a v-prefixed range', () => {
+    expect(satisfiesHostVersion('v2.1.0', '>=v2.0.0')).toBe(true);
+    expect(satisfiesHostVersion('v1.0.0', '>=v2.0.0')).toBe(false);
+  });
+});

--- a/ui/apps/everest/src/contexts/plugins/plugin-version.ts
+++ b/ui/apps/everest/src/contexts/plugins/plugin-version.ts
@@ -1,0 +1,84 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Host-version handling for the plugin compatibility check, kept out of the
+// context module so it can be unit tested without pulling in the provider.
+
+/**
+ * Everest reports versions with a leading `v` and an optional build suffix
+ * (e.g. "v0.3.0-1-a93bef"). Returns null when the value isn't a usable version
+ * — including the "dev" fallback and the unrendered Go template placeholder
+ * that `vite dev` serves, since it doesn't run the server-side template.
+ */
+export function parseVersion(value: string): [number, number, number] | null {
+  const m = value
+    .trim()
+    .replace(/^v/i, '')
+    .match(/^(\d+)\.(\d+)\.(\d+)/);
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+/**
+ * Minimal semver-range satisfaction for the common comparators used in the
+ * Plugin CR's compatibleHostVersions (">=2.0.0 <3.0.0", "^2.1.0", "~2.1.0").
+ * Returns true when the range is empty/unparseable so an unknown range never
+ * silently blocks a plugin (advisory contract, first-party ecosystem).
+ */
+export function satisfiesHostVersion(version: string, range?: string): boolean {
+  if (!range) {
+    return true;
+  }
+  const host = parseVersion(version);
+  // No usable host version, or a local build (RELEASE_VERSION defaults to
+  // v0.0.0-<sha>): never gate plugins during development.
+  if (!host || (host[0] === 0 && host[1] === 0 && host[2] === 0)) {
+    return true;
+  }
+  const cmp = (a: [number, number, number], b: [number, number, number]) =>
+    a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+
+  const evalClause = (clause: string): boolean => {
+    const comparators = clause.trim().split(/\s+/).filter(Boolean);
+    if (comparators.length === 0) {
+      return true;
+    }
+    return comparators.every((c) => {
+      const m = c.match(/^(>=|<=|>|<|=|\^|~)?(v?\d+\.\d+\.\d+)/i);
+      if (!m) {
+        return true;
+      }
+      const op = m[1] || '=';
+      const target = parseVersion(m[2]);
+      if (!target) {
+        return true;
+      }
+      if (op === '^') {
+        const upper: [number, number, number] = [target[0] + 1, 0, 0];
+        return cmp(host, target) >= 0 && cmp(host, upper) < 0;
+      }
+      if (op === '~') {
+        const upper: [number, number, number] = [target[0], target[1] + 1, 0];
+        return cmp(host, target) >= 0 && cmp(host, upper) < 0;
+      }
+      const c0 = cmp(host, target);
+      if (op === '>=') return c0 >= 0;
+      if (op === '<=') return c0 <= 0;
+      if (op === '>') return c0 > 0;
+      if (op === '<') return c0 < 0;
+      return c0 === 0;
+    });
+  };
+
+  return range.split('||').some((clause) => evalClause(clause));
+}

--- a/ui/apps/everest/src/contexts/plugins/plugins.context.tsx
+++ b/ui/apps/everest/src/contexts/plugins/plugins.context.tsx
@@ -74,9 +74,8 @@ function getHostVersion(): string {
 
 function getCSPNonce(): string {
   return (
-    document
-      .querySelector("meta[name='csp-nonce']")
-      ?.getAttribute('content') || ''
+    document.querySelector("meta[name='csp-nonce']")?.getAttribute('content') ||
+    ''
   );
 }
 
@@ -128,9 +127,7 @@ function satisfiesHostVersion(version: string, range?: string): boolean {
     });
   };
 
-  return range
-    .split('||')
-    .some((clause) => evalClause(clause));
+  return range.split('||').some((clause) => evalClause(clause));
 }
 
 // Build the PluginApi object that the host passes to each plugin's register().

--- a/ui/apps/everest/src/contexts/plugins/plugins.context.tsx
+++ b/ui/apps/everest/src/contexts/plugins/plugins.context.tsx
@@ -44,6 +44,7 @@ interface PluginDescriptor {
   name: string;
   displayName: string;
   bundleUrl: string;
+  compatibleHostVersions?: string;
   extensionPoints?: ExtensionPointDescriptor[];
 }
 
@@ -58,6 +59,79 @@ const PluginContext = createContext<PluginContextValue>({
 });
 
 export const usePlugins = () => useContext(PluginContext);
+
+// Coarse UI contract tied to the shared React major (see issue #2661). Plugins
+// bundle their own MUI, so React is the only runtime they share with the host.
+const UI_CONTRACT_VERSION = React.version.split('.')[0];
+
+function getHostVersion(): string {
+  return (
+    document
+      .querySelector("meta[name='everest-version']")
+      ?.getAttribute('content') || 'dev'
+  );
+}
+
+function getCSPNonce(): string {
+  return (
+    document
+      .querySelector("meta[name='csp-nonce']")
+      ?.getAttribute('content') || ''
+  );
+}
+
+// Minimal semver-range satisfaction for the common comparators used in the
+// Plugin CR's compatibleHostVersions (">=2.0.0 <3.0.0", "^2.1.0", "~2.1.0").
+// Returns true when the range is empty/unparseable so an unknown range never
+// silently blocks a plugin (advisory contract, first-party ecosystem).
+function satisfiesHostVersion(version: string, range?: string): boolean {
+  if (!range || version === 'dev') {
+    return true;
+  }
+  const parse = (v: string): [number, number, number] | null => {
+    const m = v.match(/^(\d+)\.(\d+)\.(\d+)/);
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+  };
+  const host = parse(version);
+  if (!host) {
+    return true;
+  }
+  const cmp = (a: [number, number, number], b: [number, number, number]) =>
+    a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+
+  const evalClause = (clause: string): boolean => {
+    const comparators = clause.trim().split(/\s+/).filter(Boolean);
+    if (comparators.length === 0) {
+      return true;
+    }
+    return comparators.every((c) => {
+      const m = c.match(/^(>=|<=|>|<|=|\^|~)?(\d+\.\d+\.\d+)/);
+      if (!m) {
+        return true;
+      }
+      const op = m[1] || '=';
+      const target = parse(m[2])!;
+      if (op === '^') {
+        const upper: [number, number, number] = [target[0] + 1, 0, 0];
+        return cmp(host, target) >= 0 && cmp(host, upper) < 0;
+      }
+      if (op === '~') {
+        const upper: [number, number, number] = [target[0], target[1] + 1, 0];
+        return cmp(host, target) >= 0 && cmp(host, upper) < 0;
+      }
+      const c0 = cmp(host, target);
+      if (op === '>=') return c0 >= 0;
+      if (op === '<=') return c0 <= 0;
+      if (op === '>') return c0 > 0;
+      if (op === '<') return c0 < 0;
+      return c0 === 0;
+    });
+  };
+
+  return range
+    .split('||')
+    .some((clause) => evalClause(clause));
+}
 
 // Build the PluginApi object that the host passes to each plugin's register().
 // When allowedTypes is provided, only extensions whose type is in the set will be registered.
@@ -88,6 +162,10 @@ function createPluginApi(
       const url = `/v1/plugins/${pluginName}${path}`;
       return window.fetch(url, { ...init, headers });
     },
+
+    cssNonce: getCSPNonce(),
+    hostVersion: getHostVersion(),
+    uiContractVersion: UI_CONTRACT_VERSION,
   };
 }
 
@@ -129,6 +207,20 @@ export const PluginProvider = ({ children }: { children: ReactNode }) => {
 
       for (const descriptor of descriptors) {
         try {
+          // Reject incompatible plugins loudly rather than rendering a detached
+          // or unthemed UI (see issue #2661).
+          if (
+            !satisfiesHostVersion(
+              getHostVersion(),
+              descriptor.compatibleHostVersions
+            )
+          ) {
+            // eslint-disable-next-line no-console
+            console.error(
+              `[plugins] Skipping "${descriptor.name}": requires host ${descriptor.compatibleHostVersions}, host is ${getHostVersion()}.`
+            );
+            continue;
+          }
           const mod = await import(/* @vite-ignore */ descriptor.bundleUrl);
           const registerFn: PluginRegisterFn = mod.default || mod.register;
           if (typeof registerFn === 'function') {

--- a/ui/apps/everest/src/contexts/plugins/plugins.context.tsx
+++ b/ui/apps/everest/src/contexts/plugins/plugins.context.tsx
@@ -26,6 +26,7 @@ import type {
 } from '@openeverest/plugin-sdk';
 import AuthContext from 'contexts/auth/auth.context';
 import { getAuthToken } from 'api/session-token';
+import { satisfiesHostVersion } from './plugin-version';
 
 export interface PluginRegistration {
   name: string;
@@ -77,57 +78,6 @@ function getCSPNonce(): string {
     document.querySelector("meta[name='csp-nonce']")?.getAttribute('content') ||
     ''
   );
-}
-
-// Minimal semver-range satisfaction for the common comparators used in the
-// Plugin CR's compatibleHostVersions (">=2.0.0 <3.0.0", "^2.1.0", "~2.1.0").
-// Returns true when the range is empty/unparseable so an unknown range never
-// silently blocks a plugin (advisory contract, first-party ecosystem).
-function satisfiesHostVersion(version: string, range?: string): boolean {
-  if (!range || version === 'dev') {
-    return true;
-  }
-  const parse = (v: string): [number, number, number] | null => {
-    const m = v.match(/^(\d+)\.(\d+)\.(\d+)/);
-    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
-  };
-  const host = parse(version);
-  if (!host) {
-    return true;
-  }
-  const cmp = (a: [number, number, number], b: [number, number, number]) =>
-    a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
-
-  const evalClause = (clause: string): boolean => {
-    const comparators = clause.trim().split(/\s+/).filter(Boolean);
-    if (comparators.length === 0) {
-      return true;
-    }
-    return comparators.every((c) => {
-      const m = c.match(/^(>=|<=|>|<|=|\^|~)?(\d+\.\d+\.\d+)/);
-      if (!m) {
-        return true;
-      }
-      const op = m[1] || '=';
-      const target = parse(m[2])!;
-      if (op === '^') {
-        const upper: [number, number, number] = [target[0] + 1, 0, 0];
-        return cmp(host, target) >= 0 && cmp(host, upper) < 0;
-      }
-      if (op === '~') {
-        const upper: [number, number, number] = [target[0], target[1] + 1, 0];
-        return cmp(host, target) >= 0 && cmp(host, upper) < 0;
-      }
-      const c0 = cmp(host, target);
-      if (op === '>=') return c0 >= 0;
-      if (op === '<=') return c0 <= 0;
-      if (op === '>') return c0 > 0;
-      if (op === '<') return c0 < 0;
-      return c0 === 0;
-    });
-  };
-
-  return range.split('||').some((clause) => evalClause(clause));
 }
 
 // Build the PluginApi object that the host passes to each plugin's register().

--- a/ui/apps/everest/src/main.tsx
+++ b/ui/apps/everest/src/main.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+// Must run before any plugin bundle is dynamically imported.
+import './plugin-runtime-host';
 import ReactDOM from 'react-dom/client';
 import App from 'App';
 

--- a/ui/apps/everest/src/main.tsx
+++ b/ui/apps/everest/src/main.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /* eslint-disable no-console */
 // Must run before any plugin bundle is dynamically imported.
 import './plugin-runtime-host';

--- a/ui/apps/everest/src/plugin-runtime-host.ts
+++ b/ui/apps/everest/src/plugin-runtime-host.ts
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Exposes the host's React runtime as a global so dynamically imported plugin
+// bundles resolve `react`/`react-dom` to the host copy through the import map
+// in index.html. A plugin that bundles its own MUI must still share the host
+// React, otherwise it loads a second React instance and hooks/theme context break.
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as ReactJSXRuntime from 'react/jsx-runtime';
+// MUI's createPalette self-imports the `@mui/material/colors` barrel with a bare
+// specifier that plugin bundlers (Vite lib mode) can't resolve. These are static
+// color-scale constants, so the host shares them via the import map; the plugin's
+// own MUI (components, theme) still stays bundled and independent.
+import * as MuiColors from '@mui/material/colors';
+
+declare global {
+  interface Window {
+    __EVEREST_PLUGIN_RUNTIME__?: {
+      React: typeof React;
+      ReactDOM: typeof ReactDOM;
+      ReactJSXRuntime: typeof ReactJSXRuntime;
+      MuiColors: typeof MuiColors;
+    };
+  }
+}
+
+window.__EVEREST_PLUGIN_RUNTIME__ = {
+  React,
+  ReactDOM,
+  ReactJSXRuntime,
+  MuiColors,
+};

--- a/ui/packages/design/src/theme-context-provider/theme-context-provider.tsx
+++ b/ui/packages/design/src/theme-context-provider/theme-context-provider.tsx
@@ -1,6 +1,7 @@
-import { useState, useMemo, useCallback } from 'react';
-import { ThemeProvider } from '@emotion/react';
-import { PaletteMode, createTheme } from '@mui/material';
+import { useState, useMemo, useCallback, useEffect } from 'react';
+// MUI's ThemeProvider (not emotion's) is required so cssVariables injects the
+// `--mui-*` custom properties; it also provides the emotion theme context.
+import { PaletteMode, createTheme, ThemeProvider } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeContextProviderProps } from './theme-context-provider.types';
 import { ColorModeContext } from './theme-contexts';
@@ -36,9 +37,20 @@ const ThemeContextProvider = ({
   }, [saveColorModeOnLocalStorage]);
 
   const theme = useMemo(
-    () => createTheme(themeOptions(colorMode)),
+    // cssVariables emits the palette/spacing/typography as `--mui-*` custom
+    // properties on :root so plugins with their own MUI can inherit host tokens.
+    () => createTheme({ ...themeOptions(colorMode), cssVariables: true }),
     [colorMode, themeOptions]
   );
+
+  // Published so plugins (which bundle their own MUI) can observe the active
+  // color scheme and re-render, since they can't read the host's React context.
+  useEffect(() => {
+    document.documentElement.setAttribute(
+      'data-everest-color-scheme',
+      colorMode
+    );
+  }, [colorMode]);
 
   return (
     <ColorModeContext.Provider value={{ colorMode, toggleColorMode }}>

--- a/ui/packages/design/src/theme-context-provider/theme-context-provider.tsx
+++ b/ui/packages/design/src/theme-context-provider/theme-context-provider.tsx
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useState, useMemo, useCallback, useEffect } from 'react';
 // MUI's ThemeProvider (not emotion's) is required so cssVariables injects the
 // `--mui-*` custom properties; it also provides the emotion theme context.

--- a/ui/packages/plugin-sdk/src/types.ts
+++ b/ui/packages/plugin-sdk/src/types.ts
@@ -252,6 +252,21 @@ export interface PluginApi {
    * The host automatically attaches the auth token.
    */
   fetch(path: string, init?: RequestInit): Promise<Response>;
+
+  /**
+   * CSP nonce for <style> tags the plugin injects (e.g. its Emotion cache).
+   * Pass this to PluginThemeProvider from @openeverest/ui-lib.
+   */
+  cssNonce: string;
+
+  /** Host application version (semver), or "dev" when unknown. */
+  hostVersion: string;
+
+  /**
+   * Coarse UI-contract version, tied to the shared React major. Plugins built
+   * against a different contract may be rejected by the host at load time.
+   */
+  uiContractVersion: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/packages/plugin-ui-lib/package.json
+++ b/ui/packages/plugin-ui-lib/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@openeverest/plugin-sdk",
-  "version": "0.3.0",
-  "description": "SDK for building OpenEverest plugins",
+  "name": "@openeverest/ui-lib",
+  "version": "0.1.2",
+  "description": "Host-themed MUI components for OpenEverest plugins. Bundles its own MUI; inherits the host design system through CSS variables so plugins stay independent across host UI upgrades.",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
   "type": "module",
@@ -18,7 +18,15 @@
     "build": "rollup -c"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "dependencies": {
+    "@emotion/cache": "^11.11.0",
+    "@emotion/react": "^11.11.0",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^7.3.0",
+    "@mui/material": "^7.3.0"
   },
   "devDependencies": {
     "@percona/tsconfig": "workspace:*",
@@ -30,7 +38,6 @@
     "react": "^18.2.0",
     "rollup": "^4.22.4",
     "rollup-plugin-dts": "^6.1.0",
-    "rollup-plugin-peer-deps-external": "^2.2.4",
     "typescript": "^5.2.2"
   }
 }

--- a/ui/packages/plugin-ui-lib/rollup.config.js
+++ b/ui/packages/plugin-ui-lib/rollup.config.js
@@ -1,0 +1,39 @@
+import commonjs from "@rollup/plugin-commonjs";
+import resolve from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+import dts from "rollup-plugin-dts";
+import terser from "@rollup/plugin-terser";
+
+// MUI/Emotion/React stay external: the consuming plugin bundles its own pinned
+// copies. React is resolved to the host singleton via the host import map.
+const external = (id) =>
+  /^react($|\/)/.test(id) ||
+  /^react-dom($|\/)/.test(id) ||
+  /^@mui\//.test(id) ||
+  /^@emotion\//.test(id);
+
+export default [
+  {
+    input: "src/index.ts",
+    output: [
+      {
+        file: "dist/esm/index.js",
+        format: "esm",
+        sourcemap: true,
+      },
+    ],
+    external,
+    plugins: [
+      resolve(),
+      commonjs(),
+      typescript({ tsconfig: "./tsconfig.json" }),
+      terser(),
+    ],
+  },
+  {
+    input: "dist/esm/typings/index.d.ts",
+    output: [{ file: "dist/index.d.ts", format: "esm" }],
+    external,
+    plugins: [dts()],
+  },
+];

--- a/ui/packages/plugin-ui-lib/src/index.ts
+++ b/ui/packages/plugin-ui-lib/src/index.ts
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export {
+  PluginThemeProvider,
+  useHostColorMode,
+} from './plugin-theme-provider';
+export type { PluginThemeProviderProps } from './plugin-theme-provider';
+
+// Curated re-exports of host-themed MUI primitives. Plugins import these
+// instead of `@mui/material` directly so the stable surface can be governed
+// over time. React stays external (host singleton via the import map).
+export {
+  Box,
+  Stack,
+  Grid,
+  Container,
+  Paper,
+  Card,
+  CardContent,
+  CardHeader,
+  CardActions,
+  Typography,
+  Button,
+  IconButton,
+  Link,
+  TextField,
+  InputBase,
+  InputAdornment,
+  Select,
+  MenuItem,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  Checkbox,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Drawer,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Divider,
+  Chip,
+  Tooltip,
+  Alert,
+  AlertTitle,
+  CircularProgress,
+  LinearProgress,
+  Skeleton,
+  Menu,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemButton,
+  ListItemIcon,
+  Collapse,
+  Tabs,
+  Tab,
+  Portal,
+  Snackbar,
+  Avatar,
+  useTheme,
+  useMediaQuery,
+  styled,
+  alpha,
+} from '@mui/material';
+
+export type { SxProps, Theme } from '@mui/material';

--- a/ui/packages/plugin-ui-lib/src/plugin-theme-provider.tsx
+++ b/ui/packages/plugin-ui-lib/src/plugin-theme-provider.tsx
@@ -1,0 +1,158 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import createCache from '@emotion/cache';
+import { CacheProvider } from '@emotion/react';
+import {
+  createTheme,
+  ThemeProvider,
+  type PaletteMode,
+  type PaletteOptions,
+  type SimplePaletteColorOptions,
+} from '@mui/material';
+
+// The host publishes its active color scheme here (see @percona/design
+// ThemeContextProvider). Plugins can't read the host React context because
+// they bundle their own MUI, so they observe this attribute instead.
+const HOST_COLOR_SCHEME_ATTR = 'data-everest-color-scheme';
+
+// Reads a host-owned `--mui-*` CSS variable's *computed* value. We resolve to
+// concrete colors rather than passing `var(...)` into the theme, because MUI's
+// color functions (alpha/darken/lighten) can't parse `var()` strings (error #9).
+function readVar(name: string): string {
+  if (typeof document === 'undefined') {
+    return '';
+  }
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+}
+
+function colorFromHost(name: string): SimplePaletteColorOptions | undefined {
+  const main = readVar(`--mui-palette-${name}-main`);
+  if (!main) {
+    return undefined;
+  }
+  const color: SimplePaletteColorOptions = { main };
+  const dark = readVar(`--mui-palette-${name}-dark`);
+  const light = readVar(`--mui-palette-${name}-light`);
+  if (dark) color.dark = dark;
+  if (light) color.light = light;
+  // contrastText is intentionally NOT read from the host: some host tokens set a
+  // low-contrast value; letting MUI derive it from `main` keeps filled chips/
+  // buttons readable.
+  return color;
+}
+
+// Builds a palette of concrete colors read from the host CSS variables. Missing
+// tokens fall back to MUI defaults. Re-run whenever the host color scheme flips.
+function hostPalette(mode: PaletteMode): PaletteOptions {
+  const palette: PaletteOptions = { mode };
+
+  const primary = colorFromHost('primary');
+  const secondary = colorFromHost('secondary');
+  const error = colorFromHost('error');
+  const warning = colorFromHost('warning');
+  const info = colorFromHost('info');
+  const success = colorFromHost('success');
+  if (primary) palette.primary = primary;
+  if (secondary) palette.secondary = secondary;
+  if (error) palette.error = error;
+  if (warning) palette.warning = warning;
+  if (info) palette.info = info;
+  if (success) palette.success = success;
+
+  const textPrimary = readVar('--mui-palette-text-primary');
+  if (textPrimary) {
+    const secondaryText = readVar('--mui-palette-text-secondary');
+    const disabledText = readVar('--mui-palette-text-disabled');
+    palette.text = {
+      primary: textPrimary,
+      ...(secondaryText && { secondary: secondaryText }),
+      ...(disabledText && { disabled: disabledText }),
+    };
+  }
+
+  const bgDefault = readVar('--mui-palette-background-default');
+  if (bgDefault) {
+    const paper = readVar('--mui-palette-background-paper');
+    palette.background = {
+      default: bgDefault,
+      ...(paper && { paper }),
+    };
+  }
+
+  const divider = readVar('--mui-palette-divider');
+  if (divider) {
+    palette.divider = divider;
+  }
+
+  return palette;
+}
+
+function readHostColorScheme(): PaletteMode {
+  if (typeof document === 'undefined') {
+    return 'light';
+  }
+  const value = document.documentElement.getAttribute(HOST_COLOR_SCHEME_ATTR);
+  return value === 'dark' ? 'dark' : 'light';
+}
+
+// Tracks the host color scheme so plugin components re-render on dark-mode toggle.
+export function useHostColorMode(): PaletteMode {
+  const [mode, setMode] = useState<PaletteMode>(readHostColorScheme);
+
+  useEffect(() => {
+    const target = document.documentElement;
+    const observer = new MutationObserver(() => setMode(readHostColorScheme()));
+    observer.observe(target, {
+      attributes: true,
+      attributeFilter: [HOST_COLOR_SCHEME_ATTR],
+    });
+    setMode(readHostColorScheme());
+    return () => observer.disconnect();
+  }, []);
+
+  return mode;
+}
+
+export interface PluginThemeProviderProps {
+  children: ReactNode;
+  /** Emotion cache key. Keep unique per plugin to avoid style collisions with the host. */
+  cacheKey?: string;
+  /** CSP nonce from the host (PluginApi.cssNonce) so injected <style> tags are allowed. */
+  nonce?: string;
+}
+
+// Wraps plugin UI in a namespaced Emotion cache + a theme bound to host tokens.
+// Deliberately renders no CssBaseline: the host owns document-level globals.
+export const PluginThemeProvider = ({
+  children,
+  cacheKey = 'openeverest-plugin',
+  nonce,
+}: PluginThemeProviderProps) => {
+  const mode = useHostColorMode();
+  const cache = useMemo(
+    () => createCache({ key: cacheKey, nonce, prepend: true }),
+    [cacheKey, nonce]
+  );
+  const theme = useMemo(() => createTheme({ palette: hostPalette(mode) }), [mode]);
+
+  return (
+    <CacheProvider value={cache}>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </CacheProvider>
+  );
+};

--- a/ui/packages/plugin-ui-lib/src/plugin-theme-provider.tsx
+++ b/ui/packages/plugin-ui-lib/src/plugin-theme-provider.tsx
@@ -21,6 +21,7 @@ import {
   type PaletteMode,
   type PaletteOptions,
   type SimplePaletteColorOptions,
+  type ThemeOptions,
 } from '@mui/material';
 
 // The host publishes its active color scheme here (see @percona/design
@@ -102,6 +103,80 @@ function hostPalette(mode: PaletteMode): PaletteOptions {
   return palette;
 }
 
+// The typography variants MUI emits as `--mui-font-*`.
+const TYPOGRAPHY_VARIANTS = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'subtitle1',
+  'subtitle2',
+  'body1',
+  'body2',
+  'button',
+  'caption',
+  'overline',
+] as const;
+
+// MUI emits each variant as a CSS `font` shorthand:
+//   "<weight> <size>[/<lineHeight>] [<family>]"
+// e.g. "600 1.5rem/22.5px 'Poppins',sans-serif".
+//
+// Note the shorthand cannot express `textTransform` or `letterSpacing`, so those
+// host values do not cross this bridge — see the note in §7.4.
+function fontFromHost(variant: string): Record<string, unknown> | undefined {
+  const raw = readVar(`--mui-font-${variant}`);
+  if (!raw) {
+    return undefined;
+  }
+  // Requiring a numeric weight also rejects non-font values such as
+  // `--mui-font-inherit: inherit inherit/inherit inherit`.
+  const m = raw.match(/^(\d+)\s+([^\s/]+)(?:\/([^\s]+))?(?:\s+(.+))?$/);
+  if (!m) {
+    return undefined;
+  }
+  const [, weight, size, lineHeight, family] = m;
+  const style: Record<string, unknown> = {
+    fontWeight: Number(weight),
+    fontSize: size,
+  };
+  if (lineHeight) {
+    style.lineHeight = lineHeight;
+  }
+  if (family) {
+    style.fontFamily = family;
+  }
+  return style;
+}
+
+// Builds the typography scale from host tokens. Variants the host doesn't
+// publish simply fall back to the plugin's own MUI defaults.
+function hostTypography(): ThemeOptions['typography'] {
+  const typography: Record<string, unknown> = {};
+  for (const variant of TYPOGRAPHY_VARIANTS) {
+    const style = fontFromHost(variant);
+    if (style) {
+      typography[variant] = style;
+    }
+  }
+  // Give unlisted variants the host's body face rather than MUI's default.
+  const bodyFamily = (typography.body1 as Record<string, unknown> | undefined)
+    ?.fontFamily;
+  if (bodyFamily) {
+    typography.fontFamily = bodyFamily;
+  }
+  return Object.keys(typography).length
+    ? (typography as ThemeOptions['typography'])
+    : undefined;
+}
+
+function hostShape(): ThemeOptions['shape'] {
+  const radius = parseFloat(readVar('--mui-shape-borderRadius'));
+  return Number.isFinite(radius) ? { borderRadius: radius } : undefined;
+}
+
 function readHostColorScheme(): PaletteMode {
   if (typeof document === 'undefined') {
     return 'light';
@@ -148,7 +223,17 @@ export const PluginThemeProvider = ({
     () => createCache({ key: cacheKey, nonce, prepend: true }),
     [cacheKey, nonce]
   );
-  const theme = useMemo(() => createTheme({ palette: hostPalette(mode) }), [mode]);
+  // Rebuilt whenever the host colour scheme flips, since every token is read
+  // from the computed CSS variables at that moment.
+  const theme = useMemo(() => {
+    const typography = hostTypography();
+    const shape = hostShape();
+    return createTheme({
+      palette: hostPalette(mode),
+      ...(typography ? { typography } : {}),
+      ...(shape ? { shape } : {}),
+    });
+  }, [mode]);
 
   return (
     <CacheProvider value={cache}>

--- a/ui/packages/plugin-ui-lib/tsconfig.json
+++ b/ui/packages/plugin-ui-lib/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@percona/tsconfig/react-library.json",
+  "include": ["src"],
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "dist/typings"
+  }
+}

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -379,6 +379,58 @@ importers:
         specifier: ^5.2.2
         version: 5.6.3
 
+  packages/plugin-ui-lib:
+    dependencies:
+      '@emotion/cache':
+        specifier: ^11.11.0
+        version: 11.14.0
+      '@emotion/react':
+        specifier: ^11.11.0
+        version: 11.13.3(@types/react@18.3.12)(react@18.3.1)
+      '@emotion/styled':
+        specifier: ^11.11.0
+        version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
+      '@mui/icons-material':
+        specifier: ^7.3.0
+        version: 7.3.11(@mui/material@7.3.11(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
+      '@mui/material':
+        specifier: ^7.3.0
+        version: 7.3.11(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@percona/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@rollup/plugin-commonjs':
+        specifier: ^25.0.7
+        version: 25.0.8(rollup@4.40.1)
+      '@rollup/plugin-node-resolve':
+        specifier: ^16.0.1
+        version: 16.0.1(rollup@4.40.1)
+      '@rollup/plugin-terser':
+        specifier: ^0.4.4
+        version: 0.4.4(rollup@4.40.1)
+      '@rollup/plugin-typescript':
+        specifier: ^11.0.0
+        version: 11.1.6(rollup@4.40.1)(tslib@2.8.1)(typescript@5.6.3)
+      '@types/react':
+        specifier: ^18.2.0
+        version: 18.3.12
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      rollup:
+        specifier: ^4.22.4
+        version: 4.40.1
+      rollup-plugin-dts:
+        specifier: ^6.1.0
+        version: 6.1.1(rollup@4.40.1)(typescript@5.6.3)
+      typescript:
+        specifier: ^5.2.2
+        version: 5.6.3
+
   packages/prettier-config:
     dependencies:
       prettier:


### PR DESCRIPTION
Closes the design discussion in #2661.

## Why

Generic plugins (spec 003) render their own UI, but today it doesn't match
OpenEverest and looks bolted-on. We want two things that pull against each other:

1. native look - plugins should be visually indistinguishable from the core.
2. independence - upgrading the core's MUI/design libs must not break existing plugins. We can't be chasing plugin authors to rebuild every time.

This PR implements Model B from the issue: share only React; each plugin
bundles its own pinned MUI; the core exposes its design tokens as CSS
variables so plugins inherit the palette + dark mode live, through the CSS
cascade, without rebuilding.

```
Host owns:  React runtime (shared)  +  design tokens on :root (--mui-*)
Plugin owns: its own MUI/Emotion (frozen)  ->  themed from host CSS variables
Contract:   React major (the only shared runtime dep)
```

## 1. What changes in the core

- **Design tokens as CSS variables.** The host theme now enables MUI
  `cssVariables`, emitting `--mui-*` custom properties on `:root`, and publishes
  the active color scheme on `document.documentElement[data-everest-color-scheme]`.
  (Switched the theme provider from Emotion's to MUI's `ThemeProvider`, required
  for variable injection.)
- **Shared React via an import map.** The host exposes its React singleton
  (`react`, `react-dom`, `react/jsx-runtime`) — plus MUI's static `colors` — through
  small shim modules served under `/static/plugin-runtime/` and an inline
  `<script type="importmap">`. Plugins mark these external so hooks/context work
  across the host↔plugin boundary. CSP gained a `script-src 'self' $NONCE` so the
  nonced import map is allowed.
- **New package `@openeverest/ui-lib`.** Bundles its own pinned MUI + Emotion and
  exports a `PluginThemeProvider` (namespaced Emotion cache, theme bound to the
  host CSS-variable tokens, follows host dark mode) plus a curated set of
  host-themed components. This is the seam that lets the core upgrade MUI without
  breaking plugins.
- **Compatibility contract.** `PluginApi` gains `cssNonce`, `hostVersion`, and a
  coarse `uiContractVersion` (React major). The loader checks the Plugin CR's
  `compatibleHostVersions` and refuses an incompatible plugin loudly instead of
  rendering it detached/unthemed; the API now forwards that field.

## 2. What changes for plugin developers

To adopt the core look (opt-in — plugins can still ship their own UI):

- **Use `@openeverest/ui-lib`** instead of importing `@mui/material` directly, and
  wrap your UI in `PluginThemeProvider`:
  ```tsx
  import { PluginThemeProvider, Box, Button, Table } from '@openeverest/ui-lib';
  // <PluginThemeProvider nonce={api.cssNonce}> ...your UI... </PluginThemeProvider>
  ```
  Colors, spacing, typography and dark mode come from the host automatically.
- **Build config**: keep React external, bundle everything else.
  ```ts
  rollupOptions: { external: ['react', 'react-dom', 'react/jsx-runtime', '@mui/material/colors'] }
  define: { 'process.env.NODE_ENV': JSON.stringify('production') } // lib mode doesn't inline this
  ```
- **(Optional) declare compatibility** in the Plugin CR:
  `spec.compatibleHostVersions: ">=2.0.0 <3.0.0"`.
- **You choose when to upgrade** `@openeverest/ui-lib`. A core MUI bump does not
  require you to rebuild; your plugin keeps its pinned MUI and still inherits the
  host palette/dark mode via CSS variables.

## Reference / scope

- `plugin-hub` is migrated end-to-end as the reference (separate companion PR):
  raw `createElement` + inline hex → host-themed MUI via `@openeverest/ui-lib`.
- Spec 003 §8.1/§9 and `docs/process/generic-plugins-design.md` updated to Model B.
- **Not** in scope: migrating other plugins, a full host-owned component facade,
  and enforced third-party version gating (the contract stays coarse/advisory).

## Notes / trade-offs

- Bundling MUI per plugin adds a few hundred KB per bundle — acceptable for an
  admin tool, and the price of upgrade independence.
- Component `styleOverrides` are not inherited (only palette/spacing/typography via
  tokens) — "best-effort native", per the issue discussion.
