### PR TITLE
fix(cli): delete the InstalledExtension on extension uninstall

### DIFF
--- a/pkg/cli/extension/uninstall.go
+++ b/pkg/cli/extension/uninstall.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	cliutils "github.com/openeverest/openeverest/v2/pkg/cli/utils"
@@ -32,7 +33,8 @@ type UninstallConfig struct {
 	Name           string
 }
 
-// PluginUninstaller uninstalls an extension by deleting its Plugin CR.
+// PluginUninstaller uninstalls an extension by deleting its InstalledExtension
+// and Plugin CRs.
 type PluginUninstaller struct {
 	cfg        UninstallConfig
 	kubeClient kubernetes.KubernetesConnector
@@ -57,11 +59,19 @@ func NewPluginUninstaller(cfg UninstallConfig, l *zap.SugaredLogger) (*PluginUni
 	return pu, nil
 }
 
-// Run deletes the Plugin CR.
+// Run deletes the InstalledExtension and Plugin CRs created by install.
 func (pu *PluginUninstaller) Run(ctx context.Context) error {
 	plugin, err := pu.kubeClient.GetPlugin(ctx, ctrlclient.ObjectKey{Name: pu.cfg.Name})
 	if err != nil {
 		return fmt.Errorf("plugin %q not found: %w", pu.cfg.Name, err)
+	}
+
+	// The InstalledExtension is created next to the Plugin by install, is
+	// cluster-scoped and carries no owner reference, so nothing else will ever
+	// reclaim it. Remove it first, so it doesn't briefly report the Plugin as
+	// missing before it goes away itself.
+	if err := pu.deleteInstalledExtension(ctx); err != nil {
+		return err
 	}
 
 	if err := pu.kubeClient.DeletePlugin(ctx, plugin); err != nil {
@@ -69,5 +79,23 @@ func (pu *PluginUninstaller) Run(ctx context.Context) error {
 	}
 
 	fmt.Printf("Plugin %q uninstalled successfully.\n", pu.cfg.Name)
+	return nil
+}
+
+// deleteInstalledExtension removes the InstalledExtension named after the
+// plugin. A missing one is not an error: the Plugin may have been created
+// without going through install.
+func (pu *PluginUninstaller) deleteInstalledExtension(ctx context.Context) error {
+	ie, err := pu.kubeClient.GetInstalledExtension(ctx, ctrlclient.ObjectKey{Name: pu.cfg.Name})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("cannot read InstalledExtension %q: %w", pu.cfg.Name, err)
+	}
+
+	if err := pu.kubeClient.DeleteInstalledExtension(ctx, ie); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("cannot delete InstalledExtension %q: %w", pu.cfg.Name, err)
+	}
 	return nil
 }

--- a/pkg/cli/extension/uninstall_test.go
+++ b/pkg/cli/extension/uninstall_test.go
@@ -1,0 +1,116 @@
+// everest
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extension
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	common "github.com/openeverest/openeverest/v2/api/common/v1alpha1"
+	extensionsv1alpha1 "github.com/openeverest/openeverest/v2/api/extensions/v1alpha1"
+	"github.com/openeverest/openeverest/v2/pkg/kubernetes"
+)
+
+// newUninstaller builds a PluginUninstaller backed by a fake Kubernetes client
+// holding the given objects.
+func newUninstaller(t *testing.T, name string, objects ...ctrlclient.Object) *PluginUninstaller {
+	t.Helper()
+
+	k := kubernetes.NewEmpty(zap.NewNop().Sugar(), "everest-system").
+		WithKubernetesClient(
+			fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.CreateScheme()).
+				WithObjects(objects...).
+				Build(),
+		)
+
+	return &PluginUninstaller{
+		cfg:        UninstallConfig{Name: name},
+		kubeClient: k,
+		l:          zap.NewNop().Sugar(),
+	}
+}
+
+// testPlugin mirrors what `extension install` creates for a plugin.
+func testPlugin(name string) *extensionsv1alpha1.Plugin {
+	return &extensionsv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: extensionsv1alpha1.PluginSpec{
+			DisplayName: name,
+			Backend:     &extensionsv1alpha1.PluginBackend{ExternalURL: "http://example.svc:8080"},
+		},
+	}
+}
+
+// testInstalledExtension mirrors the InstalledExtension `extension install`
+// creates next to the Plugin — cluster-scoped and with no owner reference.
+func testInstalledExtension(name string) *extensionsv1alpha1.InstalledExtension {
+	return &extensionsv1alpha1.InstalledExtension{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: extensionsv1alpha1.InstalledExtensionSpec{
+			Type: extensionsv1alpha1.InstalledExtensionTypePlugin,
+			Plugin: &extensionsv1alpha1.PluginInstall{
+				PluginRef: common.ObjectRef{Name: name},
+			},
+		},
+	}
+}
+
+func TestUninstall_DeletesPluginAndInstalledExtension(t *testing.T) {
+	t.Parallel()
+
+	const name = "leak-probe"
+	pu := newUninstaller(t, name, testPlugin(name), testInstalledExtension(name))
+
+	require.NoError(t, pu.Run(context.Background()))
+
+	_, err := pu.kubeClient.GetPlugin(context.Background(), ctrlclient.ObjectKey{Name: name})
+	assert.True(t, apierrors.IsNotFound(err), "Plugin should be gone, got %v", err)
+
+	_, err = pu.kubeClient.GetInstalledExtension(context.Background(), ctrlclient.ObjectKey{Name: name})
+	assert.True(t, apierrors.IsNotFound(err), "InstalledExtension should be gone, got %v", err)
+}
+
+func TestUninstall_NoInstalledExtension(t *testing.T) {
+	t.Parallel()
+
+	const name = "manual-plugin"
+	pu := newUninstaller(t, name, testPlugin(name))
+
+	require.NoError(t, pu.Run(context.Background()))
+
+	_, err := pu.kubeClient.GetPlugin(context.Background(), ctrlclient.ObjectKey{Name: name})
+	assert.True(t, apierrors.IsNotFound(err), "Plugin should be gone, got %v", err)
+}
+
+func TestUninstall_MissingPlugin(t *testing.T) {
+	t.Parallel()
+
+	const name = "absent"
+	pu := newUninstaller(t, name)
+
+	err := pu.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `plugin "absent" not found`)
+}


