### PR TITLE
fix: name the actual assignee and likely cause on delegated assign failure

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -125,7 +125,11 @@ jobs:
             // confirm rather than trusting the call to have taken effect.
             const { data: after } = await github.rest.issues.get({ owner, repo, issue_number });
             if (!(after.assignees || []).some((a) => a.login === target)) {
-              await reply(`@${commenter} I couldn't assign this to you — GitHub rejected the assignment. A maintainer will pick this up shortly.`);
+              if (target === commenter) {
+                await reply(`@${commenter} I couldn't assign this to you — GitHub rejected the assignment. A maintainer will pick this up shortly.`);
+              } else {
+                await reply(`@${commenter} I couldn't assign this to @${target} — GitHub rejected the assignment. This is usually because @${target} hasn't commented on this issue yet; GitHub only accepts assignees who are collaborators or have already participated in the thread. Ask them to comment here first, then try \`/assign @${target}\` again.`);
+              }
               return;
             }
 


### PR DESCRIPTION
Fixes #2839

The bot's rejection message only made sense for self-assign. If a maintainer delegates with `/assign @someone`, it still says "I couldn't assign this to you" and tells them a maintainer will pick it up, which is weird when they're the maintainer.

#2841 already tried to fix this but got stuck on the branch rename (targets `v1.x`, so the workflow can't even run) plus a DCO issue. Redoing it fresh against `main`.

This is a draft PR for now, keeping it small, and thats why its simple too.