### PR TITLE
fix(plugins): activate host version check and inherit typography/shape tokens

### DIFF
--- a/internal/server/everest.go
+++ b/internal/server/everest.go
@@ -59,6 +59,7 @@ import (
 	"github.com/openeverest/openeverest/v2/pkg/kubernetes"
 	"github.com/openeverest/openeverest/v2/pkg/oidc"
 	"github.com/openeverest/openeverest/v2/pkg/session"
+	"github.com/openeverest/openeverest/v2/pkg/version"
 	"github.com/openeverest/openeverest/v2/public"
 )
 
@@ -221,7 +222,12 @@ func (e *EverestServer) initHTTPServer(ctx context.Context) error {
 			// See the securityHeaders middleware for more information.
 			return c.Render(
 				http.StatusOK, "index.html",
-				map[string]any{"CSPNonce": secure.CSPNonce(c.Request().Context())},
+				map[string]any{
+					"CSPNonce": secure.CSPNonce(c.Request().Context()),
+					// Published so the UI can enforce a plugin's
+					// spec.compatibleHostVersions at load time.
+					"EverestVersion": version.Version,
+				},
 			)
 		}, e.securityHeaders(),
 	)

--- a/ui/apps/everest/index.html
+++ b/ui/apps/everest/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/static/everest.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="csp-nonce" content="{{.CSPNonce}}" />
+    <meta name="everest-version" content="{{.EverestVersion}}" />
     <title>OpenEverest</title>
     <script type="importmap" nonce="{{.CSPNonce}}">
       {

--- a/ui/apps/everest/src/contexts/plugins/plugin-version.test.ts
+++ b/ui/apps/everest/src/contexts/plugins/plugin-version.test.ts
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { parseVersion, satisfiesHostVersion } from './plugin-version';
+
+describe('parseVersion', () => {
+  it('accepts the v-prefixed versions Everest actually reports', () => {
+    // RELEASE_VERSION is v-prefixed and may carry a build suffix.
+    expect(parseVersion('v2.1.3')).toEqual([2, 1, 3]);
+    expect(parseVersion('v0.3.0-1-a93bef')).toEqual([0, 3, 0]);
+    expect(parseVersion('2.1.3')).toEqual([2, 1, 3]);
+  });
+
+  it('returns null for values that are not versions', () => {
+    expect(parseVersion('dev')).toBeNull();
+    // `vite dev` serves index.html without running the Go template.
+    expect(parseVersion('{{.EverestVersion}}')).toBeNull();
+    expect(parseVersion('')).toBeNull();
+  });
+});
+
+describe('satisfiesHostVersion', () => {
+  it('permits a plugin that declares no range', () => {
+    expect(satisfiesHostVersion('v2.1.0', undefined)).toBe(true);
+    expect(satisfiesHostVersion('v2.1.0', '')).toBe(true);
+  });
+
+  it('never gates when the host version is unusable', () => {
+    expect(satisfiesHostVersion('dev', '>=2.0.0')).toBe(true);
+    expect(satisfiesHostVersion('{{.EverestVersion}}', '>=2.0.0')).toBe(true);
+  });
+
+  it('never gates on a local build (v0.0.0-<sha>)', () => {
+    expect(satisfiesHostVersion('v0.0.0-a93bef', '>=2.0.0')).toBe(true);
+  });
+
+  it('accepts a host inside the declared range', () => {
+    expect(satisfiesHostVersion('v2.1.0', '>=2.0.0 <3.0.0')).toBe(true);
+    expect(satisfiesHostVersion('v2.1.0', '^2.0.0')).toBe(true);
+    expect(satisfiesHostVersion('v2.1.4', '~2.1.0')).toBe(true);
+  });
+
+  it('rejects a host outside the declared range', () => {
+    expect(satisfiesHostVersion('v3.0.0', '>=2.0.0 <3.0.0')).toBe(false);
+    expect(satisfiesHostVersion('v1.9.0', '>=2.0.0')).toBe(false);
+    expect(satisfiesHostVersion('v3.0.0', '^2.0.0')).toBe(false);
+    expect(satisfiesHostVersion('v2.2.0', '~2.1.0')).toBe(false);
+  });
+
+  it('supports || alternatives', () => {
+    expect(satisfiesHostVersion('v3.1.0', '^2.0.0 || ^3.0.0')).toBe(true);
+    expect(satisfiesHostVersion('v4.0.0', '^2.0.0 || ^3.0.0')).toBe(false);
+  });
+
+  it('tolerates a v-prefixed range', () => {
+    expect(satisfiesHostVersion('v2.1.0', '>=v2.0.0')).toBe(true);
+    expect(satisfiesHostVersion('v1.0.0', '>=v2.0.0')).toBe(false);
+  });
+});

--- a/ui/apps/everest/src/contexts/plugins/plugin-version.ts
+++ b/ui/apps/everest/src/contexts/plugins/plugin-version.ts
@@ -1,0 +1,84 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Host-version handling for the plugin compatibility check, kept out of the
+// context module so it can be unit tested without pulling in the provider.
+
+/**
+ * Everest reports versions with a leading `v` and an optional build suffix
+ * (e.g. "v0.3.0-1-a93bef"). Returns null when the value isn't a usable version
+ * — including the "dev" fallback and the unrendered Go template placeholder
+ * that `vite dev` serves, since it doesn't run the server-side template.
+ */
+export function parseVersion(value: string): [number, number, number] | null {
+  const m = value
+    .trim()
+    .replace(/^v/i, '')
+    .match(/^(\d+)\.(\d+)\.(\d+)/);
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+/**
+ * Minimal semver-range satisfaction for the common comparators used in the
+ * Plugin CR's compatibleHostVersions (">=2.0.0 <3.0.0", "^2.1.0", "~2.1.0").
+ * Returns true when the range is empty/unparseable so an unknown range never
+ * silently blocks a plugin (advisory contract, first-party ecosystem).
+ */
+export function satisfiesHostVersion(version: string, range?: string): boolean {
+  if (!range) {
+    return true;
+  }
+  const host = parseVersion(version);
+  // No usable host version, or a local build (RELEASE_VERSION defaults to
+  // v0.0.0-<sha>): never gate plugins during development.
+  if (!host || (host[0] === 0 && host[1] === 0 && host[2] === 0)) {
+    return true;
+  }
+  const cmp = (a: [number, number, number], b: [number, number, number]) =>
+    a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+
+  const evalClause = (clause: string): boolean => {
+    const comparators = clause.trim().split(/\s+/).filter(Boolean);
+    if (comparators.length === 0) {
+      return true;
+    }
+    return comparators.every((c) => {
+      const m = c.match(/^(>=|<=|>|<|=|\^|~)?(v?\d+\.\d+\.\d+)/i);
+      if (!m) {
+        return true;
+      }
+      const op = m[1] || '=';
+      const target = parseVersion(m[2]);
+      if (!target) {
+        return true;
+      }
+      if (op === '^') {
+        const upper: [number, number, number] = [target[0] + 1, 0, 0];
+        return cmp(host, target) >= 0 && cmp(host, upper) < 0;
+      }
+      if (op === '~') {
+        const upper: [number, number, number] = [target[0], target[1] + 1, 0];
+        return cmp(host, target) >= 0 && cmp(host, upper) < 0;
+      }
+      const c0 = cmp(host, target);
+      if (op === '>=') return c0 >= 0;
+      if (op === '<=') return c0 <= 0;
+      if (op === '>') return c0 > 0;
+      if (op === '<') return c0 < 0;
+      return c0 === 0;
+    });
+  };
+
+  return range.split('||').some((clause) => evalClause(clause));
+}

--- a/ui/apps/everest/src/contexts/plugins/plugins.context.tsx
+++ b/ui/apps/everest/src/contexts/plugins/plugins.context.tsx
@@ -26,6 +26,7 @@ import type {
 } from '@openeverest/plugin-sdk';
 import AuthContext from 'contexts/auth/auth.context';
 import { getAuthToken } from 'api/session-token';
+import { satisfiesHostVersion } from './plugin-version';
 
 export interface PluginRegistration {
   name: string;
@@ -77,57 +78,6 @@ function getCSPNonce(): string {
     document.querySelector("meta[name='csp-nonce']")?.getAttribute('content') ||
     ''
   );
-}
-
-// Minimal semver-range satisfaction for the common comparators used in the
-// Plugin CR's compatibleHostVersions (">=2.0.0 <3.0.0", "^2.1.0", "~2.1.0").
-// Returns true when the range is empty/unparseable so an unknown range never
-// silently blocks a plugin (advisory contract, first-party ecosystem).
-function satisfiesHostVersion(version: string, range?: string): boolean {
-  if (!range || version === 'dev') {
-    return true;
-  }
-  const parse = (v: string): [number, number, number] | null => {
-    const m = v.match(/^(\d+)\.(\d+)\.(\d+)/);
-    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
-  };
-  const host = parse(version);
-  if (!host) {
-    return true;
-  }
-  const cmp = (a: [number, number, number], b: [number, number, number]) =>
-    a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
-
-  const evalClause = (clause: string): boolean => {
-    const comparators = clause.trim().split(/\s+/).filter(Boolean);
-    if (comparators.length === 0) {
-      return true;
-    }
-    return comparators.every((c) => {
-      const m = c.match(/^(>=|<=|>|<|=|\^|~)?(\d+\.\d+\.\d+)/);
-      if (!m) {
-        return true;
-      }
-      const op = m[1] || '=';
-      const target = parse(m[2])!;
-      if (op === '^') {
-        const upper: [number, number, number] = [target[0] + 1, 0, 0];
-        return cmp(host, target) >= 0 && cmp(host, upper) < 0;
-      }
-      if (op === '~') {
-        const upper: [number, number, number] = [target[0], target[1] + 1, 0];
-        return cmp(host, target) >= 0 && cmp(host, upper) < 0;
-      }
-      const c0 = cmp(host, target);
-      if (op === '>=') return c0 >= 0;
-      if (op === '<=') return c0 <= 0;
-      if (op === '>') return c0 > 0;
-      if (op === '<') return c0 < 0;
-      return c0 === 0;
-    });
-  };
-
-  return range.split('||').some((clause) => evalClause(clause));
 }
 
 // Build the PluginApi object that the host passes to each plugin's register().

--- a/ui/packages/plugin-ui-lib/src/plugin-theme-provider.tsx
+++ b/ui/packages/plugin-ui-lib/src/plugin-theme-provider.tsx
@@ -21,6 +21,7 @@ import {
   type PaletteMode,
   type PaletteOptions,
   type SimplePaletteColorOptions,
+  type ThemeOptions,
 } from '@mui/material';
 
 // The host publishes its active color scheme here (see @percona/design
@@ -102,6 +103,80 @@ function hostPalette(mode: PaletteMode): PaletteOptions {
   return palette;
 }
 
+// The typography variants MUI emits as `--mui-font-*`.
+const TYPOGRAPHY_VARIANTS = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'subtitle1',
+  'subtitle2',
+  'body1',
+  'body2',
+  'button',
+  'caption',
+  'overline',
+] as const;
+
+// MUI emits each variant as a CSS `font` shorthand:
+//   "<weight> <size>[/<lineHeight>] [<family>]"
+// e.g. "600 1.5rem/22.5px 'Poppins',sans-serif".
+//
+// Note the shorthand cannot express `textTransform` or `letterSpacing`, so those
+// host values do not cross this bridge — see the note in §7.4.
+function fontFromHost(variant: string): Record<string, unknown> | undefined {
+  const raw = readVar(`--mui-font-${variant}`);
+  if (!raw) {
+    return undefined;
+  }
+  // Requiring a numeric weight also rejects non-font values such as
+  // `--mui-font-inherit: inherit inherit/inherit inherit`.
+  const m = raw.match(/^(\d+)\s+([^\s/]+)(?:\/([^\s]+))?(?:\s+(.+))?$/);
+  if (!m) {
+    return undefined;
+  }
+  const [, weight, size, lineHeight, family] = m;
+  const style: Record<string, unknown> = {
+    fontWeight: Number(weight),
+    fontSize: size,
+  };
+  if (lineHeight) {
+    style.lineHeight = lineHeight;
+  }
+  if (family) {
+    style.fontFamily = family;
+  }
+  return style;
+}
+
+// Builds the typography scale from host tokens. Variants the host doesn't
+// publish simply fall back to the plugin's own MUI defaults.
+function hostTypography(): ThemeOptions['typography'] {
+  const typography: Record<string, unknown> = {};
+  for (const variant of TYPOGRAPHY_VARIANTS) {
+    const style = fontFromHost(variant);
+    if (style) {
+      typography[variant] = style;
+    }
+  }
+  // Give unlisted variants the host's body face rather than MUI's default.
+  const bodyFamily = (typography.body1 as Record<string, unknown> | undefined)
+    ?.fontFamily;
+  if (bodyFamily) {
+    typography.fontFamily = bodyFamily;
+  }
+  return Object.keys(typography).length
+    ? (typography as ThemeOptions['typography'])
+    : undefined;
+}
+
+function hostShape(): ThemeOptions['shape'] {
+  const radius = parseFloat(readVar('--mui-shape-borderRadius'));
+  return Number.isFinite(radius) ? { borderRadius: radius } : undefined;
+}
+
 function readHostColorScheme(): PaletteMode {
   if (typeof document === 'undefined') {
     return 'light';
@@ -148,7 +223,17 @@ export const PluginThemeProvider = ({
     () => createCache({ key: cacheKey, nonce, prepend: true }),
     [cacheKey, nonce]
   );
-  const theme = useMemo(() => createTheme({ palette: hostPalette(mode) }), [mode]);
+  // Rebuilt whenever the host colour scheme flips, since every token is read
+  // from the computed CSS variables at that moment.
+  const theme = useMemo(() => {
+    const typography = hostTypography();
+    const shape = hostShape();
+    return createTheme({
+      palette: hostPalette(mode),
+      ...(typography ? { typography } : {}),
+      ...(shape ? { shape } : {}),
+    });
+  }, [mode]);
 
   return (
     <CacheProvider value={cache}>


### PR DESCRIPTION
Follow-ups to the review on #3076.

### 1. Activate host-version compatibility check

The existing compatibility check reads `meta[name="everest-version"]`, but the tag was not being rendered, so the host version was always treated as `dev`.

This commit:
- Passes `version.Version` to the HTML template.
- Renders the `everest-version` meta tag.
- Handles Everest's `v`-prefixed versions.
- Keeps local `v0.0.0-<sha>` development builds ungated.
- Adds tests for compatible/incompatible ranges and version parsing.

### 2. Inherit host typography and shape tokens

The plugin theme previously bridged only the host palette.

This now also reads the host's existing `--mui-font-*` and `--mui-shape-borderRadius` variables, so plugin typography and shape values are closer to the core theme.

This is intentionally a partial improvement. Component-specific `styleOverrides`, `textTransform`, `letterSpacing`, and some rendered font sizes are still not covered by these tokens. Closing those would require either additional host tokens or replicating the relevant core overrides in `ui-lib`.

### Verification

- `go build` / `go vet` / `gofmt` — clean
- TypeScript — 0 errors
- ESLint / Prettier — clean
- New tests — 9/9 passing
- Full suite — 646 passing, 10 pre-existing failures, 19 skipped
- The same 10 failures occur on the original `b8f9a60a` PR head
- Working tree clean