### PR DESCRIPTION
Fixes #2970

`everestctl extension install` creates two objects, a `Plugin` and an
`InstalledExtension`, but `extension uninstall` only deleted the `Plugin`.

The `InstalledExtension` is cluster-scoped and is created with no
`ownerReferences`, so garbage collection never reclaims it, and the
controller's response to a missing `Plugin` is to set a `PluginNotFound`
condition rather than to delete itself. The result is one permanently
`Failed` leftover per install/uninstall cycle, while the command prints
"uninstalled successfully" and exits 0.

`uninstall.go` now deletes the `InstalledExtension` as well, making the
command the exact inverse of `install.go`. It is deleted before the
`Plugin` so the controller does not briefly observe a dangling reference
on the way out. A missing `InstalledExtension` is tolerated rather than
treated as an error, since a `Plugin` can be created without going
through `extension install` — this mirrors how `install` tolerates an
`AlreadyExists` on either object.

`DeleteInstalledExtension` already existed in `pkg/kubernetes`; it just
was not being called.

### Testing

`pkg/cli/extension` had no test file, so this adds `uninstall_test.go`
using the same fake-client setup as `pkg/cli/status`
(`kubernetes.NewEmpty(...).WithKubernetesClient(fakeclient...)`), covering:

- plugin + InstalledExtension → both gone
- plugin only → succeeds, no error on the missing InstalledExtension
- no plugin → the existing "not found" error is unchanged

Observed locally on `main` (`c3de3b9d`):

- `go test ./pkg/cli/extension/...` → `ok`
- reverting only `uninstall.go` and rerunning fails exactly the new
  assertion: `InstalledExtension should be gone, got <nil>`
- `go build ./pkg/... ./commands/...`, `go vet ./pkg/cli/extension/...`,
  `gofmt -l` → clean
- `go tool golangci-lint run ./pkg/cli/extension/...` reports 4 issues,
  the same 4 with and without this diff (two pre-existing `forbidigo`
  `fmt.Printf` hits, one `funlen` on `install.go`, one `modernize` on
  `list.go`); the change introduces none

`go build ./...` cannot run here without a UI build, because
`public/public.go` embeds `dist/*`. That is unrelated to this change.

I have not re-run the cluster repro from the issue; the reasoning above
comes from reading `install.go`, `uninstall.go` and the
`InstalledExtension` controller, and the behaviour is pinned by the unit
tests instead.

### Not in scope

The issue also notes that `install` creates the `InstalledExtension`
without an `ownerReference`. Adding one would let garbage collection
handle this, but it only helps extensions installed after the change and
alters ownership semantics for a cluster-scoped object, so it seemed
worth a separate discussion rather than folding into this fix. Happy to
take it on if you would rather have that instead.

---

This change was written with AI assistance (Claude Code). I have read
the diff, verified the behaviour with the tests above, and can explain
and defend it in review.
