### PR TITLE
fix(cli): validate --interval on instance status

### DIFF
--- a/commands/instance/status.go
+++ b/commands/instance/status.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openeverest/openeverest/v2/pkg/cli"
 	"github.com/openeverest/openeverest/v2/pkg/cli/config"
 	instancecli "github.com/openeverest/openeverest/v2/pkg/cli/instance"
+	"github.com/openeverest/openeverest/v2/pkg/cli/waitcmd"
 	"github.com/openeverest/openeverest/v2/pkg/logger"
 	"github.com/openeverest/openeverest/v2/pkg/output"
 )
@@ -83,6 +84,11 @@ func statusPreRun(cmd *cobra.Command, _ []string) { //nolint:revive
 func statusRun(cmd *cobra.Command, _ []string) { //nolint:revive
 	cfgPath, err := config.DefaultPath()
 	if err != nil {
+		output.PrintError(err, logger.GetLogger(), statusCfg.Pretty)
+		os.Exit(1)
+	}
+
+	if err := waitcmd.ValidateWatchFlags(statusOpts.Watch, cmd.Flags().Changed(cli.FlagInstanceInterval), statusOpts.Interval); err != nil {
 		output.PrintError(err, logger.GetLogger(), statusCfg.Pretty)
 		os.Exit(1)
 	}

--- a/pkg/cli/instance/status.go
+++ b/pkg/cli/instance/status.go
@@ -95,14 +95,9 @@ func (is *InstanceStatusRunner) watch(
 	opts StatusOptions,
 	lastOutput string,
 ) error {
-	interval := opts.Interval
-	if interval <= 0 {
-		interval = 2 * time.Second
-	}
-
 	poll := newInstancePoll(c, opts.Cluster, opts.Namespace, opts.Name)
 
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(opts.Interval)
 	defer ticker.Stop()
 
 	for {
@@ -113,7 +108,7 @@ func (is *InstanceStatusRunner) watch(
 			inst, err := poll(ctx)
 			if err != nil {
 				if _, ok := errors.AsType[*wait.RetryableError](err); ok {
-					is.l.Warnf("%v — retrying in %s", err, interval)
+					is.l.Warnf("%v — retrying in %s", err, opts.Interval)
 					continue
 				}
 				return err

--- a/pkg/cli/waitcmd/waitcmd.go
+++ b/pkg/cli/waitcmd/waitcmd.go
@@ -14,7 +14,8 @@
 // limitations under the License.
 
 // Package waitcmd holds the command-layer plumbing shared by every
-// `<resource> create --wait` command (flag validation and exit-code mapping),
+// `<resource> create --wait` command and `instance status --watch` (flag
+// validation and exit-code mapping),
 // so it lives in one place instead of drifting between per-resource copies.
 package waitcmd
 
@@ -49,6 +50,17 @@ func ValidateWaitFlags(waitSet, timeoutChanged bool, timeout time.Duration) erro
 	}
 	if waitSet && timeout <= 0 {
 		return errors.New("--timeout must be a positive duration (use e.g. --timeout 10m)")
+	}
+	return nil
+}
+
+// ValidateWatchFlags rejects --interval without --watch and non-positive intervals.
+func ValidateWatchFlags(watchSet, intervalChanged bool, interval time.Duration) error {
+	if intervalChanged && !watchSet {
+		return errors.New("--interval is only valid together with --watch")
+	}
+	if watchSet && interval <= 0 {
+		return errors.New("--interval must be a positive duration (use e.g. --interval 5s)")
 	}
 	return nil
 }

--- a/pkg/cli/waitcmd/waitcmd_test.go
+++ b/pkg/cli/waitcmd/waitcmd_test.go
@@ -79,3 +79,34 @@ func TestValidateWaitFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateWatchFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		watchSet        bool
+		interval        time.Duration
+		intervalChanged bool // whether --interval was explicitly passed
+		wantErr         string
+	}{
+		{"interval without watch", false, 5 * time.Second, true, "only valid together with --watch"},
+		{"watch with zero interval", true, 0, true, "positive duration"},
+		{"watch with negative interval", true, -time.Second, true, "positive duration"},
+		{"watch with default interval", true, 2 * time.Second, false, ""},
+		{"watch with custom interval", true, 5 * time.Second, true, ""},
+		{"neither flag", false, 2 * time.Second, false, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateWatchFlags(tc.watchSet, tc.intervalChanged, tc.interval)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3107

## Why

`instance status --interval` says it is "only valid with --watch", but nothing enforced it: without `--watch` the flag was accepted and ignored, and `--interval 0s` was silently rewritten to 2s. The sibling `instance create --timeout` already rejects the same two cases through `waitcmd.ValidateWaitFlags`, so the rule was checked in one command and skipped in another.

## What

- `waitcmd.ValidateWatchFlags` next to `ValidateWaitFlags`, rejecting `--interval` without `--watch` and any non-positive interval
- `statusRun` calls it before building the runner, printing the error and exiting 1, same as `createRun`
- the `if interval <= 0` coercion in the watch loop is gone: the value is validated before it gets there, so the loop uses `opts.Interval` as given
- table test for the new validator alongside the existing one

## Checked

`go test ./pkg/cli/waitcmd/ ./pkg/cli/instance/` passes; `golangci-lint run --new-from-rev=HEAD` on the touched packages reports 0 issues.

Built `everestctl` from this branch and ran the three cases from the issue:

```
$ everestctl instance status --name x -n y --interval 5s
❌ --interval is only valid together with --watch
(exit 1)

$ everestctl instance status --name x -n y --watch --interval 0s
❌ --interval must be a positive duration (use e.g. --interval 5s)
(exit 1)

$ everestctl instance status --name x -n y --watch --interval 5s
❌ no active context found in config — run 'everestctl auth login' first
```

The last one shows a valid combination getting past validation to the normal auth check.
