### PR TITLE
Hold repeatedly-failing approved maintenance actions

### DIFF
--- a/api/core/v1alpha1/instance_types.go
+++ b/api/core/v1alpha1/instance_types.go
@@ -715,6 +715,12 @@ const (
 	// held; everything the provider requested was within the Instance's
 	// standing tolerance or has been applied.
 	ReasonNoActionsPending = "NoActionsPending"
+
+	// ReasonRetriesExhausted indicates an approved disruptive action kept
+	// failing and the runtime stopped retrying it so a crash-looping
+	// provider cannot repeatedly disrupt the database. Clear and re-set
+	// spec.maintenance.approved to retry.
+	ReasonRetriesExhausted = "RetriesExhausted"
 )
 
 // Reasons for the DataSourceReady condition.

--- a/provider-runtime/controller/common.go
+++ b/provider-runtime/controller/common.go
@@ -55,6 +55,20 @@ type Context struct {
 	// reconcile pass; the reconciler flushes them to
 	// status.pendingMaintenance after Sync.
 	pendingMaintenance []v1alpha1.PendingMaintenanceAction
+
+	// approvedMaintenance collects the tokens of disruptive actions
+	// RequestMaintenance approved this pass, so the reconciler can count
+	// Sync failures against them.
+	approvedMaintenance []string
+
+	// blockedMaintenance holds tokens whose retries are exhausted; the
+	// reconciler sets it before Sync and RequestMaintenance holds them
+	// despite approval.
+	blockedMaintenance map[string]struct{}
+
+	// maintenanceBreakerHeld reports that at least one action was held this
+	// pass because its retries were exhausted.
+	maintenanceBreakerHeld bool
 }
 
 // NewContext creates a new Context handle (used internally by the reconciler).

