### PR TITLE
Remove duplicated call to `GetConfigMap()` upon refreshing RBAC config

### DIFF
--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -126,26 +126,7 @@ func refreshEnforcerInBackground(
 		if !ok || cm.GetName() != common.EverestRBACConfigMapName {
 			return
 		}
-
-		// Validate the incoming policy on a throwaway enforcer, so that an invalid
-		// update never reaches the live one.
-		if _, err := newEnforcer(enforcer.GetAdapter(), false); err != nil {
-			l.Errorf("Invalid RBAC policy detected, keeping the previous policy: %s", err)
-			return
-		}
-
-		if err := enforcer.LoadPolicy(); err != nil {
-			l.Errorf("Failed to load RBAC policy: %s", err)
-			return
-		}
-
-		// Calling LoadPolicy() re-writes the entire model, so we need to add back the admin role.
-		if err := loadAdminPolicy(enforcer); err != nil {
-			l.Errorf("Failed to load admin policy: %s", err)
-			return
-		}
-
-		enforcer.EnableEnforce(IsEnabled(cm))
+		reloadEnforcerFromConfigMap(enforcer, cm, l)
 	})
 
 	if err := inf.Start(ctx, &corev1.ConfigMap{}); err != nil {
@@ -153,6 +134,34 @@ func refreshEnforcerInBackground(
 	}
 
 	return nil
+}
+
+// reloadEnforcerFromConfigMap reloads the enforcer's policy in response to
+// an update of the RBAC ConfigMap.
+func reloadEnforcerFromConfigMap(enforcer *casbin.Enforcer, cm *corev1.ConfigMap, l *zap.SugaredLogger) {
+	// Validate the incoming policy in-memory using the ConfigMap already
+	// delivered by the informer, so that an invalid update never reaches the
+	// live enforcer.
+	// Do not create a new enforcer here, because that calls LoadPolicy()
+	// sending an unnecessary request to GetConfigMap(), and causing
+	// e2e test flakiness on CI due to policy not being loaded in time.
+	if _, err := NewIOReaderEnforcer(strings.NewReader(cm.Data["policy.csv"])); err != nil {
+		l.Errorf("Invalid RBAC policy detected, keeping the previous policy: %s", err)
+		return
+	}
+
+	if err := enforcer.LoadPolicy(); err != nil {
+		l.Errorf("Failed to load RBAC policy: %s", err)
+		return
+	}
+
+	// Calling LoadPolicy() re-writes the entire model, so we need to add back the admin role.
+	if err := loadAdminPolicy(enforcer); err != nil {
+		l.Errorf("Failed to load admin policy: %s", err)
+		return
+	}
+
+	enforcer.EnableEnforce(IsEnabled(cm))
 }
 
 func getModel() (model.Model, error) {

--- a/pkg/rbac/rbac_test.go
+++ b/pkg/rbac/rbac_test.go
@@ -1,10 +1,36 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rbac
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 
+	"github.com/casbin/casbin/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/percona/everest/pkg/common"
+	configmapadapter "github.com/percona/everest/pkg/rbac/configmap-adapter"
 )
 
 func TestGetScopeValues(t *testing.T) {
@@ -65,4 +91,118 @@ func TestGetScopeValues(t *testing.T) {
 			assert.Equal(t, tc.out, getScopeValues(tc.claims, tc.scopes))
 		})
 	}
