### PR TITLE
test(e2e): wait for RBAC policy to be applied instead of a fixed sleep

### DIFF
--- a/ui/apps/everest/.e2e/utils/localStorage.ts
+++ b/ui/apps/everest/.e2e/utils/localStorage.ts
@@ -16,8 +16,14 @@ import { request } from '@playwright/test';
 
 const BASE_URL = process.env.EVEREST_URL || 'http://localhost:8080';
 
-const { CI_USER, CI_PASSWORD, SESSION_USER, SESSION_PASS, RBAC_USER, RBAC_PASSWORD } =
-  process.env;
+const {
+  CI_USER,
+  CI_PASSWORD,
+  SESSION_USER,
+  SESSION_PASS,
+  RBAC_USER,
+  RBAC_PASSWORD,
+} = process.env;
 
 type CachedToken = {
   token: string;

--- a/ui/apps/everest/.e2e/utils/localStorage.ts
+++ b/ui/apps/everest/.e2e/utils/localStorage.ts
@@ -16,7 +16,8 @@ import { request } from '@playwright/test';
 
 const BASE_URL = process.env.EVEREST_URL || 'http://localhost:8080';
 
-const { CI_USER, CI_PASSWORD, SESSION_USER, SESSION_PASS } = process.env;
+const { CI_USER, CI_PASSWORD, SESSION_USER, SESSION_PASS, RBAC_USER, RBAC_PASSWORD } =
+  process.env;
 
 type CachedToken = {
   token: string;
@@ -80,4 +81,8 @@ export const getCITokenFromLocalStorage = async () => {
 
 export const getSessionTokenFromLocalStorage = async () => {
   return getApiToken(SESSION_USER!, SESSION_PASS!);
+};
+
+export const getRBACTokenFromLocalStorage = async () => {
+  return getApiToken(RBAC_USER!, RBAC_PASSWORD!);
 };

--- a/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
+++ b/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
@@ -1,6 +1,12 @@
 import { execSync } from 'child_process';
+import { request } from '@playwright/test';
+import { getRBACTokenFromLocalStorage } from './localStorage';
 
 const OLD_RBAC_FILE = 'old_rbac_permissions';
+
+const BASE_URL = process.env.EVEREST_URL || 'http://localhost:8080';
+const RBAC_APPLY_TIMEOUT_MS = process.env.CI ? 15000 : 5000;
+const RBAC_APPLY_POLL_INTERVAL_MS = 200;
 
 export const saveOldRBACPermissions = async () => {
   const command = `kubectl get configmap everest-rbac --namespace everest-system -o jsonpath="{.data}" > ${OLD_RBAC_FILE}`;
@@ -19,21 +25,73 @@ export const restoreOldRBACPermissions = async () => {
   );
 };
 
+// A permission from GET /v1/permissions is [subject, resource, action, object].
+// Match on the trailing [resource, action, object] so the check is agnostic to
+// how the subject/role is rendered.
+const policyIsApplied = (
+  returned: string[][],
+  expected: [string, string, string][]
+): boolean =>
+  expected.every((exp) =>
+    returned.some((perm) => {
+      const [resource, action, object] = perm.slice(-3);
+      return resource === exp[0] && action === exp[1] && object === exp[2];
+    })
+  );
+
+// Poll GET /v1/permissions with the RBAC user's token until the freshly-patched
+// policy is reflected by the server, instead of sleeping a fixed amount. The
+// fixed sleep raced the server's ConfigMap reload and made RBAC tests flaky
+// (stale permissions -> 404 on deep-linked pages).
+const waitForRBACPolicyApplied = async (
+  permissions: [string, string, string][]
+) => {
+  if (permissions.length === 0) {
+    return;
+  }
+  const token = await getRBACTokenFromLocalStorage();
+  const ctx = await request.newContext({ baseURL: BASE_URL });
+  const deadline = Date.now() + RBAC_APPLY_TIMEOUT_MS;
+  try {
+    while (Date.now() < deadline) {
+      const resp = await ctx.get('/v1/permissions', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (resp.ok()) {
+        const body = await resp.json();
+        if (
+          body?.enabled &&
+          policyIsApplied(body.permissions ?? [], permissions)
+        ) {
+          return;
+        }
+      }
+      await new Promise((r) => setTimeout(r, RBAC_APPLY_POLL_INTERVAL_MS));
+    }
+    throw new Error(
+      `RBAC policy was not reflected in /v1/permissions within ${RBAC_APPLY_TIMEOUT_MS}ms`
+    );
+  } finally {
+    await ctx.dispose();
+  }
+};
+
 export const setRBACPermissionsK8S = async (
   permissions: [string, string, string][] = []
 ) => {
   const command = `kubectl patch configmap/everest-rbac --namespace everest-system --type merge -p '{"data":{"enabled": "${permissions !== undefined}", "policy.csv":"g,${process.env.RBAC_USER},role:e2e-rbac-user\\n${permissions.map((p) => `p,role:e2e-rbac-user,${p.join(',')}`).join('\\n')}"}}'`;
   execSync(command);
 
-  // We need this to give time for the RBAC to be applied, or headless tests might fail for being too fast
-  return new Promise<void>((resolve) =>
-    setTimeout(
-      () => {
-        resolve();
-      },
-      process.env.CI ? 3000 : 500
-    )
-  );
+  // Fall back to the previous fixed wait only when RBAC credentials are not
+  // available to poll with (keeps local runs without RBAC creds working).
+  if (!process.env.RBAC_USER || !process.env.RBAC_PASSWORD) {
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, process.env.CI ? 3000 : 500)
+    );
+    return;
+  }
+
+  await waitForRBACPolicyApplied(permissions);
 };
 
 export const giveUserAdminPermissions = async () => {

--- a/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
+++ b/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
@@ -41,11 +41,15 @@ export const restoreOldRBACPermissions = async () => {
 
 // A permission from GET /v1/permissions is [subject, resource, action, object].
 // Match on the trailing [resource, action, object] so the check is agnostic to
-// how the subject/role is rendered.
+// how the subject/role is rendered. The count must match too: the policy is
+// replaced wholesale, so a subset-only check would return early on the previous
+// (larger) policy while the server is still reloading — masking tests that
+// remove a permission.
 const policyIsApplied = (
   returned: string[][],
   expected: [string, string, string][]
 ): boolean =>
+  returned.length === expected.length &&
   expected.every((exp) =>
     returned.some((perm) => {
       const [resource, action, object] = perm.slice(-3);

--- a/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
+++ b/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
@@ -1,3 +1,17 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { execSync } from 'child_process';
 import { request } from '@playwright/test';
 import { getRBACTokenFromLocalStorage } from './localStorage';


### PR DESCRIPTION
## Problem
The RBAC e2e helper `setRBACPermissionsK8S` patches the `everest-rbac` ConfigMap and then **sleeps a fixed 3s (CI)** hoping the server has reloaded the policy. On loaded CI runners the server's ConfigMap→Casbin reload sometimes takes longer than 3s, so `GET /v1/permissions` still returns the **previous** policy. The FE route guard then renders a **404** on deep-linked pages and the assertion (`getByRole('table')`) times out.

This is the root of the recurring flaky RBAC specs (`pr/rbac/backups.e2e.ts` Hide/Show/Delete, plus intermittent `clusters`/`restores`).

## Fix
Replace the fixed sleep with a **poll of `GET /v1/permissions`** (using the RBAC user's token) until the freshly-patched policy is reflected, with a timeout. Matching is done on the trailing `[resource, action, object]` so it's agnostic to how the subject/role is rendered. Falls back to the old fixed sleep only when RBAC creds aren't available (local runs). **No call-site changes.**

## Evidence
Separately confirmed the reload-latency mechanism: an experiment that removed the extra ConfigMap GET added by #2791 turned the repeatedly-failing RBAC backups specs green across reruns (see draft #3152). This PR fixes the flake at the test level regardless of reload cost.

## Validation
Relies on this PR's own FE gatekeeper e2e (rbac specs) going green. Should be backported to `v1.x` where the flake is currently active.