--- a/provider-runtime/controller/maintenance.go
+++ b/provider-runtime/controller/maintenance.go
@@ -70,9 +70,20 @@ func severityRank(s MaintenanceSeverity) int {
 // reconcile; the runtime records it on status.pendingMaintenance instead.
 // The pending list is rebuilt every reconcile from the calls the provider
 // makes, so an action the provider stops requesting disappears on its own.
+//
+// An approved action whose Sync keeps failing eventually exhausts its
+// retries: the runtime then holds it despite the approval, so a
+// crash-looping provider cannot repeatedly disrupt the database. Clearing
+// and re-setting spec.maintenance.approved re-arms the retries.
 func (c *Context) RequestMaintenance(token, description string, severity MaintenanceSeverity) bool {
 	if c.maintenanceApproved(token, severity) {
-		return true
+		if _, blocked := c.blockedMaintenance[token]; !blocked {
+			if severityRank(severity) > severityRank(MaintenanceNonDisruptive) {
+				c.approvedMaintenance = append(c.approvedMaintenance, token)
+			}
+			return true
+		}
+		c.maintenanceBreakerHeld = true
 	}
 	c.pendingMaintenance = append(c.pendingMaintenance, v1alpha1.PendingMaintenanceAction{
 		Description:   description,
@@ -104,4 +115,30 @@ func (c *Context) maintenanceApproved(token string, severity MaintenanceSeverity
 // status.pendingMaintenance.
 func (c *Context) GetPendingMaintenance() []v1alpha1.PendingMaintenanceAction {
 	return c.pendingMaintenance
+}
+
+// GetApprovedMaintenance returns the tokens of disruptive actions approved
+// this pass (used internally by the reconciler to count Sync failures
+// against them).
+func (c *Context) GetApprovedMaintenance() []string {
+	return c.approvedMaintenance
+}
+
+// BlockMaintenance marks tokens whose retries are exhausted (used internally
+// by the reconciler before Sync). RequestMaintenance holds them despite
+// approval.
+func (c *Context) BlockMaintenance(tokens ...string) {
+	if c.blockedMaintenance == nil {
+		c.blockedMaintenance = make(map[string]struct{}, len(tokens))
+	}
+	for _, t := range tokens {
+		c.blockedMaintenance[t] = struct{}{}
+	}
+}
+
+// MaintenanceBreakerHeld reports whether at least one action was held this
+// pass because its retries were exhausted (used internally by the reconciler
+// to pick the MaintenancePending condition reason).
+func (c *Context) MaintenanceBreakerHeld() bool {
+	return c.maintenanceBreakerHeld
 }

--- a/provider-runtime/reconciler/maintenance_breaker.go
+++ b/provider-runtime/reconciler/maintenance_breaker.go
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// maintenanceBreakerThreshold is the number of consecutive failed Syncs after
+// which an approved disruptive action stops being retried.
+const maintenanceBreakerThreshold = 5
+
+// maintenanceBreaker counts consecutive Sync failures per approved disruptive
+// action so a crash-looping provider cannot repeatedly disrupt a database:
+// once the threshold is reached the action is held despite its approval.
+// Exponential backoff between the attempts themselves comes from
+// controller-runtime's rate-limited requeue.
+//
+// State is in-memory: a controller restart re-arms the retries. The durable
+// clear-stuck signal is the user changing spec.maintenance.approved, which
+// resets the counts for the Instance.
+type maintenanceBreaker struct {
+	mu        sync.Mutex
+	instances map[types.NamespacedName]*breakerEntry
+}
+
+type breakerEntry struct {
+	// approved is spec.maintenance.approved as last observed; when the user
+	// changes it the counts reset (the documented clear-stuck signal).
+	approved string
+	// failures counts consecutive failed Syncs per approved token.
+	failures map[string]int
+}
+
+// blockedTokens returns the tokens whose retries are exhausted. approved is
+// the Instance's current spec.maintenance.approved; a change since the last
+// observation resets the counts.
+func (b *maintenanceBreaker) blockedTokens(nn types.NamespacedName, approved string) []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry, ok := b.instances[nn]
+	if !ok {
+		return nil
+	}
+	if entry.approved != approved {
+		delete(b.instances, nn)
+		return nil
+	}
+	var blocked []string
+	for token, count := range entry.failures {
+		if count >= maintenanceBreakerThreshold {
+			blocked = append(blocked, token)
+		}
+	}
+	return blocked
+}
+
+// recordFailure counts a failed Sync against every disruptive action it had
+// approved.
+func (b *maintenanceBreaker) recordFailure(nn types.NamespacedName, approved string, tokens []string) {
+	if len(tokens) == 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.instances == nil {
+		b.instances = make(map[types.NamespacedName]*breakerEntry)
+	}
+	entry, ok := b.instances[nn]
+	if !ok || entry.approved != approved {
+		entry = &breakerEntry{approved: approved, failures: make(map[string]int)}
+		b.instances[nn] = entry
+	}
+	for _, token := range tokens {
+		entry.failures[token]++
+	}
+}
+
+// reset clears all counts for the Instance after a successful Sync.
+func (b *maintenanceBreaker) reset(nn types.NamespacedName) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.instances, nn)
+}

--- a/provider-runtime/reconciler/maintenance_breaker_test.go
+++ b/provider-runtime/reconciler/maintenance_breaker_test.go
@@ -1,0 +1,125 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	corev1alpha1 "github.com/openeverest/openeverest/v2/api/core/v1alpha1"
+	"github.com/openeverest/openeverest/v2/provider-runtime/controller"
+)
+
+func TestMaintenanceBreaker(t *testing.T) {
+	t.Parallel()
+
+	nn := types.NamespacedName{Namespace: "default", Name: "my-db"}
+
+	t.Run("trips only at the threshold", func(t *testing.T) {
+		t.Parallel()
+
+		var b maintenanceBreaker
+		for range maintenanceBreakerThreshold - 1 {
+			b.recordFailure(nn, "upgrade-to-0.3", []string{"upgrade-to-0.3"})
+		}
+		assert.Empty(t, b.blockedTokens(nn, "upgrade-to-0.3"))
+
+		b.recordFailure(nn, "upgrade-to-0.3", []string{"upgrade-to-0.3"})
+		assert.Equal(t, []string{"upgrade-to-0.3"}, b.blockedTokens(nn, "upgrade-to-0.3"))
+	})
+
+	t.Run("changing the approval resets the counts", func(t *testing.T) {
+		t.Parallel()
+
+		var b maintenanceBreaker
+		for range maintenanceBreakerThreshold {
+			b.recordFailure(nn, "upgrade-to-0.3", []string{"upgrade-to-0.3"})
+		}
+		require.NotEmpty(t, b.blockedTokens(nn, "upgrade-to-0.3"))
+
+		// The user clears the approval (clear-stuck), then re-approves.
+		assert.Empty(t, b.blockedTokens(nn, ""))
+		assert.Empty(t, b.blockedTokens(nn, "upgrade-to-0.3"))
+	})
+
+	t.Run("successful sync resets the counts", func(t *testing.T) {
+		t.Parallel()
+
+		var b maintenanceBreaker
+		for range maintenanceBreakerThreshold {
+			b.recordFailure(nn, "upgrade-to-0.3", []string{"upgrade-to-0.3"})
+		}
+		b.reset(nn)
+		assert.Empty(t, b.blockedTokens(nn, "upgrade-to-0.3"))
+	})
+
+	t.Run("failures without approved actions are not counted", func(t *testing.T) {
+		t.Parallel()
+
+		var b maintenanceBreaker
+		for range maintenanceBreakerThreshold + 1 {
+			b.recordFailure(nn, "upgrade-to-0.3", nil)
+		}
+		assert.Empty(t, b.blockedTokens(nn, "upgrade-to-0.3"))
+	})
+
+	t.Run("instances are tracked independently", func(t *testing.T) {
+		t.Parallel()
+
+		var b maintenanceBreaker
+		other := types.NamespacedName{Namespace: "default", Name: "other-db"}
+		for range maintenanceBreakerThreshold {
+			b.recordFailure(nn, "upgrade-to-0.3", []string{"upgrade-to-0.3"})
+		}
+		assert.Empty(t, b.blockedTokens(other, "upgrade-to-0.3"))
+	})
+}
+
+func TestRequestMaintenance_BreakerHoldsApprovedAction(t *testing.T) {
+	t.Parallel()
+
+	in := &corev1alpha1.Instance{}
+	in.Spec.Maintenance = &corev1alpha1.MaintenanceSpec{Approved: "upgrade-to-0.3"}
+	syncCtx := controller.NewContext(t.Context(), nil, in, "test-provider")
+	syncCtx.BlockMaintenance("upgrade-to-0.3")
+
+	approved := syncCtx.RequestMaintenance("upgrade-to-0.3", "brief rolling restart", controller.MaintenanceRollingRestart)
+
+	assert.False(t, approved, "a token with exhausted retries must be held despite approval")
+	assert.True(t, syncCtx.MaintenanceBreakerHeld())
+	require.Len(t, syncCtx.GetPendingMaintenance(), 1)
+	assert.Empty(t, syncCtx.GetApprovedMaintenance())
+}
+
+func TestFlushPendingMaintenance_BreakerReason(t *testing.T) {
+	t.Parallel()
+
+	in := &corev1alpha1.Instance{ObjectMeta: metav1.ObjectMeta{Name: "my-db", Namespace: "default"}}
+	in.Spec.Maintenance = &corev1alpha1.MaintenanceSpec{Approved: "upgrade-to-0.3"}
+	syncCtx := controller.NewContext(t.Context(), nil, in.DeepCopy(), "test-provider")
+	syncCtx.BlockMaintenance("upgrade-to-0.3")
+	require.False(t, syncCtx.RequestMaintenance("upgrade-to-0.3", "brief rolling restart", controller.MaintenanceRollingRestart))
+
+	flushPendingMaintenance(syncCtx, in)
+
+	cond := findMaintenanceCondition(in)
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, corev1alpha1.ReasonRetriesExhausted, cond.Reason)
+}

