### PR TITLE
Add Context.RequestMaintenance and the pending-maintenance flush

### DIFF
--- a/provider-runtime/controller/common.go
+++ b/provider-runtime/controller/common.go
@@ -50,6 +50,11 @@ type Context struct {
 	// flush the corresponding condition onto the Instance after Sync. It is
 	// nil when the provider has not invoked the helper this reconcile pass.
 	dataSourceStatus *DataSourceStatus
+
+	// pendingMaintenance collects the actions RequestMaintenance held this
+	// reconcile pass; the reconciler flushes them to
+	// status.pendingMaintenance after Sync.
+	pendingMaintenance []v1alpha1.PendingMaintenanceAction
 }
 
 // NewContext creates a new Context handle (used internally by the reconciler).

--- a/provider-runtime/controller/maintenance.go
+++ b/provider-runtime/controller/maintenance.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+// Maintenance gating.
+//
+// Providers declare each unit of disruptive work through
+// Context.RequestMaintenance during Sync, classified by its observable
+// database impact. The runtime authorizes anything within the Instance's
+// standing tolerance (spec.maintenance.autoApproveUpTo) or explicitly
+// approved by token (spec.maintenance.approved); everything else is held and
+// flushed to status.pendingMaintenance by the reconciler, so a provider
+// upgrade never causes surprise downtime.
+//
+// Design background: spec 009 (provider upgrades) in the openeverest/specs
+// repository.
+
+import (
+	"github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+)
+
+// MaintenanceSeverity re-exports the Instance API severity scale for provider
+// ergonomics.
+type MaintenanceSeverity = v1alpha1.MaintenanceSeverity
+
+// Severity levels, ordered by observable impact.
+const (
+	MaintenanceNonDisruptive  = v1alpha1.MaintenanceNonDisruptive
+	MaintenanceRollingRestart = v1alpha1.MaintenanceRollingRestart
+	MaintenanceDowntime       = v1alpha1.MaintenanceDowntime
+)
+
+// severityRank orders severities for tolerance comparison. Unknown values
+// rank above Downtime so a misclassified action is held, never auto-applied.
+func severityRank(s MaintenanceSeverity) int {
+	switch s {
+	case MaintenanceNonDisruptive:
+		return 0
+	case MaintenanceRollingRestart:
+		return 1
+	case MaintenanceDowntime:
+		return 2
+	default:
+		return 3
+	}
+}
+
+// RequestMaintenance declares a unit of work with the given observable impact
+// and reports whether the provider may perform it this reconcile.
+//
+// token identifies the action occurrence: it must be unique per occurrence
+// and stable while the action is pending (e.g. "upgrade-to-0.3",
+// "rotate-certs-2026H2"). It is both the action's identity on
+// status.pendingMaintenance and the value the user echoes into
+// spec.maintenance.approved. The framework treats it as an opaque string.
+//
+// When the result is false the provider MUST NOT perform the action this
+// reconcile; the runtime records it on status.pendingMaintenance instead.
+// The pending list is rebuilt every reconcile from the calls the provider
+// makes, so an action the provider stops requesting disappears on its own.
+func (c *Context) RequestMaintenance(token, description string, severity MaintenanceSeverity) bool {
+	if c.maintenanceApproved(token, severity) {
+		return true
+	}
+	c.pendingMaintenance = append(c.pendingMaintenance, v1alpha1.PendingMaintenanceAction{
+		Description:   description,
+		Severity:      severity,
+		ApprovalToken: token,
+	})
+	return false
+}
+
+// maintenanceApproved reports whether an action is within the Instance's
+// standing tolerance or explicitly approved by token.
+func (c *Context) maintenanceApproved(token string, severity MaintenanceSeverity) bool {
+	tolerance := MaintenanceNonDisruptive
+	approved := ""
+	if m := c.in.Spec.Maintenance; m != nil {
+		if m.AutoApproveUpTo != "" {
+			tolerance = m.AutoApproveUpTo
+		}
+		approved = m.Approved
+	}
+	if severityRank(severity) <= severityRank(tolerance) {
+		return true
+	}
+	return token != "" && token == approved
+}
+
+// GetPendingMaintenance returns the actions RequestMaintenance held this
+// reconcile pass, in request order. Used by the reconciler to flush
+// status.pendingMaintenance.
+func (c *Context) GetPendingMaintenance() []v1alpha1.PendingMaintenanceAction {
+	return c.pendingMaintenance
+}

--- a/provider-runtime/controller/maintenance_test.go
+++ b/provider-runtime/controller/maintenance_test.go
@@ -1,0 +1,144 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+)
+
+func maintenanceContext(t *testing.T, m *v1alpha1.MaintenanceSpec) *Context {
+	t.Helper()
+	in := &v1alpha1.Instance{}
+	in.Spec.Maintenance = m
+	return NewContext(t.Context(), nil, in, "test-provider")
+}
+
+func TestRequestMaintenance_Gating(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		maintenance *v1alpha1.MaintenanceSpec
+		severity    MaintenanceSeverity
+		token       string
+		want        bool
+	}{
+		{
+			name:     "nil maintenance holds a rolling restart",
+			severity: MaintenanceRollingRestart,
+			token:    "upgrade-to-0.3",
+			want:     false,
+		},
+		{
+			name:     "nil maintenance auto-applies non-disruptive",
+			severity: MaintenanceNonDisruptive,
+			token:    "upgrade-to-0.3",
+			want:     true,
+		},
+		{
+			name:        "tolerance at rolling restart auto-applies rolling restart",
+			maintenance: &v1alpha1.MaintenanceSpec{AutoApproveUpTo: v1alpha1.MaintenanceRollingRestart},
+			severity:    MaintenanceRollingRestart,
+			token:       "upgrade-to-0.3",
+			want:        true,
+		},
+		{
+			name:        "tolerance at rolling restart holds downtime",
+			maintenance: &v1alpha1.MaintenanceSpec{AutoApproveUpTo: v1alpha1.MaintenanceRollingRestart},
+			severity:    MaintenanceDowntime,
+			token:       "upgrade-to-0.3",
+			want:        false,
+		},
+		{
+			name:        "matching token approves above tolerance",
+			maintenance: &v1alpha1.MaintenanceSpec{Approved: "upgrade-to-0.3"},
+			severity:    MaintenanceDowntime,
+			token:       "upgrade-to-0.3",
+			want:        true,
+		},
+		{
+			name:        "stale token from an earlier action does not authorize a new one",
+			maintenance: &v1alpha1.MaintenanceSpec{Approved: "upgrade-to-0.3"},
+			severity:    MaintenanceRollingRestart,
+			token:       "rotate-certs-2026H2",
+			want:        false,
+		},
+		{
+			name:        "empty token never matches an empty approval",
+			maintenance: &v1alpha1.MaintenanceSpec{},
+			severity:    MaintenanceRollingRestart,
+			token:       "",
+			want:        false,
+		},
+		{
+			name:        "unknown severity is held even at the widest tolerance",
+			maintenance: &v1alpha1.MaintenanceSpec{AutoApproveUpTo: v1alpha1.MaintenanceDowntime},
+			severity:    MaintenanceSeverity("Catastrophic"),
+			token:       "upgrade-to-0.3",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := maintenanceContext(t, tt.maintenance)
+
+			got := c.RequestMaintenance(tt.token, "some action", tt.severity)
+
+			assert.Equal(t, tt.want, got)
+			if tt.want {
+				assert.Empty(t, c.GetPendingMaintenance(), "approved actions must not be recorded as pending")
+			} else {
+				require.Len(t, c.GetPendingMaintenance(), 1)
+				held := c.GetPendingMaintenance()[0]
+				assert.Equal(t, tt.token, held.ApprovalToken)
+				assert.Equal(t, tt.severity, held.Severity)
+				assert.Equal(t, "some action", held.Description)
+			}
+		})
+	}
+}
+
+func TestRequestMaintenance_MultipleActionsKeepOrder(t *testing.T) {
+	t.Parallel()
+
+	c := maintenanceContext(t, nil)
+
+	assert.False(t, c.RequestMaintenance("upgrade-to-0.3", "converge", MaintenanceRollingRestart))
+	assert.False(t, c.RequestMaintenance("rotate-certs-2026H2", "rotate certs", MaintenanceDowntime))
+
+	pending := c.GetPendingMaintenance()
+	require.Len(t, pending, 2)
+	assert.Equal(t, "upgrade-to-0.3", pending[0].ApprovalToken)
+	assert.Equal(t, "rotate-certs-2026H2", pending[1].ApprovalToken)
+}
+
+func TestRequestMaintenance_ReArmsPerOccurrence(t *testing.T) {
+	t.Parallel()
+
+	// The owner approved the 0.3 convergence; a later 0.5 convergence is a
+	// new occurrence with a new token and must be held again.
+	c := maintenanceContext(t, &v1alpha1.MaintenanceSpec{Approved: "upgrade-to-0.3"})
+
+	assert.True(t, c.RequestMaintenance("upgrade-to-0.3", "converge to 0.3", MaintenanceRollingRestart))
+	assert.False(t, c.RequestMaintenance("upgrade-to-0.5", "converge to 0.5", MaintenanceRollingRestart))
+}

