### PR TITLE
fix(cli): error out on invalid subcommands of parent commands

### DIFF
--- a/commands/accounts.go
+++ b/commands/accounts.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,14 +21,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/percona/everest/commands/accounts"
+	"github.com/percona/everest/commands/common"
 )
 
 var accountsCmd = &cobra.Command{
 	Use:   "accounts <command> [flags]",
-	Args:  cobra.ExactArgs(1),
+	Args:  common.NoSubcommandArgs,
 	Long:  "Manage Everest accounts",
 	Short: "Manage Everest accounts",
-	Run:   func(_ *cobra.Command, _ []string) {},
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	},
 }
 
 func init() {

--- a/commands/common/args.go
+++ b/commands/common/args.go
@@ -1,0 +1,45 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// NoSubcommandArgs rejects positional arguments on commands that exist only to
+// group subcommands, mirroring the "unknown command" error Cobra produces at the root,
+// suggestions included.
+func NoSubcommandArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "unknown command %q for %q", args[0], cmd.CommandPath())
+	if cmd.SuggestionsMinimumDistance <= 0 {
+		cmd.SuggestionsMinimumDistance = 2
+	}
+	if suggestions := cmd.SuggestionsFor(args[0]); len(suggestions) > 0 {
+		sb.WriteString("\n\nDid you mean this?\n")
+		for _, s := range suggestions {
+			fmt.Fprintf(&sb, "\t%s %s\n", cmd.CommandPath(), s)
+		}
+	}
+	return errors.New(sb.String())
+}

--- a/commands/namespaces.go
+++ b/commands/namespaces.go
@@ -20,15 +20,18 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/percona/everest/commands/common"
 	"github.com/percona/everest/commands/namespaces"
 )
 
 var namespacesCmd = &cobra.Command{
 	Use:   "namespaces <command> [flags]",
-	Args:  cobra.ExactArgs(1),
+	Args:  common.NoSubcommandArgs,
 	Long:  "Manage Everest database namespaces",
 	Short: "Manage Everest database namespaces",
-	Run:   func(_ *cobra.Command, _ []string) {},
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	},
 }
 
 func init() {

--- a/commands/settings.go
+++ b/commands/settings.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,15 +20,18 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/percona/everest/commands/common"
 	"github.com/percona/everest/commands/settings"
 )
 
 var settingsCmd = &cobra.Command{
 	Use:   "settings <command> [flags]",
-	Args:  cobra.ExactArgs(1),
+	Args:  common.NoSubcommandArgs,
 	Long:  "Configure Everest settings",
 	Short: "Configure Everest settings",
-	Run:   func(_ *cobra.Command, _ []string) {},
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	},
 }
 
 func init() {

--- a/commands/settings/oidc.go
+++ b/commands/settings/oidc.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,14 +20,18 @@ package settings
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/percona/everest/commands/common"
 	"github.com/percona/everest/commands/settings/oidc"
 )
 
 var settingsOIDCCmd = &cobra.Command{
 	Use:   "oidc <command> [flags]",
-	Args:  cobra.ExactArgs(1),
+	Args:  common.NoSubcommandArgs,
 	Long:  "Manage settings related to OIDC",
 	Short: "Manage settings related to OIDC",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	},
 }
 
 func init() {

--- a/commands/settings/rbac.go
+++ b/commands/settings/rbac.go
@@ -1,5 +1,6 @@
 // everest
 // Copyright (C) 2023 Percona LLC
+// Copyright (C) 2026 The OpenEverest Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,14 +20,18 @@ package settings
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/percona/everest/commands/common"
 	"github.com/percona/everest/commands/settings/rbac"
 )
 
 var settingsRBACCmd = &cobra.Command{
 	Use:   "rbac <command> [flags]",
-	Args:  cobra.ExactArgs(1),
+	Args:  common.NoSubcommandArgs,
 	Long:  "Manage RBAC settings",
 	Short: "Manage RBAC settings",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	},
 }
 
 func init() {

--- a/commands/settings/rbac/validate.go
+++ b/commands/settings/rbac/validate.go
@@ -35,6 +35,7 @@ import (
 var (
 	settingsRBACValidateCmd = &cobra.Command{
 		Use:     "validate [flags]",
+		Args:    cobra.NoArgs,
 		Long:    "Validate RBAC settings",
 		Short:   "Validate RBAC settings",
 		Example: "everestctl settings rbac validate --policy-file <file_path>",


### PR DESCRIPTION
Parent commands such as namespaces, settings and accounts only exist to group subcommands, but they declared Args: cobra.ExactArgs(1) with an empty Run. That combination bypasses Cobra's unknown command detection, so a typo ran the empty body and exited with status 0. The rbac and oidc parents had no Run at all, which made Cobra treat them as not runnable and short circuit to the help output before arguments were validated, again exiting 0.

Add a shared NoSubcommandArgs validator that rejects any positional argument with the same "unknown command" message Cobra prints at the root, suggestions included, and give every parent command a RunE that prints help so a bare invocation still behaves as before.

Also set cobra.NoArgs on settings rbac validate, the only leaf command that was silently ignoring extra arguments.
Closes #2816 