### PR TITLE
Bump helm-charts pin to pick up the Instance CRD sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.1.0
 	github.com/oapi-codegen/runtime v1.7.0
-	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260819095409-311840d26860
+	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260903133756-9025c81860d1
 	github.com/operator-framework/api v0.45.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20260429065444-70caa52c384a
 	github.com/rodaine/table v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -853,8 +853,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260819095409-311840d26860 h1:AMDqdhV9Bs95Ruu6XW+OcHYpBDgHI9F7PoEwcEZPS3s=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260819095409-311840d26860/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260903133756-9025c81860d1 h1:UzjdPOY78hHLTdhbsoCoraDkjw3rETpQExZK77jOTLg=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260903133756-9025c81860d1/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
 github.com/operator-framework/api v0.45.0 h1:hkROwtsLH3oszp4IW+WsXEFSDgveSahHI7DKStOtrUI=
 github.com/operator-framework/api v0.45.0/go.mod h1:IQ4uuISTiIhV09oAurJSGD4KabayhY5nV6k1XmA235M=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=


### PR DESCRIPTION
Bumps the everest chart dependency to helm-charts@`9025c818` — the merge of openeverest/helm-charts#102, which synced the `Instance`/`InstancePreset` CRDs (maintenance API from #3081 plus accumulated drift).

Unblocks the `dev-be-ci` chart-pin check (`make update-dev-chart && git diff --exit-code`), red since that merge per the cross-repo pin rule. Generated with `make update-dev-chart`.