### PR TITLE
Enable GitHub action workflow dispatch on BE and FE tests

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -5,6 +5,8 @@ on:
     paths-ignore:
       - 'ui/**'
       - '.github/workflows/dev-fe-ci.yaml'
+  # Allow manual runs from the Actions tab.
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -75,7 +77,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Set up Go release
@@ -85,6 +87,8 @@ jobs:
           cache: true
 
       - name: Run linters
+        # only run on PRs to run linters on the diff only.
+        if: github.event_name == 'pull_request'
         run: |
           # Stub the embedded UI build output so `//go:embed dist/*` typechecks (see `make build`/`make test`).
           mkdir -p ./public/dist && [ -f ./public/dist/index.html ] || touch ./public/dist/index.html
@@ -213,7 +217,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Go release
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -264,7 +268,7 @@ jobs:
   merge-gatekeeper:
     needs: [ test, check, integration_tests_api, integration_tests_flows, integration_tests_cli]
     name: Merge Gatekeeper
-    if: ${{ always() }}
+    if: ${{ always() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/dev-fe-e2e.yaml
+++ b/.github/workflows/dev-fe-e2e.yaml
@@ -11,6 +11,8 @@ on:
         required: true
       RBAC_PASSWORD:
         required: true
+  # Allow manual runs from the Actions tab.
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -36,7 +38,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Set up Go release


### PR DESCRIPTION
This PR adds ability to run BE and FE tests on `v1.x` branch (and branches based from `v1.x`) from `Actions` tab on GitHub.

## Context
Currently CI is only run on PR. There is no nightly run so we fail to capture flaky tests, particularly for FE tests which runs only on `ui/*` change. Changes on backend which impact FE tests are difficult to capture.

Because you can only schedule cron on default (`main`) branch, running nightly tests requires workflow dispatch to `v1.x` from `main` branch https://github.com/openeverest/openeverest/pull/3161.