--- a/provider-runtime/reconciler/provider.go
+++ b/provider-runtime/reconciler/provider.go
@@ -58,6 +58,7 @@ type ProviderReconciler struct {
 	manager      ctrl.Manager
 	serverConfig *server.ServerConfig
 	server       *server.Server
+	breaker      maintenanceBreaker
 	client.Client
 }
 
@@ -423,6 +424,7 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		return reconcile.Result{}, err
 	}
 	syncCtx := controller.NewContext(ctx, r.Client, resolvedIn, r.provider.Name())
+	syncCtx.BlockMaintenance(r.breaker.blockedTokens(req.NamespacedName, approvedMaintenanceValue(in))...)
 
 	// Passive warning for owners: flag effective component versions the
 	// installed catalog marks as deprecated, before any upgrade is attempted.
@@ -455,8 +457,10 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 			return reconcile.Result{}, nil
 		}
 		logger.Error(err, "Sync failed")
+		r.breaker.recordFailure(req.NamespacedName, approvedMaintenanceValue(in), syncCtx.GetApprovedMaintenance())
 		return reconcile.Result{}, err
 	}
+	r.breaker.reset(req.NamespacedName)
 	// Clear any stale BackupConfigured=False condition left from a previous failed Sync.
 	if _, ok := r.provider.(controller.BackupProvider); ok {
 		setCondition(in, v1alpha1.ConditionBackupConfigured, metav1.ConditionTrue,
@@ -815,15 +819,21 @@ func (r *ProviderReconciler) setDeprecationCondition(ctx context.Context, in *v1
 // flushPendingMaintenance writes the actions held by RequestMaintenance to
 // status.pendingMaintenance and maintains the MaintenancePending condition:
 // True while anything is held, flipped to False (never removed) once the
-// last held action clears.
+// last held action clears. When a hold is due to exhausted retries the
+// reason says so, surfacing the breaker state.
 func flushPendingMaintenance(syncCtx *controller.Context, in *v1alpha1.Instance) {
 	pending := syncCtx.GetPendingMaintenance()
 	in.Status.PendingMaintenance = pending
 
 	if len(pending) > 0 {
+		reason := v1alpha1.ReasonAwaitingApproval
+		message := fmt.Sprintf("%d action(s) require approval to proceed", len(pending))
+		if syncCtx.MaintenanceBreakerHeld() {
+			reason = v1alpha1.ReasonRetriesExhausted
+			message = "an approved action kept failing and is no longer retried; clear and re-set spec.maintenance.approved to retry"
+		}
 		setCondition(in, v1alpha1.ConditionMaintenancePending, metav1.ConditionTrue,
-			v1alpha1.ReasonAwaitingApproval,
-			fmt.Sprintf("%d action(s) require approval to proceed", len(pending)), metav1.Now())
+			reason, message, metav1.Now())
 		return
 	}
 	for _, c := range in.Status.Conditions {
@@ -834,6 +844,15 @@ func flushPendingMaintenance(syncCtx *controller.Context, in *v1alpha1.Instance)
 			return
 		}
 	}
+}
+
+// approvedMaintenanceValue returns spec.maintenance.approved, tolerating an
+// unset maintenance block.
+func approvedMaintenanceValue(in *v1alpha1.Instance) string {
+	if in.Spec.Maintenance == nil {
+		return ""
+	}
+	return in.Spec.Maintenance.Approved
 }
 
 // prepareInstance fetches the Provider and returns the Instance the provider


### PR DESCRIPTION
## What

The failure-handling escape hatches for disruption control ([spec 009](https://github.com/openeverest/specs/blob/main/specs/009-provider-upgrades.md) §7.7). Completes the Track 2 runtime started in #3081/#3082.

> **Stacked on #3082** — base is `provider-upgrade-request-maintenance`; will be retargeted once that merges. Only the last commit is new.

**Circuit breaker.** The reconciler counts consecutive failed `Sync`s against each disruptive action that was approved in that pass. At the threshold (5) the action is **held despite its approval** — `RequestMaintenance` returns `false` and the action reappears on `status.pendingMaintenance` — so a crash-looping provider cannot repeatedly disrupt a database. The breaker state is surfaced on the `MaintenancePending` condition with the new `RetriesExhausted` reason. Backoff *between* attempts is deliberately not reimplemented: controller-runtime's rate-limited requeue already provides per-item exponential backoff.

**Clear-stuck is declarative** (settles spec open question 2): changing or clearing `spec.maintenance.approved` resets the counts — so "clear, then re-set the approval" retries a tripped action, with no imperative reset signal or annotation.

Scope/behavior notes for review:
- Only actions above `NonDisruptive` are counted; failures of Syncs with no approved disruptive action never trip anything.
- Counts are in-memory: a controller restart re-arms retries. Worst case that re-attempts an action the owner already approved, with requeue backoff still spacing attempts — accepted for v1 rather than persisting attempt counts in status.
- Successful `Sync` resets the Instance's counts.

## Verification

Unit tests: threshold boundary, approval-change reset, success reset, no-approved-actions never counts, per-Instance isolation, breaker-held despite approval, `RetriesExhausted` condition reason. `go test -race ./provider-runtime/...` passes; lint clean.