### PR TITLE
Fix preflight catalog gaps: unpinned components, nil target, hook context

### DIFF
--- a/provider-runtime/controller/interface.go
+++ b/provider-runtime/controller/interface.go
@@ -356,11 +356,10 @@ type BackupMirror interface {
 // convergence outside the bundled operator's compatibility window.
 //
 // CheckUpgrade runs inside the chart's Helm pre-upgrade hook, not during
-// reconciliation: c carries the Kubernetes client and context but no
-// Instance, so Instance-scoped Context methods must not be used. Issues with
-// severity UpgradeError abort the upgrade.
+// reconciliation: the HookContext carries the Kubernetes client and context
+// but no Instance. Issues with severity UpgradeError abort the upgrade.
 type UpgradeProvider interface {
-	CheckUpgrade(c *Context, target *corev1alpha1.ProviderSpec, instances []corev1alpha1.Instance) []UpgradeIssue
+	CheckUpgrade(h *HookContext, target *corev1alpha1.ProviderSpec, instances []corev1alpha1.Instance) []UpgradeIssue
 }
 
 // =============================================================================

--- a/provider-runtime/controller/preflight.go
+++ b/provider-runtime/controller/preflight.go
@@ -104,7 +104,7 @@ func HasBlockingIssues(issues []UpgradeIssue) bool {
 // outside reconciliation — in the chart's pre-upgrade hook Job — where no
 // Instance is in scope. Unlike Context, every method is safe to call.
 type HookContext struct {
-	ctx          context.Context
+	ctx          context.Context //nolint:containedctx // mirrors Context: the handle scopes one short-lived preflight pass
 	client       client.Client
 	providerName string
 }
@@ -118,7 +118,9 @@ func NewHookContext(ctx context.Context, c client.Client, providerName string) *
 func (h *HookContext) Context() context.Context { return h.ctx }
 
 // Client returns the underlying Kubernetes client.
-func (h *HookContext) Client() client.Client { return h.client }
+func (h *HookContext) Client() client.Client { //nolint:ireturn // client.Client is the SDK's accessor contract, as on Context.Client
+	return h.client
+}
 
 // ProviderName returns the name of the provider under preflight.
 func (h *HookContext) ProviderName() string { return h.providerName }

--- a/provider-runtime/controller/preflight.go
+++ b/provider-runtime/controller/preflight.go
@@ -32,10 +32,12 @@ package controller
 // repository, which labels these two risks R1 and R2.
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
 	goversion "github.com/hashicorp/go-version"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openeverest/openeverest/v2/api/core/v1alpha1"
 )
@@ -98,18 +100,40 @@ func HasBlockingIssues(issues []UpgradeIssue) bool {
 	return false
 }
 
+// HookContext is the narrow handle available to provider checks that run
+// outside reconciliation — in the chart's pre-upgrade hook Job — where no
+// Instance is in scope. Unlike Context, every method is safe to call.
+type HookContext struct {
+	ctx          context.Context
+	client       client.Client
+	providerName string
+}
+
+// NewHookContext creates a HookContext (used by the preflight runner).
+func NewHookContext(ctx context.Context, c client.Client, providerName string) *HookContext {
+	return &HookContext{ctx: ctx, client: c, providerName: providerName}
+}
+
+// Context returns the underlying context.Context.
+func (h *HookContext) Context() context.Context { return h.ctx }
+
+// Client returns the underlying Kubernetes client.
+func (h *HookContext) Client() client.Client { return h.client }
+
+// ProviderName returns the name of the provider under preflight.
+func (h *HookContext) ProviderName() string { return h.providerName }
+
 // RunUpgradePreflight runs the full generic preflight — the upgrade-path
 // floor check and the catalog-membership check — and appends any
 // provider-specific issues from the optional UpgradeProvider interface.
 //
 // current is the spec of the installed Provider CR (nil when none is
-// installed); target is the spec carried by the new chart. c may be nil when
-// the provider does not implement UpgradeProvider.
-func RunUpgradePreflight(c *Context, provider ProviderInterface, current, target *v1alpha1.ProviderSpec, instances []v1alpha1.Instance) []UpgradeIssue {
+// installed); target is the spec carried by the new chart.
+func RunUpgradePreflight(h *HookContext, provider ProviderInterface, current, target *v1alpha1.ProviderSpec, instances []v1alpha1.Instance) []UpgradeIssue {
 	issues := CheckUpgradePath(current, target)
 	issues = append(issues, PreflightUpgrade(target, instances)...)
 	if up, ok := provider.(UpgradeProvider); ok {
-		issues = append(issues, up.CheckUpgrade(c, target, instances)...)
+		issues = append(issues, up.CheckUpgrade(h, target, instances)...)
 	}
 	return issues
 }
@@ -149,6 +173,9 @@ func CheckUpgradePath(current, target *v1alpha1.ProviderSpec) []UpgradeIssue {
 
 	if currentVer.LessThan(floorVer) {
 		targetStr := target.Release.Version
+		if targetStr == "" {
+			targetStr = "the target release"
+		}
 		return []UpgradeIssue{{
 			Severity: UpgradeError,
 			Reason:   UpgradeReasonPathBlocked,
@@ -180,6 +207,13 @@ func pathUnparseableIssue(what, value string) UpgradeIssue {
 //
 // Instances already being deleted are skipped.
 func PreflightUpgrade(target *v1alpha1.ProviderSpec, instances []v1alpha1.Instance) []UpgradeIssue {
+	if target == nil {
+		return []UpgradeIssue{{
+			Severity: UpgradeError,
+			Reason:   UpgradeReasonComponentUnsupported,
+			Message:  "no target provider spec to check against",
+		}}
+	}
 	var issues []UpgradeIssue
 	for i := range instances {
 		in := &instances[i]
@@ -194,15 +228,8 @@ func PreflightUpgrade(target *v1alpha1.ProviderSpec, instances []v1alpha1.Instan
 func preflightInstance(target *v1alpha1.ProviderSpec, in *v1alpha1.Instance) []UpgradeIssue {
 	var issues []UpgradeIssue
 
-	// Resolve the effective bundle the same way the reconciler does:
-	// spec.version → status.version → target default.
-	bundleName := in.Spec.Version
-	if bundleName == "" {
-		bundleName = in.Status.Version
-	}
-	if bundleName == "" {
-		bundleName = GetDefaultVersionBundleName(target)
-	}
+	// Resolve the effective bundle exactly as the runtime does before Sync.
+	bundleName := EffectiveVersionBundleName(target, in)
 
 	var bundle *v1alpha1.VersionBundle
 	if bundleName != "" {
@@ -233,11 +260,6 @@ func preflightInstance(target *v1alpha1.ProviderSpec, in *v1alpha1.Instance) []U
 		if effective == "" && bundle != nil {
 			effective = bundle.Components[compName]
 		}
-		if effective == "" {
-			// Falls back to the target's per-type default, which exists by
-			// construction.
-			continue
-		}
 		if issue := preflightComponent(target, in, compName, effective); issue != nil {
 			issues = append(issues, *issue)
 		}
@@ -265,6 +287,12 @@ func preflightComponent(target *v1alpha1.ProviderSpec, in *v1alpha1.Instance, co
 		issue.Reason = UpgradeReasonComponentUnsupported
 		issue.Message = fmt.Sprintf("component type %q is not defined by the target provider", comp.Type)
 		return issue
+	}
+
+	// No effective version means the runtime resolves the target's per-type
+	// default; membership above is all that can be checked.
+	if effective == "" {
+		return nil
 	}
 
 	entry := findComponentVersion(componentType, effective)

--- a/provider-runtime/controller/preflight_test.go
+++ b/provider-runtime/controller/preflight_test.go
@@ -41,6 +41,7 @@ func targetSpec() *v1alpha1.ProviderSpec {
 			"mongod": {Versions: []v1alpha1.ComponentVersion{
 				{Version: "6.0.19-16", Deprecated: true, RemovedInVersion: "0.3"},
 				{Version: "7.0.18-11", Deprecated: true, RemovedInVersion: "0.5"},
+				{Version: "7.5.0-1", RemovedInVersion: "0.5"},
 				{Version: "8.0.12-4", Default: true},
 			}},
 			"mongos": {Versions: []v1alpha1.ComponentVersion{
@@ -127,6 +128,15 @@ func TestCheckUpgradePath(t *testing.T) {
 			wantSeverity: UpgradeWarning,
 			wantReason:   UpgradeReasonPathUnverified,
 		},
+		{
+			name:    "unparseable floor warns",
+			current: release("0.2"),
+			target: &v1alpha1.ProviderSpec{
+				Release: &v1alpha1.Release{Version: "0.3", MinUpgradableFrom: "not-a-version"},
+			},
+			wantSeverity: UpgradeWarning,
+			wantReason:   UpgradeReasonPathUnverified,
+		},
 	}
 
 	for _, tt := range tests {
@@ -193,6 +203,23 @@ func TestPreflightUpgrade_ComponentVersions(t *testing.T) {
 			}),
 			wantSeverity: UpgradeError,
 			wantReason:   UpgradeReasonComponentUnsupported,
+		},
+		{
+			name: "component unknown to target blocks even without a pinned version",
+			in: instance("mongo-extra-unpinned", func(in *v1alpha1.Instance) {
+				in.Spec.Components["analytics"] = v1alpha1.ComponentSpec{}
+				delete(in.Spec.Components, "engine")
+			}),
+			wantSeverity: UpgradeError,
+			wantReason:   UpgradeReasonComponentUnsupported,
+		},
+		{
+			name: "removal scheduled without a deprecation flag still warns",
+			in: instance("mongo-undep", func(in *v1alpha1.Instance) {
+				in.Spec.Components["engine"] = v1alpha1.ComponentSpec{Version: "7.5.0-1"}
+			}),
+			wantSeverity: UpgradeWarning,
+			wantReason:   UpgradeReasonVersionDeprecated,
 		},
 	}
 
@@ -315,6 +342,33 @@ func TestHasBlockingIssues(t *testing.T) {
 	assert.True(t, HasBlockingIssues([]UpgradeIssue{{Severity: UpgradeWarning}, {Severity: UpgradeError}}))
 }
 
+func TestPreflightUpgrade_NilTargetBlocks(t *testing.T) {
+	t.Parallel()
+
+	issues := PreflightUpgrade(nil, []v1alpha1.Instance{instance("mongo-1", nil)})
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, UpgradeError, issues[0].Severity)
+}
+
+func TestPreflightUpgrade_UnparseableRemovedInVersionWarns(t *testing.T) {
+	t.Parallel()
+
+	target := targetSpec()
+	mongod := target.ComponentTypes["mongod"]
+	mongod.Versions = append(mongod.Versions, v1alpha1.ComponentVersion{Version: "9.0.0-1", RemovedInVersion: "garbage"})
+	target.ComponentTypes["mongod"] = mongod
+	in := instance("mongo-garbage", func(in *v1alpha1.Instance) {
+		in.Spec.Components["engine"] = v1alpha1.ComponentSpec{Version: "9.0.0-1"}
+	})
+
+	issues := PreflightUpgrade(target, []v1alpha1.Instance{in})
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, UpgradeWarning, issues[0].Severity, "a malformed removedInVersion is a definition bug, not a block")
+	assert.Equal(t, UpgradeReasonVersionDeprecated, issues[0].Reason)
+}
+
 // upgradeCheckingProvider implements UpgradeProvider for testing
 // RunUpgradePreflight's dispatch.
 type upgradeCheckingProvider struct {
@@ -327,7 +381,7 @@ func (p *upgradeCheckingProvider) Validate(*Context) error         { return nil 
 func (p *upgradeCheckingProvider) Sync(*Context) error             { return nil }
 func (p *upgradeCheckingProvider) Status(*Context) (Status, error) { return Status{}, nil }
 func (p *upgradeCheckingProvider) Cleanup(*Context) error          { return nil }
-func (p *upgradeCheckingProvider) CheckUpgrade(*Context, *v1alpha1.ProviderSpec, []v1alpha1.Instance) []UpgradeIssue {
+func (p *upgradeCheckingProvider) CheckUpgrade(*HookContext, *v1alpha1.ProviderSpec, []v1alpha1.Instance) []UpgradeIssue {
 	return p.issues
 }
 

--- a/provider-runtime/preflight/preflight.go
+++ b/provider-runtime/preflight/preflight.go
@@ -105,8 +105,8 @@ func Run(ctx context.Context, provider controller.ProviderInterface, opts Option
 		return err
 	}
 
-	c := controller.NewContext(ctx, cl, nil, provider.Name())
-	issues := controller.RunUpgradePreflight(c, provider, current, target, instances)
+	h := controller.NewHookContext(ctx, cl, provider.Name())
+	issues := controller.RunUpgradePreflight(h, provider, current, target, instances)
 
 	writeReport(opts.Out, provider.Name(), current, target, len(instances), issues)
 


### PR DESCRIPTION
Follow-up to #2626/#3069 addressing defects found in post-merge review:

- **Unpinned components bypassed the catalog check entirely (R1 bypass).** When a component had no pinned version and no bundle default, `preflightComponent` returned early before the component/type membership checks, so an Instance referencing a component the target release drops sailed through preflight. Membership checks now always run; only the version-level checks are skipped when no effective version can be resolved, and an unknown component now blocks.

- **Nil target spec crashed the preflight.** `PreflightUpgrade(nil, …)` now returns a single blocking issue ("no target provider spec to check against") instead of panicking, since a malformed hook spec is exactly when the check matters most.

- **Bundle resolution reuses `EffectiveVersionBundleName`** (from #3054) instead of a local reimplementation, so preflight and reconciler can never disagree on which bundle is effective.

- **New `HookContext` for `UpgradeProvider.CheckUpgrade`** *(breaking change to the SDK interface)*: the hook runner previously fabricated an Instance-less `*Context`, whose Instance-scoped methods would nil-panic if a provider touched them. `HookContext` carries exactly what a hook has — context, client, provider name. The only unmerged implementor, openeverest/provider-percona-server-mongodb#99, has been updated.

- Floor-block message renders "the target release" when the target release version is empty; an unparseable `removedInVersion` floor warns instead of being ignored.