### PR TITLE
[experiment/do-not-merge] RBAC refresh single ConfigMap load (revert #2791 double-load)

### DIFF
--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -127,13 +127,12 @@ func refreshEnforcerInBackground(
 			return
 		}
 
-		// Validate the incoming policy on a throwaway enforcer, so that an invalid
-		// update never reaches the live one.
-		if _, err := newEnforcer(enforcer.GetAdapter(), false); err != nil {
-			l.Errorf("Invalid RBAC policy detected, keeping the previous policy: %s", err)
-			return
-		}
-
+		// EXPERIMENT (revert of #2791 double-load): load the policy once into
+		// the live enforcer, then validate in-memory. #2791 validated on a
+		// throwaway enforcer BEFORE this load, which added a second ConfigMap
+		// GET per RBAC update and ~doubled reload latency. This variant does a
+		// single ConfigMap GET to test that latency as the cause of the flaky
+		// RBAC e2e tests. Not intended for merge.
 		if err := enforcer.LoadPolicy(); err != nil {
 			l.Errorf("Failed to load RBAC policy: %s", err)
 			return
@@ -142,6 +141,11 @@ func refreshEnforcerInBackground(
 		// Calling LoadPolicy() re-writes the entire model, so we need to add back the admin role.
 		if err := loadAdminPolicy(enforcer); err != nil {
 			l.Errorf("Failed to load admin policy: %s", err)
+			return
+		}
+
+		if err := validatePolicy(enforcer); err != nil {
+			l.Errorf("Invalid RBAC policy detected, keeping the previous policy: %s", err)
 			return
 		}
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -132,3 +132,6 @@ More about PNPM filtering: https://pnpm.io/filtering
 - Finally, run the tests using one of:
   - `pnpm --filter "@percona/everest" e2e`, to run all tests, including RBAC
   - ` pnpm --filter "@percona/everest" e2e:ignore-rbac`, to skip RBAC tests
+
+<!-- ci-experiment: trigger FE gatekeeper e2e to measure RBAC-reload flake with single ConfigMap load (revert of #2791 double-load). Not for merge. -->
+


### PR DESCRIPTION
**Experiment — do not merge.**

## Goal
Confirm whether the flaky RBAC e2e (`pr/rbac/backups.e2e.ts` Hide/Show/Delete → 404 / `getByRole('table')` timeout) is caused by RBAC-reload latency introduced by #2791.

## Background
- Failing e2e traces show `/v1/permissions` returning the *previous* policy (stale) → FE route guard renders 404 → table never appears.
- The test (`setRBACPermissionsK8S`) patches the `everest-rbac` ConfigMap then waits a fixed 3s for the server to reload.
- #2791 changed `refreshEnforcerInBackground` to validate each update on a throwaway enforcer (`newEnforcer(adapter)`) **before** `enforcer.LoadPolicy()`, adding a **second ConfigMap GET** per update (~2x reload cost).

## Change
Collapse the refresh back to a **single ConfigMap load** + in-memory `validatePolicy`. `ui/README.md` is touched only to trigger the FE gatekeeper e2e (path-filtered to `ui/**`).

## Method
Re-run the e2e job several times and compare RBAC flake rate vs baseline (unchanged v1.x).