### PR TITLE
fix(common): gracefully handle invalid versions and constraints in CheckConstraint

### DIFF
--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -73,6 +73,10 @@ func CheckConstraint[V version](v V, c string) bool {
 
 // NewSupportedVersion returns a new SupportedVersion struct.
 func NewSupportedVersion(meta *versionpb.MetadataVersion) (*SupportedVersion, error) {
+	if meta == nil {
+		return nil, errors.New("version metadata cannot be nil")
+	}
+
 	supVer := &SupportedVersion{}
 
 	// Parse MetadataVersion into supportedVersion struct.

--- a/pkg/common/version_test.go
+++ b/pkg/common/version_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"testing"
 
+	versionpb "github.com/Percona-Lab/percona-version-service/versionpb"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,4 +37,40 @@ func TestCheckConstraints(t *testing.T) {
 	assert.True(t, CheckConstraint("1.2.1-rc1", "~> 1.2.0"))
 	assert.False(t, CheckConstraint("1.3.1-rc1", "~> 1.2.0"))
 	assert.True(t, CheckConstraint("1.3.1-rc1", "> 1.2.0"))
+}
+
+func TestNewSupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil metadata returns error", func(t *testing.T) {
+		t.Parallel()
+		supVer, err := NewSupportedVersion(nil)
+		assert.Error(t, err)
+		assert.Nil(t, supVer)
+	})
+
+	t.Run("valid metadata parses constraints", func(t *testing.T) {
+		t.Parallel()
+		meta := &versionpb.MetadataVersion{
+			Supported: map[string]string{
+				"cli": ">= 1.0.0",
+			},
+		}
+		supVer, err := NewSupportedVersion(meta)
+		assert.NoError(t, err)
+		assert.NotNil(t, supVer)
+		assert.True(t, supVer.Cli.Check(goversion.Must(goversion.NewVersion("1.0.0"))))
+	})
+
+	t.Run("invalid constraint returns error", func(t *testing.T) {
+		t.Parallel()
+		meta := &versionpb.MetadataVersion{
+			Supported: map[string]string{
+				"cli": "invalid-constraint",
+			},
+		}
+		supVer, err := NewSupportedVersion(meta)
+		assert.Error(t, err)
+		assert.Nil(t, supVer)
+	})
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -39,7 +39,10 @@ func IsRC(v string) bool {
 	if v == "" {
 		return false
 	}
-	ver := version.Must(version.NewVersion(v))
+	ver, err := version.NewVersion(v)
+	if err != nil {
+		return false
+	}
 	return strings.Contains(ver.Prerelease(), "rc")
 }
 
@@ -48,7 +51,10 @@ func IsDev(v string) bool {
 	if v == "" {
 		return false
 	}
-	ver := version.Must(version.NewVersion(v))
+	ver, err := version.NewVersion(v)
+	if err != nil {
+		return false
+	}
 	devLatestVer := version.Must(version.NewVersion("v0.0.0"))
 	return ver.Core().Equal(devLatestVer)
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -31,6 +31,8 @@ func TestIsRC(t *testing.T) {
 		{"v0.3.0-xx", false},
 		{"v0.3.0-rc1", true},
 		{"v1.3.0-rc2", true},
+		{"invalid", false},
+		{"", false},
 	}
 	for _, tc := range testCases {
 		actual := IsRC(tc.version)
@@ -48,6 +50,8 @@ func TestIsDev(t *testing.T) {
 		{"v0.0.0-cf34bt", true},
 		{"v0.3.0-rc1", false},
 		{"v0.3.0", false},
+		{"invalid", false},
+		{"", false},
 	}
 	for _, tc := range testCases {
 		actual := IsDev(tc.version)


### PR DESCRIPTION
### Summary
`common.CheckConstraint(v, c)` in `pkg/common/version.go` previously used `goversion.Must(goversion.NewVersion(val))` and `panic(err)`, which panics when provided with unparseable or non-semver version strings or malformed constraint strings.

This PR updates `CheckConstraint` to handle version parsing and constraint parsing errors gracefully by returning `false` instead of panicking.

### Changes
- `pkg/common/version.go`: Check for `err != nil` from `goversion.NewVersion(val)` and `goversion.NewConstraint(c)` and return `false`.