### PR TITLE
fix: allow reordering of static wizard sections via sectionsorder

### DIFF
--- a/docs/ui/architecture/ui-generator/schema-reference.md
+++ b/docs/ui/architecture/ui-generator/schema-reference.md
@@ -10,7 +10,7 @@ Read the diagrams top-down: topology → sections → components (leaf fields) /
 ```mermaid
 flowchart TD
   T["TopologyUISchemas"] --> TP["Topology<br/>(by topology name)"]
-  TP --> SO["sectionsOrder?"]
+  TP --> SO["sectionsOrder?<br/>(supports static step IDs)"]
   TP --> S["sections"]
   S --> SEC["Section<br/>(by section name)"]
   SEC --> SM["label? / description?"]
@@ -200,6 +200,7 @@ classDiagram
 | **CEL validation**             | Cross-field validation rules declared via `celExpressions` (with an `original` namespace available in edit mode)                                                                                                                 | implemented |
 | **CEL conditional rendering**  | Show / hide fields based on another field value through a generic mechanism                                                                                                                                                      | 🛠️          |
 | **group kernel**               | `groupType: bordered/collapsible/toggleable` + `gate` + `direction`                                                                                                                                                              | 🛠️          |
+| **static step reordering**     | `sectionsOrder` supports reserved static wizard step IDs (`import`, `backups`) alongside schema section keys, producing unified wizard navigation and preview order                                                            | implemented |
 
 ## To Consider
 
@@ -209,4 +210,4 @@ classDiagram
 
 - Owner: UI
 - Status: current
-- Last updated: 2026-09-02
+- Last updated: 2026-09-03

--- a/docs/ui/ui-generator/Readme.md
+++ b/docs/ui/ui-generator/Readme.md
@@ -252,25 +252,33 @@ Array binding is not supported yet — see [Known Limitations](known-limitations
 
 Both sections and groups can specify the order of their child elements using the `Order` suffix:
 
-- **`sectionsOrder`**: Array of section keys defining section order
-- **`componentsOrder`**: Array of component keys defining component order within a section or group
+- **`sectionsOrder`**: Array of section keys defining section order. It can also reference reserved static wizard step IDs (`import`, `backups`) intermixed with schema section keys to shape the multi-step wizard flow and right-side preview.
+- **`componentsOrder`**: Array of component keys defining component order within a section or group.
 
 If not specified, the order is determined by the object key insertion order. If only a few sections are ordered, they will be ordered and displayed first. The remaining sections/components will be displayed next by the object key insertion order.
 
-**Example:**
+#### Static Step Reordering Rules
+
+In the database creation wizard, static steps can be reordered via `sectionsOrder`:
+
+- **`base` stays pinned first**: The `base` step (which contains basic database information and topology selection) is always pinned at the start of the wizard and cannot be reordered.
+- **Default positioning**: Active static steps not listed in `sectionsOrder` keep their default position (immediately after `base`, before schema-generated sections) for full backward compatibility.
+- **Reserved IDs and precedence**: Reserved static step IDs are `base`, `import`, and `backups` (`pod-scheduling` is planned). If a schema section key collides with any reserved ID, the static step takes precedence and the generated step is dropped — regardless of whether `sectionsOrder` is present. Plugin authors must avoid naming schema sections with reserved static IDs.
+
+**Example: Moving Backups to the end**
 
 ```yaml
-sections:
-  basicInfo: { ... }
-  resources: { ... }
-  advanced: { ... }
-sectionsOrder:
-  - basicInfo
-  - resources
-  - advanced
+replicaSet:
+  sections:
+    resources: { ... }
+    advanced: { ... }
+  sectionsOrder:
+    - resources
+    - advanced
+    - backups # Reserved static step ID → rendered last
 ```
 
-The next is also valid:
+The next is also valid (reordering schema sections only, while unlisted static steps remain in their default position before schema sections):
 
 ```yaml
 sectionsOrder:

--- a/ui/apps/everest/src/components/ui-generator/form-engine/index.ts
+++ b/ui/apps/everest/src/components/ui-generator/form-engine/index.ts
@@ -15,6 +15,11 @@
 export { useFormEngine } from './use-form-engine';
 export { useStepNavigation } from './use-step-navigation';
 export { useErrorRouting, flattenErrorPaths } from './use-error-routing';