+}
+
+// fakeConfigMapGetter is a fake whose GetConfigMap returns a configurable
+// policy and counts how many times it is called.
+type fakeConfigMapGetter struct {
+	policy atomic.Pointer[string]
+	calls  atomic.Int64
+}
+
+func newFakeConfigMapGetter(policy string) *fakeConfigMapGetter {
+	f := &fakeConfigMapGetter{}
+	f.policy.Store(&policy)
+	return f
+}
+
+func (f *fakeConfigMapGetter) GetConfigMap(_ context.Context, _ ctrlclient.ObjectKey) (*corev1.ConfigMap, error) {
+	f.calls.Add(1)
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.EverestRBACConfigMapName,
+			Namespace: common.SystemNamespace,
+		},
+		Data: map[string]string{
+			"enabled":    "true",
+			"policy.csv": *f.policy.Load(),
+		},
+	}, nil
+}
+
+func (f *fakeConfigMapGetter) setPolicy(policy string) {
+	f.policy.Store(&policy)
+}
+
+// newFakeEnforcer builds a enforcer backed by the fake fakeConfigMapGetter.
+func newFakeEnforcer(t *testing.T, getter *fakeConfigMapGetter) *casbin.Enforcer {
+	t.Helper()
+	adapter := configmapadapter.New(
+		zap.NewNop().Sugar(),
+		getter,
+		types.NamespacedName{
+			Namespace: common.SystemNamespace,
+			Name:      common.EverestRBACConfigMapName,
+		},
+	)
+	enf, err := newEnforcer(adapter, false)
+	require.NoError(t, err)
+	return enf
+}
+
+// cmWithPolicy returns the RBAC ConfigMap object handed to the informer's
+// OnUpdate callback for the given policy.
+func cmWithPolicy(policy string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.EverestRBACConfigMapName,
+			Namespace: common.SystemNamespace,
+		},
+		Data: map[string]string{
+			"enabled":    "true",
+			"policy.csv": policy,
+		},
+	}
+}
+
+// TestReloadEnforcerFromConfigMap exercises the real reloadEnforcerFromConfigMap
+// function (the body of refreshEnforcerInBackground's OnUpdate callback) using a
+// fake, latency-injecting ConfigMap adapter.
+func TestReloadEnforcerFromConfigMap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reloads the policy on update", func(t *testing.T) {
+		t.Parallel()
+		getter := newFakeConfigMapGetter("")
+		enf := newFakeEnforcer(t, getter)
+		getter.calls.Store(0) // ignore the initial construction load.
+
+		// Initially alice has no permissions.
+		ok, err := enf.Enforce("alice", "database-clusters", "read", "my-ns/my-cluster")
+		require.NoError(t, err)
+		require.False(t, ok)
+
+		// Update the backing policy and fire the real reload.
+		policy := "p, alice, database-clusters, read, my-ns/my-cluster"
+		getter.setPolicy(policy)
+		reloadEnforcerFromConfigMap(enf, cmWithPolicy(policy), zap.NewNop().Sugar())
+
+		ok, err = enf.Enforce("alice", "database-clusters", "read", "my-ns/my-cluster")
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.LessOrEqual(t, getter.calls.Load(), int64(1))
+	})
+
+	t.Run("invalid policy is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		initialPolicy := "p, alice, database-clusters, read, my-ns/my-cluster"
+		getter := newFakeConfigMapGetter(initialPolicy)
+		enf := newFakeEnforcer(t, getter)
+		getter.calls.Store(0) // ignore the initial construction load.
+
+		ok, err := enf.Enforce("alice", "database-clusters", "read", "my-ns/my-cluster")
+		require.NoError(t, err)
+		assert.True(t, ok)
+
+		// Invalid policy keeps the previous valid policy.
+		newInvalidPolicy := "p, alice, not-a-real-resource, read, my-ns/my-cluster"
+		getter.setPolicy(newInvalidPolicy)
+		reloadEnforcerFromConfigMap(enf, cmWithPolicy(newInvalidPolicy), zap.NewNop().Sugar())
+
+		ok, err = enf.Enforce("alice", "database-clusters", "read", "my-ns/my-cluster")
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.LessOrEqual(t, getter.calls.Load(), int64(1))
+	})
 }

--- a/ui/README.md
+++ b/ui/README.md
@@ -132,3 +132,4 @@ More about PNPM filtering: https://pnpm.io/filtering
 - Finally, run the tests using one of:
   - `pnpm --filter "@percona/everest" e2e`, to run all tests, including RBAC
   - ` pnpm --filter "@percona/everest" e2e:ignore-rbac`, to skip RBAC tests
+

--- a/ui/README.md
+++ b/ui/README.md
@@ -132,4 +132,3 @@ More about PNPM filtering: https://pnpm.io/filtering
 - Finally, run the tests using one of:
   - `pnpm --filter "@percona/everest" e2e`, to run all tests, including RBAC
   - ` pnpm --filter "@percona/everest" e2e:ignore-rbac`, to skip RBAC tests
-


### PR DESCRIPTION
See attempt 1 of failed CI https://github.com/openeverest/openeverest/actions/runs/34182603466/job/101969103106?pr=3128.
```
  ✘  18 [rbac] › ../pr/rbac/clusters.e2e.ts:19:3 › Clusters RBAC › permitted cluster creation with present clusters (9.8s)

  ✘  19 [rbac] › ../pr/rbac/clusters.e2e.ts:19:3 › Clusters RBAC › permitted cluster creation with present clusters (retry #1) (9.8s)

  ✘  20 [rbac] › ../pr/rbac/clusters.e2e.ts:19:3 › Clusters RBAC › permitted cluster creation with present clusters (retry #2) (10.0s)

  ✘  21 [rbac] › ../pr/rbac/clusters.e2e.ts:32:3 › Clusters RBAC › permitted cluster creation without present clusters (9.8s)

  ✘  22 [rbac] › ../pr/rbac/clusters.e2e.ts:32:3 › Clusters RBAC › permitted cluster creation without present clusters (retry #1) (9.8s)

  ✘  23 [rbac] › ../pr/rbac/clusters.e2e.ts:32:3 › Clusters RBAC › permitted cluster creation without present clusters (retry #2) (9.8s)
```

The change in https://github.com/openeverest/openeverest/pull/2791 had unintended regression causing `e2e` frontend tests to fail with flakiness. The cause appears to be due to increased calls for `a.kubeClient.GetConfigMap`, only once before https://github.com/openeverest/openeverest/pull/2791, and twice after. This lead to reloading RBAC policy take longer and tests expecting new policy to be loaded failed, on CI.

In https://github.com/openeverest/openeverest/pull/2791, the changes were purely backend so the frontend e2e tests weren't ran.