### PR TITLE
fix(api): reject duplicate backup schedule names

### DIFF
--- a/internal/server/handlers/validation/database_cluster.go
+++ b/internal/server/handlers/validation/database_cluster.go
@@ -330,13 +330,20 @@ func validatePitrSpec(cluster *everestv1alpha1.DatabaseCluster) error {
 }
 
 func checkDuplicateSchedules(schedules []everestv1alpha1.BackupSchedule) error {
-	unique := make(map[string]struct{})
+	uniqueExpr := make(map[string]struct{})
+	uniqueName := make(map[string]struct{})
 	for _, schedule := range schedules {
-		key := schedule.Schedule
-		if _, ok := unique[key]; ok {
+		if _, ok := uniqueExpr[schedule.Schedule]; ok {
 			return errDuplicatedSchedules
 		}
-		unique[key] = struct{}{}
+		uniqueExpr[schedule.Schedule] = struct{}{}
+
+		// The operator keys schedules by name, so a duplicate would silently
+		// overwrite the earlier one on reconcile.
+		if _, ok := uniqueName[schedule.Name]; ok {
+			return errDuplicatedScheduleNames
+		}
+		uniqueName[schedule.Name] = struct{}{}
 	}
 	return nil
 }

--- a/internal/server/handlers/validation/database_cluster_test.go
+++ b/internal/server/handlers/validation/database_cluster_test.go
@@ -405,6 +405,30 @@ func TestValidateBackupSpec(t *testing.T) {
 			err: errDuplicatedSchedules,
 		},
 		{
+			name: "errDuplicatedScheduleNames",
+			cluster: &everestv1alpha1.DatabaseCluster{
+				Spec: everestv1alpha1.DatabaseClusterSpec{
+					Backup: everestv1alpha1.Backup{
+						Schedules: []everestv1alpha1.BackupSchedule{
+							{
+								Enabled:           true,
+								Name:              "daily",
+								Schedule:          "0 0 * * *",
+								BackupStorageName: "some",
+							},
+							{
+								Enabled:           true,
+								Name:              "daily",
+								Schedule:          "0 6 * * *",
+								BackupStorageName: "some",
+							},
+						},
+					},
+				},
+			},
+			err: errDuplicatedScheduleNames,
+		},
+		{
 			name: "valid spec",
 			cluster: &everestv1alpha1.DatabaseCluster{
 				Spec: everestv1alpha1.DatabaseClusterSpec{

--- a/internal/server/handlers/validation/errors.go
+++ b/internal/server/handlers/validation/errors.go
@@ -61,6 +61,7 @@ var (
 	errDBEngineMajorUpgradeNotSeq    = errors.New("database engine major version upgrade is not supported for non-sequential versions")
 	errDBEngineDowngrade             = errors.New("database engine version cannot be downgraded")
 	errDuplicatedSchedules           = errors.New("duplicated backup schedules are not allowed")
+	errDuplicatedScheduleNames       = errors.New("duplicated backup schedule names are not allowed")
 	errDuplicatedStoragePG           = errors.New("postgres clusters can't use the same storage for the different schedules")
 	errStorageChangePG               = errors.New("the existing postgres schedules can't change their storage")
 	errShardingIsNotSupported        = errors.New("sharding is not supported")


### PR DESCRIPTION
Fixes #3018

## Why

`checkDuplicateSchedules` only deduplicates on the cron expression. Two schedules with the same `name` and different crons pass validation, the API answers 200, and the operator, which keys schedules by name, keeps only one of them on reconcile. A backup policy the user configured simply stops running with no error or event.

The `name` field is already required to be non-empty in `validateBackupSpec`, so uniqueness was the one missing check. Targeting `v1.x` because `checkDuplicateSchedules` and the `DatabaseCluster` validation path only exist there; `main` (v2) validates Instances differently.

## What

- `checkDuplicateSchedules` tracks names in a second map and returns a new `errDuplicatedScheduleNames`
- one more case in the `validateBackupSpec` table test: same name, different cron → rejected. The existing cases (same cron, and a valid spec) keep covering the other two combinations from the issue

## Checked

`go test ./internal/server/handlers/validation/` passes; with the fix stashed and only the test in place, the new case fails, so the test does pin the behaviour. `golangci-lint run --new-from-rev=HEAD` on the package reports 0 issues. `make copyright-check` passes.

I have not reproduced this against a running cluster; the reasoning follows the report and the validation code, and the unit test is what I actually ran.