+export {
+  mergeWizardSteps,
+  DEFAULT_PINNED_STEP_ID,
+  DEFAULT_RESERVED_STATIC_STEP_IDS,
+} from './merge-wizard-steps';
 export type {
   StepDefinition,
   StepProps,
@@ -22,3 +27,4 @@ export type {
   FormEngineResult,
 } from './types';
 export type { StepNavigationResult } from './use-step-navigation';
+export type { MergeWizardStepsOptions } from './merge-wizard-steps';

--- a/ui/apps/everest/src/components/ui-generator/form-engine/merge-wizard-steps.test.ts
+++ b/ui/apps/everest/src/components/ui-generator/form-engine/merge-wizard-steps.test.ts
@@ -1,0 +1,240 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+import { StepDefinition } from './types';
+import { mergeWizardSteps } from './merge-wizard-steps';
+
+const createDummyStep = (id: string, sectionKey?: string): StepDefinition => ({
+  id,
+  label: id,
+  sectionKey,
+  component: () => null,
+  fields: [],
+});
+
+describe('mergeWizardSteps', () => {
+  const baseStep = createDummyStep('base');
+  const importStep = createDummyStep('import');
+  const backupStep = createDummyStep('backups');
+
+  const standardStaticSteps = [baseStep, importStep, backupStep];
+
+  const buildGeneratedStepsMap = (
+    keys: string[]
+  ): Map<string, StepDefinition> => {
+    const map = new Map<string, StepDefinition>();
+    for (const key of keys) {
+      map.set(key, createDummyStep(`section:${key}`, key));
+    }
+    return map;
+  };
+
+  it('1. should keep default order when sectionsOrder is undefined (backward compat)', () => {
+    const generatedSteps = buildGeneratedStepsMap(['resources', 'advanced']);
+
+    const result = mergeWizardSteps(standardStaticSteps, generatedSteps);
+
+    expect(result.map((s) => s.id)).toEqual([
+      'base',
+      'import',
+      'backups',
+      'section:resources',
+      'section:advanced',
+    ]);
+  });
+
+  it('2. should keep default static positions when sectionsOrder lists only schema keys', () => {
+    const generatedSteps = buildGeneratedStepsMap(['resources', 'advanced']);
+
+    const result = mergeWizardSteps(
+      standardStaticSteps,
+      generatedSteps,
+      ['resources', 'advanced']
+    );
+
+    expect(result.map((s) => s.id)).toEqual([
+      'base',
+      'import',
+      'backups',
+      'section:resources',
+      'section:advanced',
+    ]);
+  });
+
+  it('3. should move backups to the end when specified in sectionsOrder', () => {
+    const generatedSteps = buildGeneratedStepsMap(['resources', 'advanced']);
+
+    const result = mergeWizardSteps(
+      standardStaticSteps,
+      generatedSteps,
+      ['resources', 'advanced', 'backups']
+    );
+
+    expect(result.map((s) => s.id)).toEqual([
+      'base',
+      'import',
+      'section:resources',
+      'section:advanced',
+      'backups',
+    ]);
+  });
+
+  it('4. should place backups between schema sections when specified in sectionsOrder', () => {
+    const generatedSteps = buildGeneratedStepsMap(['resources', 'advanced']);
+
+    const result = mergeWizardSteps(
+      standardStaticSteps,
+      generatedSteps,
+      ['resources', 'backups', 'advanced']
+    );
+
+    expect(result.map((s) => s.id)).toEqual([
+      'base',
+      'import',
+      'section:resources',
+      'backups',
+      'section:advanced',
+    ]);
+  });
+
+  it('5. should keep base pinned at index 0 even if listed later in sectionsOrder', () => {
+    const generatedSteps = buildGeneratedStepsMap(['resources', 'advanced']);
+
+    const result = mergeWizardSteps(
+      standardStaticSteps,
+      generatedSteps,
+      ['base', 'resources', 'backups']
+    );
+
+    expect(result.map((s) => s.id)).toEqual([
+      'base',
+      'import',
+      'section:resources',
+      'backups',
+      'section:advanced',
+    ]);
+  });
+
+  it('6. should ignore unknown keys in sectionsOrder', () => {
+    const generatedSteps = buildGeneratedStepsMap(['resources', 'advanced']);
+
+    const result = mergeWizardSteps(
+      standardStaticSteps,
+      generatedSteps,
+      ['resources', 'nonexistent', 'advanced']
+    );
+
+    expect(result.map((s) => s.id)).toEqual([
+      'base',
+      'import',
+      'backups',
+      'section:resources',
+      'section:advanced',
+    ]);
+  });
+
+  it('7. should order correctly when no static steps except base exist', () => {
+    const generatedSteps = buildGeneratedStepsMap(['resources', 'advanced']);
+
+    const result = mergeWizardSteps(
+      [baseStep],
+      generatedSteps,
+      ['resources', 'advanced']
+    );
+
+    expect(result.map((s) => s.id)).toEqual([
+      'base',
+      'section:resources',
+      'section:advanced',
+    ]);
+  });
+
+  it('8. should append unlisted generated steps at the end for partial sectionsOrder', () => {
+    const generatedSteps = buildGeneratedStepsMap(['resources', 'advanced']);
+
+    const result = mergeWizardSteps(
+      standardStaticSteps,
+      generatedSteps,
+      ['advanced']
+    );
+
+    expect(result.map((s) => s.id)).toEqual([
+      'base',
+      'import',
+      'backups',
+      'section:advanced',
+      'section:resources',
+    ]);
+  });
+
+  it('9. should drop generated section on collision with backups when explicit in sectionsOrder (fixture: base + backups, no import)', () => {
+    // Schema defines a section keyed 'backups' in addition to resources
+    const generatedSteps = buildGeneratedStepsMap(['backups', 'resources']);
+    const staticSteps = [baseStep, backupStep]; // no import step in this fixture
+
+    const result = mergeWizardSteps(
+      staticSteps,
+      generatedSteps,
+      ['backups', 'resources']
+    );
+
+    // Only the static backups step is present; generated section:backups is dropped
+    expect(result.map((s) => s.id)).toEqual([
+      'base',
+      'backups',
+      'section:resources',
+    ]);
+  });
+
+  it('10. should drop generated section on collision with backups when sectionsOrder is undefined (fixture: base + backups, no import)', () => {
+    // Schema defines a section keyed 'backups' in addition to resources and advanced
+    const generatedSteps = buildGeneratedStepsMap([
+      'backups',
+      'resources',
+      'advanced',
+    ]);
+    const staticSteps = [baseStep, backupStep]; // no import step in this fixture
+
+    const result = mergeWizardSteps(staticSteps, generatedSteps);
+
+    // Only the static backups step is present; generated section:backups is dropped
+    expect(result.map((s) => s.id)).toEqual([
+      'base',
+      'backups',
+      'section:resources',
+      'section:advanced',
+    ]);
+  });
+
+  it('11. should drop generated section on collision with import (fixture: base + import + backups)', () => {
+    // Schema defines a section keyed 'import' in addition to resources
+    const generatedSteps = buildGeneratedStepsMap(['import', 'resources']);
+
+    const result = mergeWizardSteps(
+      standardStaticSteps,
+      generatedSteps,
+      ['import', 'resources']
+    );
+
+    // Static backups is unlisted so it keeps its default position before generated sections;
+    // Static import is listed and rendered; generated section:import is dropped
+    expect(result.map((s) => s.id)).toEqual([
+      'base',
+      'backups',
+      'import',
+      'section:resources',
+    ]);
+  });
+});

--- a/ui/apps/everest/src/components/ui-generator/form-engine/merge-wizard-steps.ts
+++ b/ui/apps/everest/src/components/ui-generator/form-engine/merge-wizard-steps.ts
@@ -1,0 +1,113 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { StepDefinition } from './types';
+
+export const DEFAULT_PINNED_STEP_ID = 'base';
+export const DEFAULT_RESERVED_STATIC_STEP_IDS: ReadonlySet<string> = new Set([
+  'base',
+  'import',
+  'backups',
+]);
+
+export interface MergeWizardStepsOptions {
+  pinnedStepId?: string;
+  reservedStaticStepIds?: ReadonlySet<string>;
+}
+
+export const mergeWizardSteps = (
+  staticSteps: StepDefinition[],
+  generatedSteps: Map<string, StepDefinition>,
+  sectionsOrder?: string[],
+  options?: MergeWizardStepsOptions
+): StepDefinition[] => {
+  const pinnedStepId = options?.pinnedStepId ?? DEFAULT_PINNED_STEP_ID;
+  const reservedStaticStepIds =
+    options?.reservedStaticStepIds ?? DEFAULT_RESERVED_STATIC_STEP_IDS;
+
+  const baseStep = staticSteps.find((s) => s.id === pinnedStepId);
+  const nonBaseStaticSteps = staticSteps.filter((s) => s.id !== pinnedStepId);
+  const activeStaticStepMap = new Map(
+    nonBaseStaticSteps.map((step) => [step.id, step])
+  );
+
+  // Step 0: Filter collisions across all reserved static step IDs.
+  // Schema sections sharing a key with any reserved static step ID are dropped.
+  const collisionIds = new Set([...reservedStaticStepIds, pinnedStepId]);
+  const filteredGeneratedSteps = new Map<string, StepDefinition>();
+  for (const [key, step] of generatedSteps.entries()) {
+    if (!collisionIds.has(key)) {
+      filteredGeneratedSteps.set(key, step);
+    }
+  }
+
+  const result: StepDefinition[] = [];
+  if (baseStep) {
+    result.push(baseStep);
+  }
+
+  // Step 2: When no explicit sectionsOrder is provided, keep default ordering
+  if (!sectionsOrder || sectionsOrder.length === 0) {
+    for (const staticStep of nonBaseStaticSteps) {
+      result.push(staticStep);
+    }
+    for (const genStep of filteredGeneratedSteps.values()) {
+      result.push(genStep);
+    }
+    return result;
+  }
+
+  // Step 3: Partition non-base static steps into listed vs unlisted
+  const orderSet = new Set(sectionsOrder);
+  const unlistedStaticSteps = nonBaseStaticSteps.filter(
+    (step) => !orderSet.has(step.id)
+  );
+
+  // Unlisted static steps retain their default position before generated sections
+  for (const staticStep of unlistedStaticSteps) {
+    result.push(staticStep);
+  }
+
+  // Step 4: Walk sectionsOrder
+  const addedStepIds = new Set(result.map((step) => step.id));
+
+  for (const key of sectionsOrder) {
+    if (key === pinnedStepId) {
+      continue;
+    }
+
+    const staticStep = activeStaticStepMap.get(key);
+    if (staticStep && !addedStepIds.has(staticStep.id)) {
+      result.push(staticStep);
+      addedStepIds.add(staticStep.id);
+      continue;
+    }
+
+    const genStep = filteredGeneratedSteps.get(key);
+    if (genStep && !addedStepIds.has(genStep.id)) {
+      result.push(genStep);
+      addedStepIds.add(genStep.id);
+    }
+  }
+
+  // Step 5: Append any remaining generated steps not referenced in sectionsOrder
+  for (const genStep of filteredGeneratedSteps.values()) {
+    if (!addedStepIds.has(genStep.id)) {
+      result.push(genStep);
+      addedStepIds.add(genStep.id);
+    }
+  }
+
+  return result;
+};

--- a/ui/apps/everest/src/components/ui-generator/form-engine/use-form-engine.ts
+++ b/ui/apps/everest/src/components/ui-generator/form-engine/use-form-engine.ts
@@ -21,6 +21,8 @@ import { getSectionStepId } from '../utils/section-step-id';
 import { UIGenerator } from '../ui-generator';
 import { applyModeOverrides } from '../utils/preprocess/apply-mode-overrides';
 
+import { mergeWizardSteps } from './merge-wizard-steps';
+
 /**
  * Core form-engine hook.
  *
@@ -58,52 +60,49 @@ export const useFormEngine = (config: FormEngineConfig): FormEngineResult => {
     [sections, formMode]
   );
 
-  // 2. Build generated steps from schema sections
-  const sectionKeys = useMemo(
-    () => sectionsOrder || Object.keys(effectiveSections),
-    [sectionsOrder, effectiveSections]
-  );
+  // 2. Build generated steps map from schema sections
+  const generatedStepsMap = useMemo(() => {
+    const map = new Map<string, StepDefinition>();
 
-  const generatedSteps: StepDefinition[] = useMemo(
-    () =>
-      sectionKeys.map((sectionKey): StepDefinition => {
-        const section = effectiveSections[sectionKey];
+    for (const sectionKey of Object.keys(effectiveSections)) {
+      const section = effectiveSections[sectionKey];
 
-        // Collect field paths owned by this section
-        const fields = Object.entries(sectionFieldMap)
-          .filter(([, sk]) => sk === sectionKey)
-          .map(([fieldPath]) => fieldPath);
+      // Collect field paths owned by this section
+      const fields = Object.entries(sectionFieldMap)
+        .filter(([, sk]) => sk === sectionKey)
+        .map(([fieldPath]) => fieldPath);
 
-        // Each generated step renders UIGenerator for its section
-        const GeneratedStepComponent = ({
-          loadingDefaultsForEdition,
-        }: {
-          loadingDefaultsForEdition?: boolean;
-        }) =>
-          React.createElement(UIGenerator, {
-            sectionKey,
-            sections: effectiveSections,
-            providerObject,
-            loadingDefaultsForEdition,
-            namespace,
-          });
-
-        return {
-          id: getSectionStepId(sectionKey),
-          label: section?.label || sectionKey,
-          description: section?.description,
+      // Each generated step renders UIGenerator for its section
+      const GeneratedStepComponent = ({
+        loadingDefaultsForEdition,
+      }: {
+        loadingDefaultsForEdition?: boolean;
+      }) =>
+        React.createElement(UIGenerator, {
           sectionKey,
-          component: GeneratedStepComponent,
-          fields,
-        };
-      }),
-    [sectionKeys, effectiveSections, sectionFieldMap, providerObject, namespace]
-  );
+          sections: effectiveSections,
+          providerObject,
+          loadingDefaultsForEdition,
+          namespace,
+        });
 
-  // 3. Merge static + generated steps
+      map.set(sectionKey, {
+        id: getSectionStepId(sectionKey),
+        label: section?.label || sectionKey,
+        description: section?.description,
+        sectionKey,
+        component: GeneratedStepComponent,
+        fields,
+      });
+    }
+
+    return map;
+  }, [effectiveSections, sectionFieldMap, providerObject, namespace]);
+
+  // 3. Merge static + generated steps into a unified order
   const steps = useMemo(
-    () => [...staticSteps, ...generatedSteps],
-    [staticSteps, generatedSteps]
+    () => mergeWizardSteps(staticSteps, generatedStepsMap, sectionsOrder),
+    [staticSteps, generatedStepsMap, sectionsOrder]
   );
 
   // 4. Build complete field → step-ID map

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/constants.ts
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/constants.ts
@@ -15,3 +15,9 @@
 export const BASE_STEP_ID = 'base';
 export const IMPORT_STEP_ID = 'import';
 export const BACKUP_STEP_ID = 'backups';
+
+export const RESERVED_STATIC_STEP_IDS = new Set([
+  BASE_STEP_ID,
+  IMPORT_STEP_ID,
+  BACKUP_STEP_ID,
+]);

--- a/ui/apps/everest/src/pages/database-form/database-form-context.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-context.tsx
@@ -18,6 +18,7 @@ import {
   TopologyUISchemas,
 } from 'components/ui-generator/ui-generator.types';
 import { Provider } from 'shared-types/api.types';
+import { StepDefinition } from 'components/ui-generator/form-engine';
 
 type DatabaseFormContextType = {
   uiSchema: TopologyUISchemas;
@@ -28,6 +29,7 @@ type DatabaseFormContextType = {
   sectionsOrder?: string[];
   providerObject?: Provider;
   hasBackupStep: boolean;
+  steps?: StepDefinition[];
 };
 
 const DatabaseFormContext = createContext<DatabaseFormContextType | null>(null);

--- a/ui/apps/everest/src/pages/database-form/database-form.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form.tsx
@@ -518,6 +518,7 @@ export const DatabasePage = () => {
         sectionsOrder: engine.sectionsOrder,
         providerObject,
         hasBackupStep,
+        steps: engine.steps,
       }}
     >
       <Stack direction={isDesktop ? 'row' : 'column'}>

--- a/ui/apps/everest/src/pages/database-form/database-preview/database-preview.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-preview/database-preview.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Stack, Typography } from '@mui/material';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useLocation } from 'react-router-dom';
@@ -30,6 +30,10 @@ import {
   IMPORT_STEP_ID,
 } from '../database-form-body/steps/constants.ts';
 import { getSectionStepId } from 'components/ui-generator/utils/section-step-id.ts';
+import {
+  mergeWizardSteps,
+  StepDefinition,
+} from 'components/ui-generator/form-engine';
 
 export const DatabasePreview = ({
   activeStepId,
@@ -42,51 +46,98 @@ export const DatabasePreview = ({
   const { getValues } = useFormContext<DbWizardType>();
   const location = useLocation();
   const showImportStep = location.state?.showImport;
-  const { sections, sectionsOrder, hasBackupStep } = useDatabaseFormContext();
+  const { sections, sectionsOrder, hasBackupStep, steps } =
+    useDatabaseFormContext();
 
   // Trigger a re-render when any form value changes so the preview stays in sync
   useWatch();
 
   const values = getValues();
 
-  const orderedSectionKeys = sectionsOrder || Object.keys(sections);
+  const fallbackSteps = useMemo((): StepDefinition[] => {
+    if (steps) {
+      return steps;
+    }
+
+    const fallbackStaticSteps: StepDefinition[] = [
+      {
+        id: BASE_STEP_ID,
+        label: 'Basic Information',
+        component: () => null,
+        fields: [],
+      },
+    ];
+
+    if (showImportStep) {
+      fallbackStaticSteps.push({
+        id: IMPORT_STEP_ID,
+        label: 'Import information',
+        component: () => null,
+        fields: [],
+      });
+    }
+
+    if (hasBackupStep) {
+      fallbackStaticSteps.push({
+        id: BACKUP_STEP_ID,
+        label: 'Backups',
+        component: () => null,
+        fields: [],
+      });
+    }
+
+    const genMap = new Map<string, StepDefinition>();
+    for (const key of Object.keys(sections)) {
+      genMap.set(key, {
+        id: getSectionStepId(key),
+        label: sections[key]?.label || key,
+        sectionKey: key,
+        component: () => null,
+        fields: [],
+      });
+    }
+
+    return mergeWizardSteps(fallbackStaticSteps, genMap, sectionsOrder);
+  }, [steps, showImportStep, hasBackupStep, sections, sectionsOrder]);
+
+  const effectiveSteps = steps || fallbackSteps;
 
   const previewSections: {
     stepId: string;
     title: string;
     content: React.ReactNode;
-  }[] = [
-    {
-      stepId: BASE_STEP_ID,
-      title: 'Basic Information',
-      content: <PreviewSectionOne {...values} />,
-    },
-    ...(showImportStep
-      ? [
-          {
-            stepId: IMPORT_STEP_ID,
-            title: 'Import information',
-            content: <PreviewContentText text="" />,
-          },
-        ]
-      : []),
-    ...(hasBackupStep
-      ? [
-          {
-            stepId: BACKUP_STEP_ID,
-            title: 'Backups',
-            content: <PreviewBackupSection {...values} />,
-          },
-        ]
-      : []),
-    ...orderedSectionKeys.map((key) => ({
-      stepId: getSectionStepId(key),
-      title: sections[key]?.label || key,
-      content: (
-        <DynamicSectionPreview section={sections[key]} formValues={values} />
-      ),
-    })),
-  ];
+  }[] = effectiveSteps.map((step) => {
+    if (step.id === BASE_STEP_ID) {
+      return {
+        stepId: BASE_STEP_ID,
+        title: 'Basic Information',
+        content: <PreviewSectionOne {...values} />,
+      };
+    }
+    if (step.id === IMPORT_STEP_ID) {
+      return {
+        stepId: IMPORT_STEP_ID,
+        title: 'Import information',
+        content: <PreviewContentText text="" />,
+      };
+    }
+    if (step.id === BACKUP_STEP_ID) {
+      return {
+        stepId: BACKUP_STEP_ID,
+        title: 'Backups',
+        content: <PreviewBackupSection {...values} />,
+      };
+    }
+    const sectionKey = step.sectionKey;
+    const section = sectionKey ? sections[sectionKey] : undefined;
+    return {
+      stepId: step.id,
+      title: section?.label || step.label || step.id,
+      content: section ? (
+        <DynamicSectionPreview section={section} formValues={values} />
+      ) : null,
+    };
+  });
 
   return (
     <Stack

--- a/ui/apps/everest/src/pages/database-form/database-preview/sections-order.test.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-preview/sections-order.test.tsx
@@ -198,4 +198,130 @@ describe('DatabasePreview - Sections Order', () => {
     expect(screen.getByText(/Resources/)).toBeInTheDocument();
     expect(screen.getByText(/Advanced Configurations/)).toBeInTheDocument();
   });
+
+  it('should render backups at the end when specified in sectionsOrder', () => {
+    const sections: { [key: string]: Section } = {
+      resources: {
+        label: 'Resources',
+        components: {},
+      },
+      advancedConfigurations: {
+        label: 'Advanced Configurations',
+        components: {},
+      },
+    };
+
+    const sectionsOrder = ['resources', 'advancedConfigurations', 'backups'];
+
+    render(
+      <FormProviderWrapper>
+        <TestWrapper>
+          <DatabaseFormProvider
+            value={{
+              uiSchema: {},
+              topologies: ['replica'],
+              hasMultipleTopologies: false,
+              defaultTopology: 'replica',
+              sections,
+              sectionsOrder,
+              providerObject: undefined,
+              hasBackupStep: true,
+            }}
+          >
+            <DatabasePreview stepsWithErrors={[]} activeStepId="base" />
+          </DatabaseFormProvider>
+        </TestWrapper>
+      </FormProviderWrapper>
+    );
+
+    const allSections = screen.getAllByText(/^\d+\./);
+    expect(allSections[0]).toHaveTextContent('1. Basic Information');
+    expect(allSections[1]).toHaveTextContent('2. Resources');
+    expect(allSections[2]).toHaveTextContent('3. Advanced Configurations');
+    expect(allSections[3]).toHaveTextContent('4. Backups');
+  });
+
+  it('should render backups between schema sections when specified in sectionsOrder', () => {
+    const sections: { [key: string]: Section } = {
+      resources: {
+        label: 'Resources',
+        components: {},
+      },
+      advancedConfigurations: {
+        label: 'Advanced Configurations',
+        components: {},
+      },
+    };
+
+    const sectionsOrder = ['resources', 'backups', 'advancedConfigurations'];
+
+    render(
+      <FormProviderWrapper>
+        <TestWrapper>
+          <DatabaseFormProvider
+            value={{
+              uiSchema: {},
+              topologies: ['replica'],
+              hasMultipleTopologies: false,
+              defaultTopology: 'replica',
+              sections,
+              sectionsOrder,
+              providerObject: undefined,
+              hasBackupStep: true,
+            }}
+          >
+            <DatabasePreview stepsWithErrors={[]} activeStepId="base" />
+          </DatabaseFormProvider>
+        </TestWrapper>
+      </FormProviderWrapper>
+    );
+
+    const allSections = screen.getAllByText(/^\d+\./);
+    expect(allSections[0]).toHaveTextContent('1. Basic Information');
+    expect(allSections[1]).toHaveTextContent('2. Resources');
+    expect(allSections[2]).toHaveTextContent('3. Backups');
+    expect(allSections[3]).toHaveTextContent('4. Advanced Configurations');
+  });
+
+  it('should keep backups before schema sections when not listed in sectionsOrder (backward compat)', () => {
+    const sections: { [key: string]: Section } = {
+      resources: {
+        label: 'Resources',
+        components: {},
+      },
+      advancedConfigurations: {
+        label: 'Advanced Configurations',
+        components: {},
+      },
+    };
+
+    const sectionsOrder = ['resources', 'advancedConfigurations'];
+
+    render(
+      <FormProviderWrapper>
+        <TestWrapper>
+          <DatabaseFormProvider
+            value={{
+              uiSchema: {},
+              topologies: ['replica'],
+              hasMultipleTopologies: false,
+              defaultTopology: 'replica',
+              sections,
+              sectionsOrder,
+              providerObject: undefined,
+              hasBackupStep: true,
+            }}
+          >
+            <DatabasePreview stepsWithErrors={[]} activeStepId="base" />
+          </DatabaseFormProvider>
+        </TestWrapper>
+      </FormProviderWrapper>
+    );
+
+    const allSections = screen.getAllByText(/^\d+\./);
+    expect(allSections[0]).toHaveTextContent('1. Basic Information');
+    expect(allSections[1]).toHaveTextContent('2. Backups');
+    expect(allSections[2]).toHaveTextContent('3. Resources');
+    expect(allSections[3]).toHaveTextContent('4. Advanced Configurations');
+  });
 });


### PR DESCRIPTION
### Summary
* Allows static form steps (such as Backups or Import) to be custom reordered alongside dynamically generated schema sections using `sectionsOrder`
* Synchronized the step sequence between the step-by-step form wizard and the summary preview panel so they always stay in sync.
* Preserves original default section placements whenever a custom section order is not explicitly provided.
* added unit test coverage  and updated docs accordingly too.

Closes : #3021 