--- a/provider-runtime/reconciler/maintenance_flush_test.go
+++ b/provider-runtime/reconciler/maintenance_flush_test.go
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
+)
+
+func findMaintenanceCondition(in *corev1alpha1.Instance) *metav1.Condition {
+	for i := range in.Status.Conditions {
+		if in.Status.Conditions[i].Type == corev1alpha1.ConditionMaintenancePending {
+			return &in.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+func TestFlushPendingMaintenance(t *testing.T) {
+	t.Parallel()
+
+	t.Run("held actions land on status with condition True", func(t *testing.T) {
+		t.Parallel()
+
+		in := &corev1alpha1.Instance{ObjectMeta: metav1.ObjectMeta{Name: "my-db", Namespace: "default"}}
+		syncCtx := controller.NewContext(t.Context(), nil, in.DeepCopy(), "test-provider")
+		require.False(t, syncCtx.RequestMaintenance(
+			"upgrade-to-0.3", "brief rolling restart", controller.MaintenanceRollingRestart))
+
+		flushPendingMaintenance(syncCtx, in)
+
+		require.Len(t, in.Status.PendingMaintenance, 1)
+		assert.Equal(t, "upgrade-to-0.3", in.Status.PendingMaintenance[0].ApprovalToken)
+		cond := findMaintenanceCondition(in)
+		require.NotNil(t, cond)
+		assert.Equal(t, metav1.ConditionTrue, cond.Status)
+		assert.Equal(t, corev1alpha1.ReasonAwaitingApproval, cond.Reason)
+	})
+
+	t.Run("no requests leaves untouched instance without the condition", func(t *testing.T) {
+		t.Parallel()
+
+		in := &corev1alpha1.Instance{ObjectMeta: metav1.ObjectMeta{Name: "my-db", Namespace: "default"}}
+		syncCtx := controller.NewContext(t.Context(), nil, in.DeepCopy(), "test-provider")
+
+		flushPendingMaintenance(syncCtx, in)
+
+		assert.Empty(t, in.Status.PendingMaintenance)
+		assert.Nil(t, findMaintenanceCondition(in))
+	})
+
+	t.Run("cleared hold empties the list and flips the condition to False", func(t *testing.T) {
+		t.Parallel()
+
+		in := &corev1alpha1.Instance{ObjectMeta: metav1.ObjectMeta{Name: "my-db", Namespace: "default"}}
+		in.Status.PendingMaintenance = []corev1alpha1.PendingMaintenanceAction{
+			{Description: "brief rolling restart", Severity: corev1alpha1.MaintenanceRollingRestart, ApprovalToken: "upgrade-to-0.3"},
+		}
+		in.Status.Conditions = []metav1.Condition{{
+			Type:   corev1alpha1.ConditionMaintenancePending,
+			Status: metav1.ConditionTrue,
+			Reason: corev1alpha1.ReasonAwaitingApproval,
+		}}
+		// This pass the provider no longer requests anything (e.g. the action
+		// was approved and applied, or is no longer needed).
+		syncCtx := controller.NewContext(t.Context(), nil, in.DeepCopy(), "test-provider")
+
+		flushPendingMaintenance(syncCtx, in)
+
+		assert.Empty(t, in.Status.PendingMaintenance)
+		cond := findMaintenanceCondition(in)
+		require.NotNil(t, cond)
+		assert.Equal(t, metav1.ConditionFalse, cond.Status)
+		assert.Equal(t, corev1alpha1.ReasonNoActionsPending, cond.Reason)
+	})
+}

--- a/provider-runtime/reconciler/provider.go
+++ b/provider-runtime/reconciler/provider.go
@@ -476,6 +476,11 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 			ds.Reason, ds.Message, metav1.Now())
 	}
 
+	// Flush the actions Context.RequestMaintenance held during Sync. The
+	// pending list is rebuilt from scratch every pass so it can never go
+	// stale, while the approval stays durable in spec.
+	flushPendingMaintenance(syncCtx, in)
+
 	// Compute and update status
 	logger.Info("Computing status")
 	status, err := r.provider.Status(syncCtx)
@@ -802,6 +807,30 @@ func (r *ProviderReconciler) setDeprecationCondition(ctx context.Context, in *v1
 			setCondition(in, v1alpha1.ConditionComponentVersionDeprecated, metav1.ConditionFalse,
 				v1alpha1.ReasonVersionsSupported,
 				"All component versions are supported by the installed provider", metav1.Now())
+			return
+		}
+	}
+}
+
+// flushPendingMaintenance writes the actions held by RequestMaintenance to
+// status.pendingMaintenance and maintains the MaintenancePending condition:
+// True while anything is held, flipped to False (never removed) once the
+// last held action clears.
+func flushPendingMaintenance(syncCtx *controller.Context, in *v1alpha1.Instance) {
+	pending := syncCtx.GetPendingMaintenance()
+	in.Status.PendingMaintenance = pending
+
+	if len(pending) > 0 {
+		setCondition(in, v1alpha1.ConditionMaintenancePending, metav1.ConditionTrue,
+			v1alpha1.ReasonAwaitingApproval,
+			fmt.Sprintf("%d action(s) require approval to proceed", len(pending)), metav1.Now())
+		return
+	}
+	for _, c := range in.Status.Conditions {
+		if c.Type == v1alpha1.ConditionMaintenancePending {
+			setCondition(in, v1alpha1.ConditionMaintenancePending, metav1.ConditionFalse,
+				v1alpha1.ReasonNoActionsPending,
+				"No disruptive actions are held", metav1.Now())
 			return
 		}
 	}


### PR DESCRIPTION
## What

Part 2 runtime of the provider upgrades feature ([spec 009](https://github.com/openeverest/specs/blob/main/specs/009-provider-upgrades.md) §7): the gating helper and reconciler flush behind the maintenance API from #3081.

> **Stacked on #3081** — base is `provider-upgrade-maintenance-api`;

**`Context.RequestMaintenance(token, description, severity) bool`** — providers declare each unit of disruptive work during `Sync`, classified by observable impact. Returns `true` (may proceed) when the severity is within `spec.maintenance.autoApproveUpTo` **or** the token matches `spec.maintenance.approved` exactly; otherwise the action is staged and the provider must not act this reconcile.

**Reconciler flush** — after `Sync`, held actions are written to `status.pendingMaintenance` (rebuilt from scratch every pass, so the list can never go stale — the ephemeral-notice/durable-approval split) and the `MaintenancePending` condition is maintained: `True` while anything is held, flipped to `False` once the last hold clears (never added to Instances that never held anything).

Safety details worth reviewing:
- **Unknown severities rank above `Downtime`** — a misclassified action is held, never auto-applied.
- **An empty token never matches an empty approval** — `approved: ""` (the default) authorizes nothing.
- Approved actions are *not* recorded as pending, per the spec's "runtime records a pending action only when held".

Mirrors the existing `DataSourceStatus` staging pattern (`Context` private field → post-Sync flush). Severity constants are re-exported from the API package for provider ergonomics (`controller.MaintenanceRollingRestart`, per the spec's provider-facing examples).

## Verification

Table-driven gating tests (nil-spec defaults, tolerance boundaries, token match, per-occurrence re-arm, empty-token/empty-approval, unknown severity, multi-action ordering) plus flush tests (hold → status+condition True; nothing requested → untouched; cleared hold → list emptied, condition False). `go test -race ./provider-runtime/...` passes; lint clean.