### PR TITLE
Fix `cli` interactive test hanging on real terminal

### DIFF
--- a/pkg/cli/instance/delete_test.go
+++ b/pkg/cli/instance/delete_test.go
@@ -286,6 +286,7 @@ func TestDelete_VerboseAloneDoesNotForceNonInteractive(t *testing.T) {
 		Cluster:    "main",
 		JSON:       false,
 		IsTerminal: func() bool { return true },
+		Yes:        true,
 	}
 
 	id := NewDeleter(Config{Pretty: false}, zap.NewNop().Sugar())


### PR DESCRIPTION
Same issue as https://github.com/openeverest/openeverest/pull/3068. This one was missed initially because `make test` uses cached results. With `-count=1` tests run without cache.

`SIGINT` was used to kill test after a while and below shows hanging instance package test.

```
ok  	github.com/openeverest/openeverest/v2/pkg/cli/instance	68.437s
```

```
 % go test -count=1 -race ./...
?   	github.com/openeverest/openeverest/v2/api/backup/v1alpha1	[no test files]
?   	github.com/openeverest/openeverest/v2/api/backup/v1alpha1/jobspec	[no test files]
?   	github.com/openeverest/openeverest/v2/api/common/v1alpha1	[no test files]
?   	github.com/openeverest/openeverest/v2/api/core/v1alpha1	[no test files]
?   	github.com/openeverest/openeverest/v2/api/extensions/v1alpha1	[no test files]
?   	github.com/openeverest/openeverest/v2/api/monitoring/v1alpha1	[no test files]
?   	github.com/openeverest/openeverest/v2/api-tests/node_modules/flatted/golang/pkg/flatted	[no test files]
?   	github.com/openeverest/openeverest/v2/cli-tests/node_modules/flatted/golang/pkg/flatted	[no test files]
?   	github.com/openeverest/openeverest/v2/client	[no test files]
?   	github.com/openeverest/openeverest/v2/cmd	[no test files]
?   	github.com/openeverest/openeverest/v2/cmd/cli	[no test files]
?   	github.com/openeverest/openeverest/v2/cmd/config	[no test files]
?   	github.com/openeverest/openeverest/v2/cmd/controller	[no test files]
ok  	github.com/openeverest/openeverest/v2/commands	2.172s
?   	github.com/openeverest/openeverest/v2/commands/accounts	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/auth	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/backup	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/backupclass	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/backupstorage	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/common	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/extension	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/instance	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/namespaces	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/provider	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/restore	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/settings	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/settings/oidc	[no test files]
?   	github.com/openeverest/openeverest/v2/commands/settings/rbac	[no test files]
?   	github.com/openeverest/openeverest/v2/data	[no test files]
?   	github.com/openeverest/openeverest/v2/hack	[no test files]
ok  	github.com/openeverest/openeverest/v2/hack/gen-crds-openapi	2.488s
?   	github.com/openeverest/openeverest/v2/hack/gen-rbac-resources	[no test files]
?   	github.com/openeverest/openeverest/v2/internal/controller/backup	[no test files]
?   	github.com/openeverest/openeverest/v2/internal/controller/extension	[no test files]
?   	github.com/openeverest/openeverest/v2/internal/controller/monitoring	[no test files]
ok  	github.com/openeverest/openeverest/v2/internal/server	3.952s
?   	github.com/openeverest/openeverest/v2/internal/server/api	[no test files]
?   	github.com/openeverest/openeverest/v2/internal/server/handlers	[no test files]
ok  	github.com/openeverest/openeverest/v2/internal/server/handlers/k8s	4.720s
ok  	github.com/openeverest/openeverest/v2/internal/server/handlers/rbac	6.583s
ok  	github.com/openeverest/openeverest/v2/internal/server/handlers/validation	6.481s
ok  	github.com/openeverest/openeverest/v2/internal/tokenregistry	7.391s
?   	github.com/openeverest/openeverest/v2/internal/webhook/monitoring/v1alpha1	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/accounts	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/accounts/cli	7.601s
?   	github.com/openeverest/openeverest/v2/pkg/cli	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/cli/auth	7.446s
ok  	github.com/openeverest/openeverest/v2/pkg/cli/backup	10.649s
                                                                       ok  	github.com/openeverest/openeverest/v2/pkg/cli/backupclass	7.508s
                              ok  	github.com/openeverest/openeverest/v2/pkg/cli/backupstorage	7.101s
                                                                                                              ok  github.com/openeverest/openeverest/v2/pkg/cli/clienterr	7.089s
                                                              ok  	github.com/openeverest/openeverest/v2/pkg/cli/clientmeta	6.954s
                      ok  	github.com/openeverest/openeverest/v2/pkg/cli/config	6.832s
                                                                                              ok  	github.com/openeverest/openeverest/v2/pkg/cli/confirm	6.675s
                                                      ok  	github.com/openeverest/openeverest/v2/pkg/cli/deletion	5.432s
              ?   	github.com/openeverest/openeverest/v2/pkg/cli/extension	[no test files]
                                                                                               ok  	github.com/openeverest/openeverest/v2/pkg/cli/helm	5.444s
                                              ok  	github.com/openeverest/openeverest/v2/pkg/cli/helm/utils	4.063s
     ok  	github.com/openeverest/openeverest/v2/pkg/cli/install	4.652s
                                                                              ok  	github.com/openeverest/openeverest/v2/pkg/cli/instance	68.437s
ok  	github.com/openeverest/openeverest/v2/pkg/cli/namespaces	4.502s
ok  	github.com/openeverest/openeverest/v2/pkg/cli/provider	4.483s
ok  	github.com/openeverest/openeverest/v2/pkg/cli/restore	7.307s
ok  	github.com/openeverest/openeverest/v2/pkg/cli/status	5.162s
?   	github.com/openeverest/openeverest/v2/pkg/cli/steps	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/cli/tui	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/cli/uninstall	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/cli/upgrade	5.720s
ok  	github.com/openeverest/openeverest/v2/pkg/cli/utils	6.189s
ok  	github.com/openeverest/openeverest/v2/pkg/cli/wait	5.744s
ok  	github.com/openeverest/openeverest/v2/pkg/cli/waitcmd	5.761s
ok  	github.com/openeverest/openeverest/v2/pkg/common	6.209s
ok  	github.com/openeverest/openeverest/v2/pkg/convertors	5.719s
ok  	github.com/openeverest/openeverest/v2/pkg/events	6.451s
ok  	github.com/openeverest/openeverest/v2/pkg/kubernetes	6.990s
?   	github.com/openeverest/openeverest/v2/pkg/kubernetes/informer	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/logger	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/oidc	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/output	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/plugintoken	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/pmm	6.555s
ok  	github.com/openeverest/openeverest/v2/pkg/rbac	7.022s
ok  	github.com/openeverest/openeverest/v2/pkg/rbac/configmap-adapter	7.033s
?   	github.com/openeverest/openeverest/v2/pkg/rbac/io-reader-adapter	[no test files]
?   	github.com/openeverest/openeverest/v2/pkg/rbac/mocks	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/rbac/utils	5.861s
ok  	github.com/openeverest/openeverest/v2/pkg/session	10.015s
?   	github.com/openeverest/openeverest/v2/pkg/utils/must	[no test files]
ok  	github.com/openeverest/openeverest/v2/pkg/version	3.657s
?   	github.com/openeverest/openeverest/v2/pkg/version_service	[no test files]
ok  	github.com/openeverest/openeverest/v2/provider-runtime/conformance	5.550s
ok  	github.com/openeverest/openeverest/v2/provider-runtime/controller	5.776s
ok  	github.com/openeverest/openeverest/v2/provider-runtime/internal/instanceprep	6.294s
?   	github.com/openeverest/openeverest/v2/provider-runtime/openapi	[no test files]
ok  	github.com/openeverest/openeverest/v2/provider-runtime/reconciler	7.561s
ok  	github.com/openeverest/openeverest/v2/provider-runtime/server	6.595s
?   	github.com/openeverest/openeverest/v2/public	[no test files]
```