### PR TITLE
test(e2e): wait for RBAC policy to be applied instead of a fixed sleep (v1.x)

### DIFF
--- a/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
+++ b/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
@@ -43,6 +43,11 @@ export const restoreOldRBACPermissions = async () => {
 // run) lives in the saved storage state — read it once.
 let rbacToken: string | undefined;
 
+type PermissionsResponse = {
+  enabled?: boolean;
+  permissions?: string[][];
+};
+
 // A permission from GET /v1/permissions is [subject, resource, action, object].
 // Match on the trailing [resource, action, object]; the count must match too,
 // so a shrinking policy isn't satisfied by the previous (larger) one while the
@@ -52,10 +57,14 @@ const policyIsApplied = (
   expected: [string, string, string][]
 ): boolean =>
   returned.length === expected.length &&
-  expected.every(([resource, action, object]) =>
+  expected.every(([wantResource, wantAction, wantObject]) =>
     returned.some((perm) => {
-      const [r, a, o] = perm.slice(-3);
-      return r === resource && a === action && o === object;
+      const [resource, action, object] = perm.slice(-3);
+      return (
+        resource === wantResource &&
+        action === wantAction &&
+        object === wantObject
+      );
     })
   );
 
@@ -78,9 +87,9 @@ const waitForRBACPolicyApplied = async (
         headers: { Authorization: `Bearer ${rbacToken}` },
       });
       if (resp.ok()) {
-        const body = await resp.json();
+        const body: PermissionsResponse = await resp.json();
         if (
-          body?.enabled &&
+          body.enabled &&
           policyIsApplied(body.permissions ?? [], permissions)
         ) {
           return;
@@ -99,7 +108,7 @@ const waitForRBACPolicyApplied = async (
 export const setRBACPermissionsK8S = async (
   permissions: [string, string, string][] = []
 ) => {
-  const command = `kubectl patch configmap/everest-rbac --namespace everest-system --type merge -p '{"data":{"enabled": "${permissions !== undefined}", "policy.csv":"g,${process.env.RBAC_USER},role:e2e-rbac-user\\n${permissions.map((p) => `p,role:e2e-rbac-user,${p.join(',')}`).join('\\n')}"}}'`;
+  const command = `kubectl patch configmap/everest-rbac --namespace everest-system --type merge -p '{"data":{"enabled": "true", "policy.csv":"g,${process.env.RBAC_USER},role:e2e-rbac-user\\n${permissions.map((p) => `p,role:e2e-rbac-user,${p.join(',')}`).join('\\n')}"}}'`;
   execSync(command);
 
   await waitForRBACPolicyApplied(permissions);

--- a/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
+++ b/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
@@ -48,10 +48,9 @@ type PermissionsResponse = {
   permissions?: string[][];
 };
 
-// A permission from GET /v1/permissions is [subject, resource, action, object].
-// Match on the trailing [resource, action, object]; the count must match too,
-// so a shrinking policy isn't satisfied by the previous (larger) one while the
-// server is still reloading.
+// /v1/permissions returns [subject, resource, action, object]; compare the
+// trailing triple. The count must match too, so a shrinking policy isn't
+// satisfied by the previous (larger) one mid-reload.
 const policyIsApplied = (
   returned: string[][],
   expected: [string, string, string][]
@@ -68,10 +67,8 @@ const policyIsApplied = (
     })
   );
 
-// Poll GET /v1/permissions until the freshly-patched policy is reflected by the
-// server, instead of sleeping a fixed amount. The fixed sleep raced the
-// server's ConfigMap reload and made RBAC tests flaky (stale permissions ->
-// 404 on deep-linked pages).
+// Poll until the server reflects the patched policy instead of a fixed sleep,
+// which raced the ConfigMap reload and made RBAC tests flaky (stale perms -> 404).
 const waitForRBACPolicyApplied = async (
   permissions: [string, string, string][]
 ) => {

--- a/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
+++ b/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
@@ -39,15 +39,9 @@ export const restoreOldRBACPermissions = async () => {
   );
 };
 
-// After rbac.setup switches to the RBAC user, its token lives in the saved
-// storage state, so GET /v1/permissions reflects that user's effective policy.
-let cachedRBACToken: string | undefined;
-const getRBACToken = async (forceRefresh = false): Promise<string> => {
-  if (!cachedRBACToken || forceRefresh) {
-    cachedRBACToken = await getTokenFromLocalStorage();
-  }
-  return cachedRBACToken;
-};
+// rbac.setup switches to the RBAC user, so its token (the same for the whole
+// run) lives in the saved storage state — read it once.
+let rbacToken: string | undefined;
 
 // A permission from GET /v1/permissions is [subject, resource, action, object].
 // Match on the trailing [resource, action, object]; the count must match too,
@@ -58,10 +52,10 @@ const policyIsApplied = (
   expected: [string, string, string][]
 ): boolean =>
   returned.length === expected.length &&
-  expected.every((exp) =>
+  expected.every(([resource, action, object]) =>
     returned.some((perm) => {
-      const [resource, action, object] = perm.slice(-3);
-      return resource === exp[0] && action === exp[1] && object === exp[2];
+      const [r, a, o] = perm.slice(-3);
+      return r === resource && a === action && o === object;
     })
   );
 
@@ -70,23 +64,20 @@ const policyIsApplied = (
 // server's ConfigMap reload and made RBAC tests flaky (stale permissions ->
 // 404 on deep-linked pages).
 const waitForRBACPolicyApplied = async (
-  permissions: [string, string, string][],
-  initialToken: string
+  permissions: [string, string, string][]
 ) => {
   if (permissions.length === 0) {
     return;
   }
-  let token = initialToken;
+  rbacToken ??= await getTokenFromLocalStorage();
   const ctx = await request.newContext({ baseURL: BASE_URL });
   const deadline = Date.now() + RBAC_APPLY_TIMEOUT_MS;
   try {
     while (Date.now() < deadline) {
       const resp = await ctx.get('/v1/permissions', {
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { Authorization: `Bearer ${rbacToken}` },
       });
-      if (resp.status() === 401) {
-        token = await getRBACToken(true);
-      } else if (resp.ok()) {
+      if (resp.ok()) {
         const body = await resp.json();
         if (
           body?.enabled &&
@@ -111,19 +102,7 @@ export const setRBACPermissionsK8S = async (
   const command = `kubectl patch configmap/everest-rbac --namespace everest-system --type merge -p '{"data":{"enabled": "${permissions !== undefined}", "policy.csv":"g,${process.env.RBAC_USER},role:e2e-rbac-user\\n${permissions.map((p) => `p,role:e2e-rbac-user,${p.join(',')}`).join('\\n')}"}}'`;
   execSync(command);
 
-  let token: string;
-  try {
-    token = await getRBACToken();
-  } catch {
-    // No stored token to poll with — fall back to the previous fixed wait so
-    // behaviour never regresses.
-    await new Promise<void>((resolve) =>
-      setTimeout(resolve, process.env.CI ? 3000 : 500)
-    );
-    return;
-  }
-
-  await waitForRBACPolicyApplied(permissions, token);
+  await waitForRBACPolicyApplied(permissions);
 };
 
 export const giveUserAdminPermissions = async () => {

--- a/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
+++ b/ui/apps/everest/.e2e/utils/rbac-cmd-line.ts
@@ -1,6 +1,26 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { execSync } from 'child_process';
+import { request } from '@playwright/test';
+import { getTokenFromLocalStorage } from './localStorage';
 
 const OLD_RBAC_FILE = 'old_rbac_permissions';
+
+const BASE_URL = process.env.EVEREST_URL || 'http://localhost:8080';
+const RBAC_APPLY_TIMEOUT_MS = process.env.CI ? 15000 : 5000;
+const RBAC_APPLY_POLL_INTERVAL_MS = 200;
 
 export const saveOldRBACPermissions = async () => {
   const command = `kubectl get configmap everest-rbac --namespace everest-system -o jsonpath="{.data}" > ${OLD_RBAC_FILE}`;
@@ -19,21 +39,91 @@ export const restoreOldRBACPermissions = async () => {
   );
 };
 
+// After rbac.setup switches to the RBAC user, its token lives in the saved
+// storage state, so GET /v1/permissions reflects that user's effective policy.
+let cachedRBACToken: string | undefined;
+const getRBACToken = async (forceRefresh = false): Promise<string> => {
+  if (!cachedRBACToken || forceRefresh) {
+    cachedRBACToken = await getTokenFromLocalStorage();
+  }
+  return cachedRBACToken;
+};
+
+// A permission from GET /v1/permissions is [subject, resource, action, object].
+// Match on the trailing [resource, action, object]; the count must match too,
+// so a shrinking policy isn't satisfied by the previous (larger) one while the
+// server is still reloading.
+const policyIsApplied = (
+  returned: string[][],
+  expected: [string, string, string][]
+): boolean =>
+  returned.length === expected.length &&
+  expected.every((exp) =>
+    returned.some((perm) => {
+      const [resource, action, object] = perm.slice(-3);
+      return resource === exp[0] && action === exp[1] && object === exp[2];
+    })
+  );
+
+// Poll GET /v1/permissions until the freshly-patched policy is reflected by the
+// server, instead of sleeping a fixed amount. The fixed sleep raced the
+// server's ConfigMap reload and made RBAC tests flaky (stale permissions ->
+// 404 on deep-linked pages).
+const waitForRBACPolicyApplied = async (
+  permissions: [string, string, string][],
+  initialToken: string
+) => {
+  if (permissions.length === 0) {
+    return;
+  }
+  let token = initialToken;
+  const ctx = await request.newContext({ baseURL: BASE_URL });
+  const deadline = Date.now() + RBAC_APPLY_TIMEOUT_MS;
+  try {
+    while (Date.now() < deadline) {
+      const resp = await ctx.get('/v1/permissions', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (resp.status() === 401) {
+        token = await getRBACToken(true);
+      } else if (resp.ok()) {
+        const body = await resp.json();
+        if (
+          body?.enabled &&
+          policyIsApplied(body.permissions ?? [], permissions)
+        ) {
+          return;
+        }
+      }
+      await new Promise((r) => setTimeout(r, RBAC_APPLY_POLL_INTERVAL_MS));
+    }
+    throw new Error(
+      `RBAC policy was not reflected in /v1/permissions within ${RBAC_APPLY_TIMEOUT_MS}ms`
+    );
+  } finally {
+    await ctx.dispose();
+  }
+};
+
 export const setRBACPermissionsK8S = async (
   permissions: [string, string, string][] = []
 ) => {
   const command = `kubectl patch configmap/everest-rbac --namespace everest-system --type merge -p '{"data":{"enabled": "${permissions !== undefined}", "policy.csv":"g,${process.env.RBAC_USER},role:e2e-rbac-user\\n${permissions.map((p) => `p,role:e2e-rbac-user,${p.join(',')}`).join('\\n')}"}}'`;
   execSync(command);
 
-  // We need this to give time for the RBAC to be applied, or headless tests might fail for being too fast
-  return new Promise<void>((resolve) =>
-    setTimeout(
-      () => {
-        resolve();
-      },
-      process.env.CI ? 3000 : 500
-    )
-  );
+  let token: string;
+  try {
+    token = await getRBACToken();
+  } catch {
+    // No stored token to poll with — fall back to the previous fixed wait so
+    // behaviour never regresses.
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, process.env.CI ? 3000 : 500)
+    );
+    return;
+  }
+
+  await waitForRBACPolicyApplied(permissions, token);
 };
 
 export const giveUserAdminPermissions = async () => {


### PR DESCRIPTION
## Problem
The RBAC e2e helper `setRBACPermissionsK8S` patches the `everest-rbac` ConfigMap then **sleeps a fixed 3s (CI)** hoping the server reloaded the policy. On loaded CI runners the ConfigMap→Casbin reload sometimes takes longer, so `GET /v1/permissions` still returns the previous policy → the FE route guard renders **404** on deep-linked pages → flaky `pr/rbac/backups.e2e.ts` (Hide/Show/Delete) plus intermittent `clusters`/`restores`.

## Fix
Poll `GET /v1/permissions` until the freshly-patched policy is reflected (timeout-bounded), instead of sleeping. The RBAC user's token is read from the saved storage state — `rbac.setup` switches to that user, so `getTokenFromLocalStorage()` returns it. Exact match (incl. count) so a shrinking policy isn't satisfied by the previous larger one while the server is still reloading. Falls back to the old fixed sleep if no token is available. **No call-site changes.**

## Why v1.x
The rbac e2e project is **enabled on `v1.x`** (it's commented out on `main`), so this is where the flake actually reproduces and where the fix is validated by CI. Counterpart on `main`: #3154 (harmless there but not exercised, since rbac tests don't run).

## Validation
Relies on this PR's own FE gatekeeper e2e (rbac specs) going green.